### PR TITLE
Check for Updates asks GitHub and walks you to the DMG

### DIFF
--- a/graphcode/Sources/Clients/UpdateClient.swift
+++ b/graphcode/Sources/Clients/UpdateClient.swift
@@ -1,0 +1,57 @@
+import Dependencies
+import Foundation
+
+/// Asks GitHub for the newest stable release, and answers what this build is. Both live
+/// here rather than in the reducer so a test can hand the check any release and any
+/// installed version without a network or a real bundle.
+struct UpdateClient: Sendable {
+  var latestRelease: @Sendable () async throws -> UpdateRelease
+  var currentVersion: @Sendable () -> String
+}
+
+enum UpdateCheckFailure: Error, LocalizedError, Equatable {
+  case requestFailed(status: Int)
+
+  var errorDescription: String? {
+    switch self {
+    case .requestFailed(let status):
+      return "GitHub answered with status \(status)."
+    }
+  }
+}
+
+extension UpdateClient: DependencyKey {
+  static let liveValue = UpdateClient(
+    latestRelease: {
+      // `releases/latest` excludes drafts and prereleases by definition, which matches
+      // what the README's download link and the stable cask install — a beta user is
+      // offered the stable line, never a newer beta.
+      guard
+        let url = URL(string: "https://api.github.com/repos/scgopi/GraphCode/releases/latest")
+      else { throw UpdateCheckFailure.requestFailed(status: 0) }
+      var request = URLRequest(url: url)
+      request.timeoutInterval = 15
+      request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+      let (data, response) = try await URLSession.shared.data(for: request)
+      if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+        throw UpdateCheckFailure.requestFailed(status: http.statusCode)
+      }
+      return try JSONDecoder().decode(UpdateRelease.self, from: data)
+    },
+    currentVersion: {
+      Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
+    })
+
+  /// Tests have no network and should not discover that by hanging — a test that wants
+  /// a particular release overrides `latestRelease` with a fixture.
+  static let testValue = UpdateClient(
+    latestRelease: { throw UpdateCheckFailure.requestFailed(status: 0) },
+    currentVersion: { "0.0.0" })
+}
+
+extension DependencyValues {
+  var updateClient: UpdateClient {
+    get { self[UpdateClient.self] }
+    set { self[UpdateClient.self] = newValue }
+  }
+}

