### PR TITLE
build 46 for 0.1.14-beta4

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -53,7 +53,7 @@ let project = Project(
                 // beta *of*, and the build number is what actually distinguishes one
                 // beta from the next (0.1.6-beta was 17, -beta2 18, the release 19).
                 "CFBundleShortVersionString": "0.1.14",
-                "CFBundleVersion": "45",
+                "CFBundleVersion": "46",
             ]),
             resources: [
                 "graphcode/Resources/**"


### PR DESCRIPTION
`CFBundleVersion` 45 → 46, for cutting `0.1.14-beta4`. `CFBundleShortVersionString` stays `0.1.14` — a beta's suffix lives on the tag only, per the note in `Project.swift`.

Build 45 (`e935f18`, "build 45 for 0.1.14") was prepared for the 0.1.14 release and never tagged or published. Two commits have landed on `main` since then — `c77182f` (swift-format) and `35cc723` (the #25 sidebar fix) — so beta4 takes a build number of its own rather than reusing 45, and no published build ever shares a number with a different set of commits. The 0.1.14 final will need 47.

beta3 was build 44 at `6b83ca3`, so 46 stays monotonic.

## Verified in cloud

- `CFBundleVersion` appears exactly once in the tree outside `ThirdParty/` (`Project.swift:56`) — nothing else to keep in step.
- `Project.swift:55` still reads `0.1.14`, and `make tap-bump CHANNEL=beta` requires `VERSION=` explicitly for that channel, so it does not read the suffix from here.

## NOT verified — needs local Mac

This sandbox has no Xcode or macOS SDK, so nothing was generated or built.

- [ ] `make generate` — Tuist re-reads this manifest
- [ ] `make check` and `make test`
- [ ] `make release-dmg SIGN_ID="Developer ID Application: … (TEAMID)"`, then confirm About reports 0.1.14 (46)
- [ ] Tag `0.1.14-beta4`, `gh release create … --prerelease`, `make tap-bump CHANNEL=beta VERSION=0.1.14-beta4`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgieFmL824C6VjMc42n9Sz)_