### PR TITLE
fix: loops created from a card's + handle can have no sidebar row until relaunch (#25)

### DIFF
--- a/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
@@ -284,10 +284,26 @@ extension AppSidebarView {
     }
   }
 
-  /// Every node id across the open projects — what `onChange` watches to notice a loop
-  /// being created.
-  var allNodeIDs: Set<UUID> {
-    Set(store.projects.flatMap { $0.graph.nodes.map(\.id) })
+  /// Every edge id across the open projects — what `onChange` watches to notice a loop
+  /// being put under a parent.
+  var allEdgeIDs: Set<UUID> {
+    Set(store.projects.flatMap { $0.graph.edges.map(\.id) })
+  }
+
+  /// The parents to disclose after a graph change: the ancestor chain of every loop an
+  /// edge that wasn't there before now points at.
+  ///
+  /// Watching the *edges* rather than the nodes is the whole point. A loop created from
+  /// a card's + handle is two daemon commands, so it arrives in two broadcasts: the node
+  /// first, with no inbound edge and therefore no chain to disclose, and the hand-off
+  /// edge second — which moves it from a root row to a child row under a parent that may
+  /// well be collapsed. The node set is unchanged by that second broadcast, so keying on
+  /// nodes meant nothing looked again and the loop simply had no visible row.
+  static func parentsToExpand(
+    forEdgesNotIn known: Set<UUID>, in graphs: [LoopGraph]
+  ) -> Set<UUID> {
+    let targets = graphs.flatMap { $0.edges }.filter { !known.contains($0.id) }.map(\.to)
+    return parentsToExpand(for: Set(targets), in: graphs)
   }
 
   /// The parents to disclose so every newly created loop is visible: each new node's

--- a/graphcode/Sources/Features/App/AppSidebarView.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView.swift
@@ -41,10 +41,11 @@ struct AppSidebarView: View {
     let stored = UserDefaults.standard.stringArray(forKey: expandedNodeIDsDefaultsKey) ?? []
     return Set(stored.compactMap(UUID.init))
   }
-  /// Every node id seen across the open projects, for telling a freshly created loop
-  /// from one that was already there. `nil` until the first observation, so a relaunch
-  /// seeds silently instead of springing every parent in the graph open.
-  @State var knownNodeIDs: Set<UUID>?
+  /// Every edge id seen across the open projects, for telling a loop that has just been
+  /// wired under a parent from one that was already there. `nil` until the first
+  /// observation, so a relaunch seeds silently instead of springing every parent in the
+  /// graph open.
+  @State var knownEdgeIDs: Set<UUID>?
   /// What the rows' ages are measured against — the window's one 30s tick, the same one
   /// the canvases' cards use. See `CanvasClock`.
   @State var sidebarNow = Date()
@@ -70,15 +71,15 @@ struct AppSidebarView: View {
       .onReceive(CanvasClock.tick) { sidebarNow = $0 }
       // A loop that fans out shouldn't hide its children behind an unexpanded chevron —
       // the human watching the sidebar should see new loops appear, not wonder where
-      // they went. Every newly created node's parent chain is disclosed the moment the
-      // node shows up; existing nodes on relaunch stay as the human left them.
-      .onChange(of: allNodeIDs, initial: true) { _, current in
-        if let known = knownNodeIDs {
+      // they went. Every newly drawn hand-off's parent chain is disclosed the moment the
+      // edge shows up — which is the moment a loop stops being a root row and starts
+      // being a child one; existing edges on relaunch stay as the human left them.
+      .onChange(of: allEdgeIDs, initial: true) { _, current in
+        if let known = knownEdgeIDs {
           expandedNodeIDs.formUnion(
-            Self.parentsToExpand(
-              for: current.subtracting(known), in: store.projects.map(\.graph)))
+            Self.parentsToExpand(forEdgesNotIn: known, in: store.projects.map(\.graph)))
         }
-        knownNodeIDs = current
+        knownEdgeIDs = current
       }
       .onChange(of: expandedNodeIDs) { _, expanded in
         UserDefaults.standard.set(

--- a/graphcode/Tests/SidebarAutoExpandTests.swift
+++ b/graphcode/Tests/SidebarAutoExpandTests.swift
@@ -55,4 +55,35 @@ struct SidebarAutoExpandTests {
     let parents = AppSidebarView.parentsToExpand(for: [b.id], in: [g])
     #expect(parents.contains(a.id))
   }
+
+  /// A loop made from a card's + handle arrives in two broadcasts — the node, then the
+  /// hand-off edge that puts it under its parent. The second one is the one that can
+  /// hide it, so it is the one that has to disclose the chain.
+  @Test
+  func aChildWiredUpAfterItArrivesStillDisclosesItsParent() {
+    let parent = LoopNode(title: "parent")
+    let child = LoopNode(title: "child")
+
+    // Broadcast one: the child exists, unwired. It shows as a root row, and there is
+    // no chain to open.
+    let unwired = graph(nodes: [parent, child], edges: [])
+    let seeded = Set(unwired.edges.map(\.id))
+    #expect(AppSidebarView.parentsToExpand(forEdgesNotIn: seeded, in: [unwired]).isEmpty)
+
+    // Broadcast two: the hand-off lands. The child is now a row under `parent`, so
+    // `parent` has to be disclosed or the loop has no visible row at all.
+    let wired = graph(nodes: [parent, child], edges: [LoopEdge(from: parent.id, to: child.id)])
+    #expect(AppSidebarView.parentsToExpand(forEdgesNotIn: seeded, in: [wired]) == [parent.id])
+  }
+
+  /// The other half of the same rule: edges that were already there on relaunch open
+  /// nothing, or every graph would spring fully open every launch.
+  @Test
+  func edgesThatWereAlreadyThereDiscloseNothing() {
+    let parent = LoopNode(title: "parent")
+    let child = LoopNode(title: "child")
+    let g = graph(nodes: [parent, child], edges: [LoopEdge(from: parent.id, to: child.id)])
+
+    #expect(AppSidebarView.parentsToExpand(forEdgesNotIn: Set(g.edges.map(\.id)), in: [g]).isEmpty)
+  }
 }


### PR DESCRIPTION
Fixes #25

## Root cause

A loop created from a card's **+** handle is two daemon commands — `.createNode` then `.createEdge` (`ProjectFeature.createNodeConfirmed`) — and `GraphStore.handle` broadcasts after each, so the app sees it in two `graphChanged` events. The sidebar's auto-disclose watched the set of *node* ids (`AppSidebarView`, `.onChange(of: allNodeIDs)`), so it looked exactly once: at the first broadcast, where the child has no inbound edge and `parentsToExpand` therefore finds no ancestor chain to open. The second broadcast adds the hand-off, which is what moves the loop out of `startAnchors` — from a root row to a child row under a parent that may be collapsed — but it leaves the node set unchanged, so the `onChange` never fired again and the loop had no visible row at all. Whether it bites depends on whether the window renders between the two broadcasts, which is what makes it intermittent. A relaunch appears to fix it because `knownNodeIDs` starts `nil` and seeds on the first observation, which happens before any project has arrived — so every node then counts as new and every parent chain springs open.

## Change

Key the auto-disclose on edge ids rather than node ids: the arrival of an inbound edge is the moment a loop can become hidden, so it is the moment to disclose its chain. `allNodeIDs` → `allEdgeIDs`, `knownNodeIDs` → `knownEdgeIDs`, and a new `parentsToExpand(forEdgesNotIn:in:)` that reuses the existing (and already tested) `parentsToExpand(for:in:)` walk unchanged.

This is strictly more expansion than before, never less: a node arriving with its edge in one broadcast (the CLI's `createdBy` fan-out path) has a new edge too, and a new node with no inbound edge had nothing to expand either way. It also covers an edge drawn by hand on the canvas between two existing loops, which could hide its target the same way.

No behaviour outside the sidebar's disclosure state is touched — the daemon, the graph protocol, and the canvas are untouched.

## Verified in cloud

Static only; this sandbox has no Xcode or macOS SDK.

- Every symbol used exists as referenced: `LoopGraph.edges` is `IdentifiedArrayOf<LoopEdge>` (`LoopGraph.swift:21`), `LoopEdge.id` is a `UUID` (`LoopEdge.swift:9`), `LoopEdge(from:to:)` defaults `id` to a fresh `UUID`, `parentsToExpand(for:in:)` keeps its `(Set<UUID>, [LoopGraph]) -> Set<UUID>` signature, and the two overloads differ in first argument label so there is no ambiguity.
- No stale references: `grep -rn "allNodeIDs\|knownNodeIDs"` across the tree returns nothing, and both were only ever read by the one `onChange` that changed (they were never used elsewhere in sources or tests).
- `onChange(of:initial:)` still watches a `Set<UUID>`, exactly as before, so the observation contract is unchanged.
- The reasoning was checked against the actual call sites: `ProjectFeature.createNodeConfirmed` sends `.createNode` and `.createEdge` as separate `.graphCommand`s, `createdBy` is never set by the app (only by the CLI path), and `GraphStore.handle` ends in `drainAndBroadcast()` per command.
- Style gates: all touched lines are ≤ 100 chars (`.swift-format` `lineLength`), the multi-line signature style matches the surrounding file, and nothing trips the opt-in swiftlint rules.

What I could **not** verify: nothing was compiled and no test was executed. The claim that SwiftUI coalescing is what makes it intermittent is reasoned from the code, not observed.

## NOT verified — needs local Mac

- [ ] `make build-app`
- [ ] `make test` — including the two new cases in `SidebarAutoExpandTests` (`aChildWiredUpAfterItArrivesStillDisclosesItsParent`, `edgesThatWereAlreadyThereDiscloseNothing`)
- [ ] `make check` (swift-format lint `--strict` + swiftlint)
- [ ] Manual repro for #25: open a project with at least one loop; collapse that loop's chevron in the sidebar; create a child from its **+** handle on the canvas. Before this change the child intermittently has no sidebar row until relaunch; after it, the parent discloses and the child's row appears immediately.
- [ ] Regression check: draw a hand-off edge on the canvas between two existing top-level loops — the target should move under its new parent with the parent disclosed, not vanish.
- [ ] Regression check: relaunch with a graph the human had partly collapsed — pre-existing edges must not spring anything open beyond what already happens today.
- [ ] Worth confirming the reporter meant the sidebar list. The canvas draws every node regardless of disclosure state, so if loops were missing from the *canvas* this fix does not address that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgieFmL824C6VjMc42n9Sz)_