--- a/graphcode/Sources/Features/App/AppFeature+Updates.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Updates.swift
@@ -1,0 +1,88 @@
+import ComposableArchitecture
+import Foundation
+
+/// Check for Updates — the app-menu item, the check against GitHub's newest stable
+/// release, and the two alerts `AppView` hosts for the outcome (issue #27).
+///
+/// The update itself is a download, not an in-place swap: dragging the DMG's app over
+/// /Applications *is* the whole installation — `DaemonBootstrap` re-stages the bundled
+/// helpers on next launch — so the flow's job ends at putting the right DMG in front of
+/// the human, in the browser, where a large download has progress and resume for free.
+extension AppFeature {
+  /// A completed check's one-sentence outcome, for the alert that reports it. Only the
+  /// "nothing to do" outcomes land here — an actual update gets the richer alert driven
+  /// by `State.availableUpdate`.
+  struct UpdateNotice: Equatable, Sendable {
+    var title: String
+    var message: String
+
+    static func upToDate(current: String) -> UpdateNotice {
+      UpdateNotice(
+        title: "You're up to date",
+        message: "GraphCode \(current) is the newest release.")
+    }
+
+    static func checkFailed(_ reason: String) -> UpdateNotice {
+      UpdateNotice(
+        title: "Couldn't check for updates",
+        message: "\(reason)\n\nCheck your connection and try again in a while.")
+    }
+  }
+
+  var updatesReducer: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .checkForUpdatesTapped:
+        // A second click while a check is in flight would just race two alerts; the
+        // menu item is disabled on this flag, and this guard is the backstop.
+        guard !state.isCheckingForUpdates else { return .none }
+        state.isCheckingForUpdates = true
+        return .run { send in
+          do {
+            let release = try await updateClient.latestRelease()
+            let update = AppUpdate.available(
+              current: updateClient.currentVersion(), release: release)
+            await send(.updateCheckCompleted(.success(update)))
+          } catch {
+            await send(.updateCheckCompleted(.failure(error)))
+          }
+        }
+
+      case .updateCheckCompleted(.success(let update)):
+        state.isCheckingForUpdates = false
+        if let update {
+          state.availableUpdate = update
+        } else {
+          state.updateNotice = .upToDate(current: updateClient.currentVersion())
+        }
+        return .none
+
+      case .updateCheckCompleted(.failure(let error)):
+        state.isCheckingForUpdates = false
+        state.updateNotice = .checkFailed(error.localizedDescription)
+        return .none
+
+      case .updateDownloadTapped:
+        guard let update = state.availableUpdate else { return .none }
+        state.availableUpdate = nil
+        return .run { _ in await openURL(update.downloadURL) }
+
+      case .updateReleaseNotesTapped:
+        guard let update = state.availableUpdate else { return .none }
+        state.availableUpdate = nil
+        return .run { _ in await openURL(update.releaseNotesURL) }
+
+      case .updateAlertDismissed:
+        state.availableUpdate = nil
+        return .none
+
+      case .updateNoticeDismissed:
+        state.updateNotice = nil
+        return .none
+
+      default:
+        return .none
+      }
+    }
+  }
+}

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -85,6 +85,13 @@ struct AppFeature {
     var jumpQuery = ""
     var jumpSelection = 0
 
+    /// Check for Updates — see `AppFeature+Updates.swift`. The newer release a check
+    /// found (the offer alert is up while non-nil), the "nothing to do" outcome (up to
+    /// date, or why the check failed), and the in-flight flag the menu item disables on.
+    var availableUpdate: AvailableUpdate?
+    var updateNotice: UpdateNotice?
+    var isCheckingForUpdates = false
+
     /// State changes seen since launch, for the activity strip — see
     /// `AppFeature+Activity.swift`. Bounded, and deliberately not persisted.
     var activityLog: [ActivityEvent] = []
@@ -181,6 +188,13 @@ struct AppFeature {
     /// The first-launch terminology primer — see `OnboardingView`.
     case onboardingRequested
     case onboardingDismissed
+    /// The app menu's "Check for Updates…" — see `AppFeature+Updates.swift`.
+    case checkForUpdatesTapped
+    case updateCheckCompleted(Result<AvailableUpdate?, any Error>)
+    case updateDownloadTapped
+    case updateReleaseNotesTapped
+    case updateAlertDismissed
+    case updateNoticeDismissed
     /// The Quick Chats section's actions — see `State.quickChats`.
     case newQuickChatTapped
     /// The Quick Chats header row: shows the chats' own canvas, the way a folder row
@@ -203,6 +217,8 @@ struct AppFeature {
   @Dependency(\.orchestratorClient) var orchestratorClient
   @Dependency(\.terminalLayoutStore) var terminalLayoutStore
   @Dependency(\.quickChatStore) var quickChatStore
+  @Dependency(\.updateClient) var updateClient
+  @Dependency(\.openURL) var openURL
   /// Only for the cases where a workspace goes away because the *loop* did. Merely
   /// switching to another loop leaves its surfaces alive on purpose — see
   /// `TerminalSurfaceStore` — but a deleted loop, or a closed project, is never coming
@@ -218,6 +234,7 @@ struct AppFeature {
     // section, a canvas, and two dialogs) that has nothing to do with projects or graphs.
     quickChatsReducer
     jumpPaletteReducer
+    updatesReducer
     Reduce { state, action in
       switch action {
       case .task:
@@ -414,6 +431,12 @@ struct AppFeature {
         UserDefaults.standard.set(true, forKey: "hasSeenOnboarding")
         return .none
 
+      // Every update action is handled by `updatesReducer`, in
+      // `AppFeature+Updates.swift` — listed here only so this switch stays exhaustive.
+      case .checkForUpdatesTapped, .updateCheckCompleted, .updateDownloadTapped,
+        .updateReleaseNotesTapped, .updateAlertDismissed, .updateNoticeDismissed:
+        return .none
+
       // Every Quick Chats action is handled by `quickChatsReducer`, in
       // `AppFeature+QuickChats.swift` — listed here only so this switch stays exhaustive
       // and a new action can't be added without deciding which of the two answers it.
@@ -496,7 +519,11 @@ struct AppFeature {
       ProjectFeature()
     }
   }
+}
 
+// The reducer's helpers — an extension so the type body stays inside the lint budget as
+// the state and actions above keep growing.
+extension AppFeature {
   /// Steps the open workspace to another loop, in the order the sidebar draws them —
   /// every open project's nodes, flattened — wrapping at the ends and skipping blocked
   /// nodes, the same rule a direct `.nodeTapped` applies. With no workspace open it

--- a/graphcode/Sources/Features/App/AppUpdate.swift
+++ b/graphcode/Sources/Features/App/AppUpdate.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// A version as the app and its release tags write one — `0.1.14`, `v0.1.14`,
+/// `0.1.14-beta3`. One parser for both sides of the comparison, because the two
+/// spellings genuinely differ: stable tags carry a `v` prefix, beta tags don't
+/// (see `TAG_PREFIX` in the Makefile), and the bundle's own
+/// `CFBundleShortVersionString` carries neither prefix nor prerelease.
+struct AppVersion: Equatable, Comparable, Sendable {
+  var release: [Int]
+  /// The prerelease's number — `0.1.14-beta3` is `3`. `nil` means a stable version,
+  /// which sorts *after* every prerelease of the same release.
+  var prerelease: Int?
+
+  init?(_ string: String) {
+    var text = Substring(string.trimmingCharacters(in: .whitespaces))
+    if text.hasPrefix("v") { text = text.dropFirst() }
+    let parts = text.split(separator: "-", maxSplits: 1)
+    guard let numeric = parts.first else { return nil }
+    let components = numeric.split(separator: ".", omittingEmptySubsequences: false)
+    guard !components.isEmpty else { return nil }
+    var numbers: [Int] = []
+    for component in components {
+      guard let number = Int(component) else { return nil }
+      numbers.append(number)
+    }
+    release = numbers
+    if parts.count == 2 {
+      // "beta3" — the digits order prereleases among themselves; a marker with no
+      // number still counts as a prerelease, just the earliest possible one.
+      prerelease = Int(parts[1].drop { !$0.isNumber }) ?? 0
+    }
+  }
+
+  static func < (lhs: AppVersion, rhs: AppVersion) -> Bool {
+    // Padded numeric comparison, not lexicographic — "0.1.9" < "0.1.14" is the case
+    // that string comparison gets wrong, and this project has already shipped both.
+    for index in 0..<max(lhs.release.count, rhs.release.count) {
+      let left = index < lhs.release.count ? lhs.release[index] : 0
+      let right = index < rhs.release.count ? rhs.release[index] : 0
+      if left != right { return left < right }
+    }
+    switch (lhs.prerelease, rhs.prerelease) {
+    case (nil, nil): return false
+    case (.some, nil): return true
+    case (nil, .some): return false
+    case (.some(let left), .some(let right)): return left < right
+    }
+  }
+}
+
+/// The slice of a GitHub release the update check reads —
+/// `GET /repos/…/releases/latest`, which is GitHub's own "newest stable": drafts and
+/// prereleases never appear in it, matching what the DMG link and the cask ship.
+struct UpdateRelease: Equatable, Sendable, Decodable {
+  struct Asset: Equatable, Sendable, Decodable {
+    var name: String
+    var browserDownloadURL: URL
+
+    enum CodingKeys: String, CodingKey {
+      case name
+      case browserDownloadURL = "browser_download_url"
+    }
+  }
+
+  var tagName: String
+  var htmlURL: URL
+  var assets: [Asset]
+
+  enum CodingKeys: String, CodingKey {
+    case tagName = "tag_name"
+    case htmlURL = "html_url"
+    case assets
+  }
+
+  /// The DMG this release ships — the exact name `release-dmg` uploads, falling back
+  /// to any `.dmg` so a renamed asset degrades to a working download rather than none.
+  var dmgDownloadURL: URL? {
+    let exact = assets.first { $0.name == "graphcode-macos-arm64.dmg" }
+    let anyDMG = assets.first { $0.name.hasSuffix(".dmg") }
+    return (exact ?? anyDMG)?.browserDownloadURL
+  }
+
+  /// The tag as a human version — `v0.1.14` reads as `0.1.14` everywhere the app says it.
+  var displayVersion: String {
+    tagName.hasPrefix("v") ? String(tagName.dropFirst()) : tagName
+  }
+}
+
+/// A newer release the check found, shaped for the alert that offers it.
+struct AvailableUpdate: Equatable, Sendable {
+  var version: String
+  var currentVersion: String
+  var downloadURL: URL
+  var releaseNotesURL: URL
+}
+
+enum AppUpdate {
+  /// The whole decision: the update the release represents for someone on `current`,
+  /// or `nil` when there's nothing newer. An unparsable version on either side also
+  /// answers `nil` — a dev build with no real version should never be nagged, and a
+  /// malformed tag is GitHub telling us nothing trustworthy.
+  static func available(current: String, release: UpdateRelease) -> AvailableUpdate? {
+    guard let installed = AppVersion(current), let latest = AppVersion(release.tagName),
+      installed < latest
+    else { return nil }
+    return AvailableUpdate(
+      version: release.displayVersion,
+      currentVersion: current,
+      downloadURL: release.dmgDownloadURL ?? release.htmlURL,
+      releaseNotesURL: release.htmlURL)
+  }
+}

--- a/graphcode/Sources/Features/App/AppView.swift
+++ b/graphcode/Sources/Features/App/AppView.swift
@@ -184,6 +184,36 @@ struct AppView: View {
         "\(store.pendingChatDeletion?.title ?? "This chat")'s session and scrollback "
           + "will be permanently deleted.")
     }
+    // Check for Updates — hosted here like every other dialog, so the answer can open
+    // over a terminal as readily as over a canvas. Two alerts because the outcomes ask
+    // different things of you: a found update offers verbs, the rest is one sentence.
+    .alert(
+      "GraphCode \(store.availableUpdate?.version ?? "") is available",
+      isPresented: Binding(
+        get: { store.availableUpdate != nil },
+        set: { if !$0 { store.send(.updateAlertDismissed) } }
+      )
+    ) {
+      Button("Download Update") { store.send(.updateDownloadTapped) }
+      Button("Release Notes") { store.send(.updateReleaseNotesTapped) }
+      Button("Later", role: .cancel) { store.send(.updateAlertDismissed) }
+    } message: {
+      Text(
+        "You're running \(store.availableUpdate?.currentVersion ?? ""). The download "
+          + "opens in your browser — drag GraphCode into Applications to install it, "
+          + "and the app takes care of its helpers on the next launch.")
+    }
+    .alert(
+      store.updateNotice?.title ?? "",
+      isPresented: Binding(
+        get: { store.updateNotice != nil },
+        set: { if !$0 { store.send(.updateNoticeDismissed) } }
+      )
+    ) {
+      Button("OK") { store.send(.updateNoticeDismissed) }
+    } message: {
+      Text(store.updateNotice?.message ?? "")
+    }
   }
 
   /// The open loop's trailing panel, toggled from where macOS puts an inspector toggle.

--- a/graphcode/Sources/GraphcodeApp.swift
+++ b/graphcode/Sources/GraphcodeApp.swift
@@ -64,6 +64,13 @@ struct GraphcodeApp: App {
     // dismissed it before the words had anything on screen to stick to. In Help rather
     // than the sidebar toolbar, where a second item overflowed the column into a » menu.
     .commands {
+      // Right under About, where every Mac app that can update itself puts it.
+      CommandGroup(after: .appInfo) {
+        Button("Check for Updates…") {
+          Self.store.send(.checkForUpdatesTapped)
+        }
+        .disabled(Self.store.isCheckingForUpdates)
+      }
       CommandGroup(after: .help) {
         Button("GraphCode Basics") {
           Self.store.send(.onboardingRequested)

--- a/graphcode/Tests/CheckForUpdatesTests.swift
+++ b/graphcode/Tests/CheckForUpdatesTests.swift
@@ -1,0 +1,272 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import graphcode
+
+/// Check for Updates (issue #27): the version comparison the offer hangs on, the slice
+/// of GitHub's release JSON the check reads, and the flow from the menu item to the two
+/// alerts `AppView` hosts.
+@Suite
+struct CheckForUpdatesTests {
+
+  // MARK: - Versions
+
+  @Test
+  func aStableTagAndABundleVersionAreTheSameVersion() {
+    // The two spellings this app actually ships: `v0.1.14` on the tag,
+    // `0.1.14` in the bundle.
+    #expect(AppVersion("v0.1.14") == AppVersion("0.1.14"))
+  }
+
+  private func version(_ string: String) throws -> AppVersion {
+    try #require(AppVersion(string))
+  }
+
+  @Test
+  func versionsCompareNumericallyNotLexicographically() throws {
+    // "0.1.9" > "0.1.14" as strings — the released history already contains both, so
+    // this is the comparison a naive check would get wrong.
+    #expect(try version("0.1.9") < version("0.1.14"))
+    #expect(try version("0.1.99") < version("0.2"))
+    // A shorter version pads with zeros rather than sorting by length.
+    #expect(try version("0.1.14") < version("0.1.14.1"))
+    #expect(try !(version("0.1.14") < version("0.1.14")))
+  }
+
+  @Test
+  func aBetaPrecedesItsOwnReleaseAndBetasOrderByNumber() throws {
+    // Beta tags carry no `v` (see the Makefile's TAG_PREFIX) and sort before the
+    // release they are a beta of; beta10 after beta2 is the numeric half again.
+    #expect(try version("0.1.14-beta3") < version("v0.1.14"))
+    #expect(try version("0.1.14-beta2") < version("0.1.14-beta10"))
+    #expect(try version("v0.1.12") < version("0.1.14-beta1"))
+  }
+
+  @Test
+  func garbageIsNotAVersion() {
+    #expect(AppVersion("main") == nil)
+    #expect(AppVersion("") == nil)
+    #expect(AppVersion("1.two.3") == nil)
+  }
+
+  // MARK: - The release JSON
+
+  private func release(_ json: String) throws -> UpdateRelease {
+    try JSONDecoder().decode(UpdateRelease.self, from: Data(json.utf8))
+  }
+
+  /// The shape `GET /repos/scgopi/GraphCode/releases/latest` actually answers with,
+  /// trimmed to the keys the check reads plus a few it must ignore.
+  private let latestReleaseJSON = """
+    {
+      "tag_name": "v0.2.0",
+      "name": "v0.2.0 — a bigger canvas",
+      "html_url": "https://example.com/releases/tag/v0.2.0",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "graphcode-macos-arm64.dmg.sha256",
+          "browser_download_url": "https://example.com/v0.2.0/graphcode-macos-arm64.dmg.sha256"
+        },
+        {
+          "name": "graphcode-macos-arm64.dmg",
+          "browser_download_url": "https://example.com/v0.2.0/graphcode-macos-arm64.dmg"
+        }
+      ]
+    }
+    """
+
+  @Test
+  func theReleaseJSONDecodesToTagNotesAndTheExactDMG() throws {
+    let release = try release(latestReleaseJSON)
+    #expect(release.tagName == "v0.2.0")
+    #expect(release.displayVersion == "0.2.0")
+    // The exact asset `release-dmg` uploads — not the `.sha256` beside it, even though
+    // that one's name also contains ".dmg".
+    #expect(
+      release.dmgDownloadURL?.absoluteString
+        == "https://example.com/v0.2.0/graphcode-macos-arm64.dmg")
+  }
+
+  @Test
+  func aRenamedDMGStillDownloadsAndNoDMGFallsBackToTheReleasePage() throws {
+    let renamed = try release(
+      """
+      {
+        "tag_name": "v0.2.0",
+        "html_url": "https://example.com/releases/tag/v0.2.0",
+        "assets": [
+          {
+            "name": "GraphCode-0.2.0.dmg",
+            "browser_download_url": "https://example.com/GraphCode-0.2.0.dmg"
+          }
+        ]
+      }
+      """)
+    #expect(renamed.dmgDownloadURL?.absoluteString == "https://example.com/GraphCode-0.2.0.dmg")
+
+    let bare = try release(
+      """
+      {
+        "tag_name": "v0.2.0",
+        "html_url": "https://example.com/releases/tag/v0.2.0",
+        "assets": []
+      }
+      """)
+    #expect(bare.dmgDownloadURL == nil)
+    let update = AppUpdate.available(current: "0.1.14", release: bare)
+    // No DMG is a mis-shaped release, not a dead end — the button leads somewhere the
+    // human can still get the update.
+    #expect(update?.downloadURL == bare.htmlURL)
+  }
+
+  // MARK: - The decision
+
+  @Test
+  func aNewerReleaseIsAnUpdateAndTheSameOrOlderIsNot() throws {
+    let release = try release(latestReleaseJSON)
+    let update = AppUpdate.available(current: "0.1.14", release: release)
+    #expect(update?.version == "0.2.0")
+    #expect(update?.currentVersion == "0.1.14")
+    #expect(update?.downloadURL == release.dmgDownloadURL)
+    #expect(update?.releaseNotesURL == release.htmlURL)
+
+    #expect(AppUpdate.available(current: "0.2.0", release: release) == nil)
+    // Running ahead of the newest release — a build from main — is not an update either.
+    #expect(AppUpdate.available(current: "0.3.0", release: release) == nil)
+  }
+
+  @Test
+  func anUnparsableVersionOnEitherSideOffersNothing() throws {
+    // A dev build with no real version should never be nagged, and a malformed tag is
+    // GitHub telling us nothing trustworthy.
+    let release = try release(latestReleaseJSON)
+    #expect(AppUpdate.available(current: "unversioned", release: release) == nil)
+
+    let badTag = try self.release(
+      """
+      {
+        "tag_name": "latest",
+        "html_url": "https://example.com/releases/tag/latest",
+        "assets": []
+      }
+      """)
+    #expect(AppUpdate.available(current: "0.1.14", release: badTag) == nil)
+  }
+
+  // MARK: - The flow
+
+  private func fixtureRelease() throws -> UpdateRelease {
+    try release(latestReleaseJSON)
+  }
+
+  @Test
+  @MainActor
+  func theMenuItemFindsAnUpdateAndOffersIt() async throws {
+    let release = try fixtureRelease()
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateClient.latestRelease = { release }
+      $0.updateClient.currentVersion = { "0.1.14" }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.checkForUpdatesTapped)
+    #expect(store.state.isCheckingForUpdates)
+    await store.receive(\.updateCheckCompleted)
+
+    #expect(!store.state.isCheckingForUpdates)
+    #expect(store.state.availableUpdate?.version == "0.2.0")
+    #expect(store.state.updateNotice == nil)
+  }
+
+  @Test
+  @MainActor
+  func beingUpToDateSaysSoInsteadOfOffering() async throws {
+    let release = try fixtureRelease()
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateClient.latestRelease = { release }
+      $0.updateClient.currentVersion = { "0.2.0" }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.checkForUpdatesTapped)
+    await store.receive(\.updateCheckCompleted)
+
+    #expect(store.state.availableUpdate == nil)
+    #expect(store.state.updateNotice == .upToDate(current: "0.2.0"))
+
+    await store.send(.updateNoticeDismissed)
+    #expect(store.state.updateNotice == nil)
+  }
+
+  @Test
+  @MainActor
+  func aFailedCheckExplainsItselfInsteadOfStayingSilent() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateClient.latestRelease = { throw UpdateCheckFailure.requestFailed(status: 503) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.checkForUpdatesTapped)
+    await store.receive(\.updateCheckCompleted)
+
+    #expect(store.state.availableUpdate == nil)
+    #expect(store.state.updateNotice?.title == "Couldn't check for updates")
+    // The check is done either way — the menu item must come back.
+    #expect(!store.state.isCheckingForUpdates)
+  }
+
+  private actor OpenedURLsBox {
+    var urls: [URL] = []
+    func append(_ url: URL) { urls.append(url) }
+  }
+
+  @Test
+  @MainActor
+  func downloadOpensTheDMGInTheBrowserAndTakesTheAlertDown() async throws {
+    let release = try fixtureRelease()
+    let update = try #require(AppUpdate.available(current: "0.1.14", release: release))
+    var state = AppFeature.State()
+    state.availableUpdate = update
+
+    let opened = OpenedURLsBox()
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.openURL = OpenURLEffect { url in
+        await opened.append(url)
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.updateDownloadTapped)
+    await store.finish()
+
+    #expect(store.state.availableUpdate == nil)
+    #expect(await opened.urls == [update.downloadURL])
+  }
+
+  @Test
+  @MainActor
+  func laterDismissesWithoutOpeningAnything() async throws {
+    let release = try fixtureRelease()
+    var state = AppFeature.State()
+    state.availableUpdate = AppUpdate.available(current: "0.1.14", release: release)
+
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.updateAlertDismissed)
+    #expect(store.state.availableUpdate == nil)
+  }
+}


### PR DESCRIPTION
Fixes #27.

## What this adds

- **Check for Updates…** in the app menu, right under About. It asks `GET /repos/scgopi/GraphCode/releases/latest` — GitHub's own "newest stable", so drafts and prereleases never appear — and compares that tag against the running bundle's version.
- A found update raises an alert offering **Download Update** (the release's `graphcode-macos-arm64.dmg`, opened in the browser where a large download gets progress and resume for free) or **Release Notes**; *up to date* and *check failed* each answer in one sentence.
- Installing stays a drag onto Applications: `DaemonBootstrap` already re-stages the bundled helpers on next launch, so the flow's job ends at putting the right DMG in front of the human.

## Why the version type exists

Tags are asymmetric here — stable is `v0.1.14`, betas are `0.1.14-beta3` with no `v` — and the history contains `v0.1.9` next to `v0.1.14`, which string comparison orders wrong. `AppVersion` strips the prefix, compares numerically with zero-padding, and sorts a prerelease before its own release. An unparsable version on either side offers nothing: a dev build should never be nagged, and a malformed tag is GitHub telling us nothing trustworthy.

## Shape

`UpdateClient` is the house `DependencyKey` client (`liveValue` on URLSession, `testValue` that never touches the network); the flow is a slice of `AppFeature` in `AppFeature+Updates.swift` like Quick Chats and the jump palette; the two alerts are hosted by `AppView` with the other dialogs, so they open over a terminal as readily as over a canvas. Moving `AppFeature`'s private helpers into a same-file extension keeps the type body inside the lint budget.

## Tests

`CheckForUpdatesTests` (11 tests): version parsing and ordering (numeric vs lexicographic, beta ordering, garbage), the release-JSON slice (exact DMG asset vs the `.sha256` beside it, renamed-asset and no-asset fallbacks), the update decision, and the reducer flow (found/up-to-date/failed, download opens the DMG URL and drops the alert, Later opens nothing). Full suite: 615 tests in 66 suites, green; `make check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)