### PR TITLE
Focus follows a loop switch: one click lands the keyboard in the session

### DIFF
--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView+Visibility.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView+Visibility.swift
@@ -96,6 +96,38 @@ extension GhosttyTerminalNSView {
     window.makeFirstResponder(self)
   }
 
+  /// Claims the keyboard for a surface that just entered the window, one run-loop turn
+  /// later — the moment `viewDidMoveToWindow` fires, the outgoing loop's surface is
+  /// still mounted (and still first responder), and a sidebar click's `List` selection
+  /// hasn't finished moving first responder to its table. Deciding then reads a world
+  /// that is about to change; a turn later both have settled and `MountFocusPolicy` can
+  /// look at what actually holds the keyboard. See that type for the rule and issue #30
+  /// for the second-click symptom this removes.
+  func claimKeyboardOnMount() {
+    DispatchQueue.main.async { [weak self] in
+      MainActor.assumeIsolated {
+        guard let self, let window = self.window else { return }
+        let holder: MountFocusPolicy.Holder
+        switch window.firstResponder {
+        case let responder as GhosttyTerminalNSView:
+          holder =
+            responder === self
+            ? .thisSurface : responder.isActive ? .activeSurface : .inactiveSurface
+        case is NSTextView:
+          // `NSTextField` edits through a shared field editor, which is an `NSTextView`,
+          // so this covers a rename field as well as a real text view.
+          holder = .textInput
+        default:
+          holder = .somethingElse
+        }
+        guard
+          MountFocusPolicy.shouldClaimKeyboard(holder: holder, surfaceIsActive: self.isActive)
+        else { return }
+        window.makeFirstResponder(self)
+      }
+    }
+  }
+
   /// Take the keyboard back when nothing in the window is holding it.
   ///
   /// **This is a frame-pacing fix, not a keyboard one.** libghostty runs its

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView.swift
@@ -216,12 +216,13 @@ final class GhosttyTerminalNSView: NSView {
     }
     syncOcclusion()
     guard window != nil else { return }
-    // Only claim focus if no other terminal already holds it. Mounting used to take it
-    // unconditionally, so with several tabs alive the last surface to appear captured
-    // the keyboard no matter which tab was showing — typing, and prefixes like tmux's
-    // ctrl+a, went to a shell that wasn't on screen.
-    guard !(window?.firstResponder is GhosttyTerminalNSView) else { return }
-    window?.makeFirstResponder(self)
+    // Mounting used to take the keyboard unconditionally, so with several tabs alive the
+    // last surface to appear captured it no matter which tab was showing; the guard that
+    // fixed that declined whenever *any* terminal held it — including the outgoing
+    // loop's still-mounted surface, which is why switching loops needed a second click
+    // before typing worked (issue #30). Both rules now live in `MountFocusPolicy`,
+    // evaluated a run-loop turn later once the old pane is gone.
+    claimKeyboardOnMount()
   }
 
   // MARK: - Keyboard

--- a/graphcode/Sources/Infrastructure/Ghostty/MountFocusPolicy.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/MountFocusPolicy.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Whether a terminal surface that just entered the window should take the keyboard.
+///
+/// Switching loops replaces the whole workspace, and the incoming surface mounts while
+/// the outgoing loop's surface — or the sidebar's table, mid-click — still holds first
+/// responder. The old mount rule declined whenever *any* terminal held the keyboard, so
+/// the outgoing surface blocked the incoming one; when the old pane then unmounted,
+/// first responder fell back to the window and nobody claimed it. One click opened the
+/// workspace, and a second click was needed before typing worked (issue #30).
+///
+/// The claim is evaluated one run-loop turn after the mount (see
+/// `claimKeyboardOnMount`), so the outgoing pane has unmounted and the sidebar's `List`
+/// has finished its selection dance by the time the holder is inspected. A pure decision
+/// function for the same reason `ScrollFocusPolicy` is one: the alternative is a rule
+/// spelled out in `if` statements inside an `NSView` that no test can reach.
+enum MountFocusPolicy {
+  /// What the window's first responder is by the time the deferred claim runs. Richer
+  /// than `ScrollFocusPolicy.Holder` in exactly one place: a mount has to tell the
+  /// legitimately focused pane apart from a leftover one, so `anotherSurface` splits
+  /// into active and inactive.
+  enum Holder: Equatable {
+    /// This very surface — nothing to do.
+    case thisSurface
+    /// The surface the user is typing into — its tab showing, that tab's focused pane.
+    /// A mounting sibling (the far half of a new split, another tab's pane) must not
+    /// pull the keyboard out of it.
+    case activeSurface
+    /// A terminal nobody is looking at: the outgoing loop's pane, a hidden tab's.
+    case inactiveSurface
+    /// Somewhere text is being typed: a rename field, a form. Never taken from.
+    case textInput
+    /// Anything else — the window itself, the sidebar's table after the click that
+    /// opened this workspace.
+    case somethingElse
+  }
+
+  /// Whether the freshly mounted surface should be made first responder.
+  ///
+  /// Only the active surface claims — every tab of a workspace mounts at once, and the
+  /// old rule's real purpose (the last surface to appear must not capture the keyboard
+  /// for a shell that isn't on screen) survives as that gate.
+  ///
+  /// Taking from `somethingElse` is the fix: after a sidebar click that is the table,
+  /// after a canvas click the window itself. Opening a workspace is always the user
+  /// choosing this terminal, so focus follows the switch.
+  ///
+  /// No `windowIsKey` gate, unlike a scroll: a workspace opened while the window isn't
+  /// key should be ready to type the moment it becomes key, and the mount claim never
+  /// checked key status before.
+  static func shouldClaimKeyboard(holder: Holder, surfaceIsActive: Bool) -> Bool {
+    guard surfaceIsActive else { return false }
+    switch holder {
+    case .thisSurface, .activeSurface, .textInput: return false
+    case .inactiveSurface, .somethingElse: return true
+    }
+  }
+}

