### PR TITLE
Check for Updates follows the install's channel: beta builds hear about betas

### DIFF
--- a/graphcode/Sources/Clients/UpdateClient.swift
+++ b/graphcode/Sources/Clients/UpdateClient.swift
@@ -1,12 +1,18 @@
 import Dependencies
 import Foundation
 
-/// Asks GitHub for the newest stable release, and answers what this build is. Both live
-/// here rather than in the reducer so a test can hand the check any release and any
-/// installed version without a network or a real bundle.
+/// Asks GitHub what releases exist, and answers what this build is and which channel it
+/// follows. All of it lives here rather than in the reducer so a test can hand the check
+/// any release, any installed version, and any channel without a network or a real
+/// bundle or defaults.
 struct UpdateClient: Sendable {
   var latestRelease: @Sendable () async throws -> UpdateRelease
+  var allReleases: @Sendable () async throws -> [UpdateRelease]
   var currentVersion: @Sendable () -> String
+  /// The `updateChannel` default, verbatim — "beta" opts a stable install into
+  /// prereleases, "stable" pins a beta build to stables. Interpreting it (including
+  /// ignoring garbage) is `UpdateChannel.channel(for:override:)`'s job.
+  var channelOverride: @Sendable () -> String?
 }
 
 enum UpdateCheckFailure: Error, LocalizedError, Equatable {
@@ -24,29 +30,42 @@ extension UpdateClient: DependencyKey {
   static let liveValue = UpdateClient(
     latestRelease: {
       // `releases/latest` excludes drafts and prereleases by definition, which matches
-      // what the README's download link and the stable cask install — a beta user is
-      // offered the stable line, never a newer beta.
-      guard
-        let url = URL(string: "https://api.github.com/repos/scgopi/GraphCode/releases/latest")
-      else { throw UpdateCheckFailure.requestFailed(status: 0) }
-      var request = URLRequest(url: url)
-      request.timeoutInterval = 15
-      request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-      let (data, response) = try await URLSession.shared.data(for: request)
-      if let http = response as? HTTPURLResponse, http.statusCode != 200 {
-        throw UpdateCheckFailure.requestFailed(status: http.statusCode)
-      }
-      return try JSONDecoder().decode(UpdateRelease.self, from: data)
+      // what the README's download link and the stable cask install — the stable
+      // channel's whole answer in one request.
+      try await fetch("releases/latest")
+    },
+    allReleases: {
+      // The list includes prereleases; drafts only appear to authenticated callers,
+      // which this request never is. One page is a year of this project's history.
+      try await fetch("releases?per_page=30")
     },
     currentVersion: {
       Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
+    },
+    channelOverride: {
+      UserDefaults.standard.string(forKey: "updateChannel")
     })
 
+  private static func fetch<Value: Decodable>(_ path: String) async throws -> Value {
+    guard let url = URL(string: "https://api.github.com/repos/scgopi/GraphCode/\(path)")
+    else { throw UpdateCheckFailure.requestFailed(status: 0) }
+    var request = URLRequest(url: url)
+    request.timeoutInterval = 15
+    request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+    let (data, response) = try await URLSession.shared.data(for: request)
+    if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+      throw UpdateCheckFailure.requestFailed(status: http.statusCode)
+    }
+    return try JSONDecoder().decode(Value.self, from: data)
+  }
+
   /// Tests have no network and should not discover that by hanging — a test that wants
-  /// a particular release overrides `latestRelease` with a fixture.
+  /// a particular release overrides `latestRelease` or `allReleases` with a fixture.
   static let testValue = UpdateClient(
     latestRelease: { throw UpdateCheckFailure.requestFailed(status: 0) },
-    currentVersion: { "0.0.0" })
+    allReleases: { throw UpdateCheckFailure.requestFailed(status: 0) },
+    currentVersion: { "0.0.0" },
+    channelOverride: { nil })
 }
 
 extension DependencyValues {

--- a/graphcode/Sources/Features/App/AppFeature+Updates.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Updates.swift
@@ -1,8 +1,9 @@
 import ComposableArchitecture
 import Foundation
 
-/// Check for Updates — the app-menu item, the check against GitHub's newest stable
-/// release, and the two alerts `AppView` hosts for the outcome (issue #27).
+/// Check for Updates — the app-menu item, the check against GitHub's releases on the
+/// install's channel (issue #27; beta channel #33), and the two alerts `AppView` hosts
+/// for the outcome.
 ///
 /// The update itself is a download, not an in-place swap: dragging the DMG's app over
 /// /Applications *is* the whole installation — `DaemonBootstrap` re-stages the bundled
@@ -39,9 +40,18 @@ extension AppFeature {
         state.isCheckingForUpdates = true
         return .run { send in
           do {
-            let release = try await updateClient.latestRelease()
-            let update = AppUpdate.available(
-              current: updateClient.currentVersion(), release: release)
+            let current = updateClient.currentVersion()
+            let update: AvailableUpdate?
+            switch UpdateChannel.channel(
+              for: current, override: updateClient.channelOverride())
+            {
+            case .stable:
+              update = AppUpdate.available(
+                current: current, release: try await updateClient.latestRelease())
+            case .beta:
+              update = AppUpdate.available(
+                current: current, releases: try await updateClient.allReleases())
+            }
             await send(.updateCheckCompleted(.success(update)))
           } catch {
             await send(.updateCheckCompleted(.failure(error)))

--- a/graphcode/Sources/Features/App/AppUpdate.swift
+++ b/graphcode/Sources/Features/App/AppUpdate.swift
@@ -48,9 +48,26 @@ struct AppVersion: Equatable, Comparable, Sendable {
   }
 }
 
-/// The slice of a GitHub release the update check reads —
-/// `GET /repos/…/releases/latest`, which is GitHub's own "newest stable": drafts and
-/// prereleases never appear in it, matching what the DMG link and the cask ship.
+/// Which release line the check follows. Stable installs ask `releases/latest`, GitHub's
+/// own "newest stable", exactly as before; a beta build also weighs prereleases from the
+/// releases list, because `releases/latest` by definition never mentions a newer beta.
+enum UpdateChannel: String, Equatable, Sendable {
+  case stable
+  case beta
+
+  /// The channel an install follows: an explicit override wins, otherwise the installed
+  /// version speaks for itself — a prerelease build is on the beta channel. An override
+  /// that names neither channel is ignored rather than guessed at.
+  static func channel(for current: String, override: String?) -> UpdateChannel {
+    if let override, let chosen = UpdateChannel(rawValue: override) { return chosen }
+    return AppVersion(current)?.prerelease != nil ? .beta : .stable
+  }
+}
+
+/// The slice of a GitHub release the update check reads — one element of
+/// `GET /repos/…/releases`, or `releases/latest`, GitHub's own "newest stable": drafts
+/// and prereleases never appear in the latter, matching what the DMG link and the cask
+/// ship.
 struct UpdateRelease: Equatable, Sendable, Decodable {
   struct Asset: Equatable, Sendable, Decodable {
     var name: String
@@ -108,5 +125,17 @@ enum AppUpdate {
       currentVersion: current,
       downloadURL: release.dmgDownloadURL ?? release.htmlURL,
       releaseNotesURL: release.htmlURL)
+  }
+
+  /// The beta-channel decision: the newest of all releases — prereleases included —
+  /// judged by the same ordering. Stables are in the list too, so a beta install is
+  /// walked forward to the stable that closes its line, and a tag that doesn't parse
+  /// as a version simply doesn't compete.
+  static func available(current: String, releases: [UpdateRelease]) -> AvailableUpdate? {
+    let versioned = releases.compactMap { release in
+      AppVersion(release.tagName).map { ($0, release) }
+    }
+    guard let newest = versioned.max(by: { $0.0 < $1.0 })?.1 else { return nil }
+    return available(current: current, release: newest)
   }
 }

--- a/graphcode/Tests/CheckForUpdatesTests.swift
+++ b/graphcode/Tests/CheckForUpdatesTests.swift
@@ -50,6 +50,21 @@ struct CheckForUpdatesTests {
     #expect(AppVersion("1.two.3") == nil)
   }
 
+  // MARK: - The channel
+
+  @Test
+  func theInstalledVersionPicksTheChannelAndAnOverrideWins() {
+    // A beta build follows betas, a stable install follows stables — no setting needed.
+    #expect(UpdateChannel.channel(for: "0.1.15-beta2", override: nil) == .beta)
+    #expect(UpdateChannel.channel(for: "0.1.15", override: nil) == .stable)
+    // The explicit setting beats the version in both directions.
+    #expect(UpdateChannel.channel(for: "0.1.15", override: "beta") == .beta)
+    #expect(UpdateChannel.channel(for: "0.1.15-beta2", override: "stable") == .stable)
+    // Garbage in the default and an unversioned dev build both fall back safely.
+    #expect(UpdateChannel.channel(for: "0.1.15", override: "nightly") == .stable)
+    #expect(UpdateChannel.channel(for: "unversioned", override: nil) == .stable)
+  }
+
   // MARK: - The release JSON
 
   private func release(_ json: String) throws -> UpdateRelease {
@@ -155,6 +170,88 @@ struct CheckForUpdatesTests {
     #expect(AppUpdate.available(current: "0.1.14", release: badTag) == nil)
   }
 
+  /// The releases list as the beta channel sees it: the newest beta, its predecessor,
+  /// and the stable line's newest, in GitHub's newest-first order.
+  private let releasesListJSON = """
+    [
+      {
+        "tag_name": "0.1.15-beta2",
+        "html_url": "https://example.com/releases/tag/0.1.15-beta2",
+        "prerelease": true,
+        "assets": [
+          {
+            "name": "graphcode-macos-arm64.dmg",
+            "browser_download_url": "https://example.com/0.1.15-beta2/graphcode-macos-arm64.dmg"
+          }
+        ]
+      },
+      {
+        "tag_name": "0.1.15-beta1",
+        "html_url": "https://example.com/releases/tag/0.1.15-beta1",
+        "prerelease": true,
+        "assets": []
+      },
+      {
+        "tag_name": "v0.1.14",
+        "html_url": "https://example.com/releases/tag/v0.1.14",
+        "prerelease": false,
+        "assets": []
+      }
+    ]
+    """
+
+  private func releasesList() throws -> [UpdateRelease] {
+    try JSONDecoder().decode([UpdateRelease].self, from: Data(releasesListJSON.utf8))
+  }
+
+  @Test
+  func aBetaInstallSeesTheNewerBetaAndItsDMG() throws {
+    // The issue's acceptance case: 0.1.15-beta1 is walked to 0.1.15-beta2.
+    let update = try AppUpdate.available(current: "0.1.15-beta1", releases: releasesList())
+    #expect(update?.version == "0.1.15-beta2")
+    #expect(
+      update?.downloadURL.absoluteString
+        == "https://example.com/0.1.15-beta2/graphcode-macos-arm64.dmg")
+
+    #expect(try AppUpdate.available(current: "0.1.15-beta2", releases: releasesList()) == nil)
+  }
+
+  @Test
+  func aStableThatClosesTheBetaLineWinsOverTheBetas() throws {
+    // Once v0.1.15 ships it outranks its own betas — the beta install is walked to
+    // the stable, not left on the prerelease line.
+    var releases = try releasesList()
+    releases.append(
+      try release(
+        """
+        {
+          "tag_name": "v0.1.15",
+          "html_url": "https://example.com/releases/tag/v0.1.15",
+          "assets": []
+        }
+        """))
+    let update = AppUpdate.available(current: "0.1.15-beta2", releases: releases)
+    #expect(update?.version == "0.1.15")
+  }
+
+  @Test
+  func unversionedTagsDoNotCompeteAndAnEmptyListOffersNothing() throws {
+    var releases = try releasesList()
+    releases.insert(
+      try release(
+        """
+        {
+          "tag_name": "nightly",
+          "html_url": "https://example.com/releases/tag/nightly",
+          "assets": []
+        }
+        """), at: 0)
+    let update = AppUpdate.available(current: "0.1.15-beta1", releases: releases)
+    #expect(update?.version == "0.1.15-beta2")
+
+    #expect(AppUpdate.available(current: "0.1.15-beta1", releases: []) == nil)
+  }
+
   // MARK: - The flow
 
   private func fixtureRelease() throws -> UpdateRelease {
@@ -180,6 +277,46 @@ struct CheckForUpdatesTests {
     #expect(!store.state.isCheckingForUpdates)
     #expect(store.state.availableUpdate?.version == "0.2.0")
     #expect(store.state.updateNotice == nil)
+  }
+
+  @Test
+  @MainActor
+  func aBetaBuildChecksTheReleasesListAndIsOfferedTheNewerBeta() async throws {
+    // `latestRelease` keeps the throwing test default — if the beta channel touched
+    // GitHub's stable answer at all, this test would fail with a check error.
+    let releases = try releasesList()
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateClient.allReleases = { releases }
+      $0.updateClient.currentVersion = { "0.1.15-beta1" }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.checkForUpdatesTapped)
+    await store.receive(\.updateCheckCompleted)
+
+    #expect(store.state.availableUpdate?.version == "0.1.15-beta2")
+    #expect(store.state.updateNotice == nil)
+  }
+
+  @Test
+  @MainActor
+  func aStableInstallOptedIntoBetaIsOfferedTheBetaToo() async throws {
+    let releases = try releasesList()
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateClient.allReleases = { releases }
+      $0.updateClient.currentVersion = { "0.1.14" }
+      $0.updateClient.channelOverride = { "beta" }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.checkForUpdatesTapped)
+    await store.receive(\.updateCheckCompleted)
+
+    #expect(store.state.availableUpdate?.version == "0.1.15-beta2")
   }
 
   @Test


### PR DESCRIPTION
Closes #33.

Check for Updates (from #27) asked `releases/latest`, which excludes prereleases — so a beta build never heard about a newer beta. The check now derives an update channel from the install:

- A build whose installed version is a prerelease is on the **beta** channel: it queries the releases list and picks the newest tag by the existing `AppVersion` ordering (which already parses `betaN` suffixes). Stables appear in that list too, so a closing stable outranks its own betas and the beta install is walked forward to it.
- A **stable** install still asks `releases/latest` exactly as before — no behavior change by default.
- The `updateChannel` user default ("beta"/"stable") explicitly overrides in either direction; anything else is ignored.

Acceptance: an installed 0.1.15-beta1 is offered 0.1.15-beta2 and walked to its DMG (covered by `aBetaInstallSeesTheNewerBetaAndItsDMG` and the flow test); a stable install is only offered stables by default (existing flow tests pass untouched with `allReleases` left throwing).

Tests: full suite green — 627 tests in 67 suites. `swiftlint` and `swift format lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)