### PR TITLE
A loop created from the app switches to itself once its broadcast lands

### DIFF
--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -111,6 +111,14 @@ struct ProjectFeature {
     /// new nodes append, deleted nodes drop out, and the rest keep their places.
     var sidebarNodeOrder: [UUID] = []
 
+    /// A loop just created from this app's own form, waiting for the daemon's
+    /// `graphChanged` broadcast to deliver it — at which point its workspace opens via
+    /// `.nodeTapped`. The node can't be opened at creation time because it doesn't
+    /// exist locally until the broadcast lands. Only ever set on the form path: a loop
+    /// created from the CLI arrives as a bare broadcast with nothing pending, so it
+    /// never steals focus.
+    var pendingCreatedNodeID: UUID?
+
     var id: String { graph.project.path }
 
     init(graph: LoopGraph) {
@@ -220,6 +228,13 @@ struct ProjectFeature {
           for node in newGraph.nodes where !state.sidebarNodeOrder.contains(node.id) {
             state.sidebarNodeOrder.append(node.id)
           }
+          // The broadcast that delivers a form-created loop is what makes it openable —
+          // switch to it now, the way tapping it would. Matched by id so an unrelated
+          // broadcast (another loop finishing, a CLI edit) leaves the pending id waiting.
+          if let pending = state.pendingCreatedNodeID, newGraph.nodes[id: pending] != nil {
+            state.pendingCreatedNodeID = nil
+            return .send(.nodeTapped(pending))
+          }
         case .errorOccurred(let message):
           state.connectionError = message
         case .recentProjectsListed:
@@ -262,6 +277,14 @@ struct ProjectFeature {
         // canvas somewhere the human didn't ask to go.
         if draft.loopType == .composite, insideComposite == nil {
           state.openCompositeID = draft.id
+        }
+        // A loop created from the form switches to itself once its broadcast lands —
+        // see `pendingCreatedNodeID`. Not composites: opening their sub-graph canvas
+        // (above) already is the switch. Not inside a composite either: the drilled-in
+        // canvas the human is looking at is where the new card appears, and workspace
+        // opening (`AppFeature`'s `.nodeTapped`) only reaches top-level nodes anyway.
+        if draft.loopType != .composite, insideComposite == nil {
+          state.pendingCreatedNodeID = draft.id
         }
 
         // Creating the worktree is the app's job, not the daemon's: `GitClient` lives

--- a/graphcode/Tests/AppFeatureTests.swift
+++ b/graphcode/Tests/AppFeatureTests.swift
@@ -192,6 +192,48 @@ struct AppFeatureTests {
     #expect(store.state.selectedProjectPath == Self.projectA.path)
   }
 
+  /// Issue #24, end to end: confirming the new-loop form opens the loop's workspace as
+  /// soon as the daemon's broadcast delivers the node — the human asked for this loop,
+  /// so the screen goes to it without a second tap.
+  @Test
+  @MainActor
+  func aLoopCreatedFromTheFormOpensItsWorkspaceWhenTheBroadcastLands() async {
+    var project = ProjectFeature.State(graph: LoopGraph(project: Self.projectA))
+    project.draftTitle = "Research"
+    project.draftGoal = "Say hello"
+    project.draftLoopType = .goalBased
+    var state = AppFeature.State()
+    state.projects.append(project)
+    state.selectedProjectPath = Self.projectA.path
+
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalLayoutStore = makeTerminalLayoutStore()
+      $0.orchestratorClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .projects(.element(id: Self.projectA.path, action: .createNodeConfirmed)))
+    guard let draftID = store.state.projects[id: Self.projectA.path]?.draftID else {
+      return #expect(Bool(false), "the project under test disappeared")
+    }
+    #expect(store.state.openLoop == nil)
+
+    let created = LoopNode(id: draftID, title: "Research", checkDescription: "Sound?")
+    await store.send(
+      .daemonEvent(.graphChanged(LoopGraph(project: Self.projectA, nodes: [created]))))
+    // The broadcast reaches the project as a forwarded `.daemonEvent`, which answers
+    // with the `.nodeTapped` that opens the workspace — drain both.
+    await store.receive(\.projects)
+    await store.receive(\.projects)
+
+    #expect(store.state.openLoop?.node.id == draftID)
+    #expect(store.state.selectedProjectPath == Self.projectA.path)
+    await store.finish()
+  }
+
   @Test
   @MainActor
   func aGraphChangedRefreshesTheOpenWorkspacesNodeInPlace() async {

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -104,6 +104,92 @@ struct ProjectFeatureTests {
     #expect(commands.count == 1)
   }
 
+  /// Creating a loop from the form switches to it — but only once the daemon's
+  /// broadcast delivers it, because until then there is no node to open. The switch
+  /// itself is a `.nodeTapped`, which `AppFeature` turns into an open workspace.
+  @Test
+  @MainActor
+  func aLoopCreatedFromTheFormOpensOnceItsBroadcastLands() async {
+    let store = TestStore(
+      initialState: ProjectFeature.State(graph: LoopGraph(project: Self.testProject))
+    ) {
+      ProjectFeature()
+    } withDependencies: {
+      $0.gitClient.listWorktrees = { _ in [] }
+      $0.orchestratorClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.addNodeButtonTapped(parentBackend: nil))
+    await store.send(.binding(.set(\.draftTitle, "Research")))
+    await store.send(.binding(.set(\.draftGoal, "Say hello")))
+    await store.send(.createNodeConfirmed)
+    let draftID = store.state.draftID
+    #expect(store.state.pendingCreatedNodeID == draftID)
+
+    // A broadcast without the new node — some unrelated change won the race — must
+    // neither open anything nor forget what is being waited for.
+    let stranger = LoopNode(title: "Other", checkDescription: "Done?")
+    await store.send(
+      .daemonEvent(.graphChanged(LoopGraph(project: Self.testProject, nodes: [stranger]))))
+    #expect(store.state.pendingCreatedNodeID == draftID)
+
+    let created = LoopNode(id: draftID, title: "Research", checkDescription: "Sound?")
+    await store.send(
+      .daemonEvent(
+        .graphChanged(LoopGraph(project: Self.testProject, nodes: [stranger, created]))))
+    await store.receive(\.nodeTapped, draftID)
+    #expect(store.state.pendingCreatedNodeID == nil)
+    await store.finish()
+  }
+
+  /// The other half of the deal: a loop created from the CLI arrives as a bare
+  /// broadcast and must not steal the screen. Exhaustive on purpose — a `.nodeTapped`
+  /// emitted here would fail the test as an unreceived action.
+  @Test
+  @MainActor
+  func aLoopArrivingFromTheCLIDoesNotSwitchToItself() async {
+    let store = TestStore(
+      initialState: ProjectFeature.State(graph: LoopGraph(project: Self.testProject))
+    ) {
+      ProjectFeature()
+    }
+
+    let node = LoopNode(title: "Research", checkDescription: "Sound?")
+    let graph = LoopGraph(project: Self.testProject, nodes: [node])
+
+    await store.send(.daemonEvent(.graphChanged(graph))) {
+      $0.graph = graph
+      $0.nodePositions[node.id] = ProjectFeature.gridPosition(0)
+      $0.sidebarNodeOrder = [node.id]
+    }
+  }
+
+  /// A composite's **Create & open** already moves the canvas into its sub-graph —
+  /// that *is* the switch, so no workspace open is queued on top of it.
+  @Test
+  @MainActor
+  func aCompositeCreatedFromTheFormOpensItsCanvasNotAWorkspace() async {
+    let store = TestStore(
+      initialState: ProjectFeature.State(graph: LoopGraph(project: Self.testProject))
+    ) {
+      ProjectFeature()
+    } withDependencies: {
+      $0.gitClient.listWorktrees = { _ in [] }
+      $0.orchestratorClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.addNodeButtonTapped(parentBackend: nil))
+    await store.send(.binding(.set(\.draftLoopType, .composite)))
+    await store.send(.binding(.set(\.draftTitle, "Nightly")))
+    await store.send(.createNodeConfirmed)
+
+    #expect(store.state.openCompositeID == store.state.draftID)
+    #expect(store.state.pendingCreatedNodeID == nil)
+    await store.finish()
+  }
+
   /// The form's metric fields become the goal's `metricCommand`/`metricDirection` —
   /// a control that looks set but doesn't travel would be a silent no-op in shipping UI.
   @Test


### PR DESCRIPTION
Fixes #24.

When a loop is created from the app's new-loop form, the app now switches to it — the detail pane opens the new loop's workspace as soon as the daemon's `graphChanged` broadcast delivers the node. Loops created from the `graphcode` CLI still arrive without any selection change.

## How

- `ProjectFeature.State.pendingCreatedNodeID`: set on `createNodeConfirmed` to the draft's id. The node can't be opened at creation time because it doesn't exist locally until the daemon broadcasts it back.
- When a `graphChanged` broadcast contains the pending node, the reducer clears the pending id and sends the same `.nodeTapped` a tap would — `AppFeature`'s existing interception opens the workspace and selects the project. A broadcast that doesn't contain the node (an unrelated change winning the race) leaves the pending id waiting.
- CLI-created loops arrive as bare broadcasts with nothing pending, so they never steal focus — that half already held and is now pinned by an exhaustive test.
- Composites are excluded on purpose: **Create & open** already moves the canvas into the new composite's sub-graph, which *is* the switch. Loops created *inside* an open composite are also excluded — the drilled-in canvas the human is looking at is where the new card appears, and workspace opening only reaches top-level nodes.

## Tests

- `ProjectFeatureTests.aLoopCreatedFromTheFormOpensOnceItsBroadcastLands` — pending id set on confirm, unrelated broadcast leaves it waiting, delivering broadcast emits `.nodeTapped`.
- `ProjectFeatureTests.aLoopArrivingFromTheCLIDoesNotSwitchToItself` — exhaustive, so any emitted `.nodeTapped` fails as an unreceived action.
- `ProjectFeatureTests.aCompositeCreatedFromTheFormOpensItsCanvasNotAWorkspace`
- `AppFeatureTests.aLoopCreatedFromTheFormOpensItsWorkspaceWhenTheBroadcastLands` — end to end: form confirm → broadcast → `openLoop` is the new node.

Full suite: 602 tests in 65 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)