--- a/graphcode/Tests/MountFocusPolicyTests.swift
+++ b/graphcode/Tests/MountFocusPolicyTests.swift
@@ -1,0 +1,59 @@
+import Testing
+
+@testable import graphcode
+
+/// Whether a surface that just entered the window takes the keyboard — which is really
+/// whether opening a loop leaves you ready to type.
+///
+/// The regression this guards is issue #30: clicking a loop opened its workspace, but the
+/// outgoing loop's still-mounted surface made the old mount rule decline, first responder
+/// fell back to the window when that pane unmounted, and a second click was needed before
+/// typing worked. The other direction is guarded too — the rule the old guard existed for
+/// (a mounting surface must not capture the keyboard for a shell that isn't on screen)
+/// has to keep holding.
+@Suite
+struct MountFocusPolicyTests {
+  @Test("The active surface takes the keyboard from the outgoing loop's leftover pane")
+  func claimsFromInactiveSurface() {
+    #expect(
+      MountFocusPolicy.shouldClaimKeyboard(holder: .inactiveSurface, surfaceIsActive: true))
+  }
+
+  /// The observed failure paths: after a sidebar click the holder is the `List`'s table,
+  /// after a canvas click (or once the old pane unmounts) the window itself. Both mean
+  /// the user just chose this terminal, so it claims.
+  @Test("The active surface takes the keyboard from the sidebar table or the window")
+  func claimsFromSomethingElse() {
+    #expect(
+      MountFocusPolicy.shouldClaimKeyboard(holder: .somethingElse, surfaceIsActive: true))
+  }
+
+  /// The rule the old unconditional-mount guard existed for, kept: every tab's surfaces
+  /// mount at once, and only the pane the user is actually in may claim.
+  @Test("An inactive surface never claims, whoever holds the keyboard")
+  func inactiveSurfaceNeverClaims() {
+    for holder: MountFocusPolicy.Holder in [
+      .thisSurface, .activeSurface, .inactiveSurface, .textInput, .somethingElse,
+    ] {
+      #expect(!MountFocusPolicy.shouldClaimKeyboard(holder: holder, surfaceIsActive: false))
+    }
+  }
+
+  @Test("The pane being typed into keeps the keyboard")
+  func neverTakesFromActiveSurface() {
+    #expect(
+      !MountFocusPolicy.shouldClaimKeyboard(holder: .activeSurface, surfaceIsActive: true))
+  }
+
+  /// Same refusal as `ScrollFocusPolicy`, same reason: a workspace opening under a rename
+  /// field must not swallow the next keystroke.
+  @Test("Text being edited keeps the keyboard")
+  func neverTakesFromTextInput() {
+    #expect(!MountFocusPolicy.shouldClaimKeyboard(holder: .textInput, surfaceIsActive: true))
+  }
+
+  @Test("A surface that already has the keyboard does nothing")
+  func noOpWhenAlreadyFocused() {
+    #expect(!MountFocusPolicy.shouldClaimKeyboard(holder: .thisSurface, surfaceIsActive: true))
+  }
+}


### PR DESCRIPTION
## Summary
- Clicking a loop (sidebar row or canvas card) opened its workspace but left the keyboard on the sidebar's table or the window itself; a second click into the terminal was needed before typing worked.
- Root cause: `viewDidMoveToWindow`'s mount guard declined to claim first responder whenever *any* `GhosttyTerminalNSView` held it — and the outgoing loop's still-mounted surface always did. When that pane unmounted, first responder fell back to the window and nothing re-claimed it.
- Fix: the mount claim defers one run-loop turn (so the outgoing pane has unmounted and the sidebar `List` has finished moving first responder) and consults a new pure `MountFocusPolicy`: only the active surface claims, and never from the pane being typed into or a text field. The old guard's rule — a mounting hidden tab must not capture the keyboard for a shell that isn't on screen — survives as the `surfaceIsActive` gate.

## Test plan
- New `MountFocusPolicyTests` covers the full decision table (5 holders × 2 activity states), mirroring `ScrollFocusPolicyTests`.
- Full suite: `make test` → 621 tests, TEST SUCCEEDED.
- `make check` clean (swiftlint + swift-format strict).
- Adversarially reviewed: reused-surface, fresh-surface, split-creation, quick-chat, ⇧⌘] stepping, jump-palette, and broadcast-opened (#24) paths all traced; the stale-holder worst case degrades to the old symptom for one switch, never focus theft.

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)