### PR TITLE
Updates install themselves: live buttons, a Settings channel switch, in-place install

### DIFF
--- a/graphcode/Sources/Clients/UpdateInstallClient.swift
+++ b/graphcode/Sources/Clients/UpdateInstallClient.swift
@@ -1,0 +1,215 @@
+import AppKit
+import Dependencies
+import Foundation
+
+/// Downloads a release DMG, verifies what it carries, and swaps it into /Applications —
+/// the drag the browser flow asks the human to do, done by the app on its own behalf.
+/// Behind a client so the reducer's install flow is testable without a 40MB download,
+/// a disk image, or a signature to verify.
+struct UpdateInstallClient: Sendable {
+  /// Downloads and installs, reporting download progress in 0...1. Returns once the new
+  /// app is in place in /Applications; throws with a human-readable reason otherwise.
+  var install:
+    @Sendable (_ dmg: URL, _ progress: @escaping @Sendable (Double) -> Void) async throws
+      -> Void
+  /// Launches the installed app and exits this one.
+  var relaunch: @Sendable () async -> Void
+}
+
+enum UpdateInstallFailure: Error, LocalizedError {
+  case downloadFailed(status: Int)
+  case mountFailed
+  case nothingToInstall
+  case signatureRejected
+  case swapFailed(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .downloadFailed(let status):
+      return "The download failed (status \(status))."
+    case .mountFailed:
+      return "The downloaded disk image couldn't be opened."
+    case .nothingToInstall:
+      return "The disk image doesn't contain an app."
+    case .signatureRejected:
+      return "The downloaded app isn't signed by GraphCode's developer."
+    case .swapFailed(let reason):
+      return "Couldn't replace the installed app: \(reason)"
+    }
+  }
+}
+
+extension UpdateInstallClient: DependencyKey {
+  private static let installedApp = URL(fileURLWithPath: "/Applications/graphcode.app")
+
+  static let liveValue = UpdateInstallClient(
+    install: { dmg, progress in
+      let image = try await download(dmg, progress: progress)
+      defer { try? FileManager.default.removeItem(at: image) }
+      let mountPoint = try await attach(image)
+      do {
+        let app = try appInside(mountPoint)
+        try await verifySignature(of: app)
+        try await swapIntoApplications(app)
+      } catch {
+        try? await run("/usr/bin/hdiutil", ["detach", mountPoint.path, "-force"])
+        throw error
+      }
+      try? await run("/usr/bin/hdiutil", ["detach", mountPoint.path, "-force"])
+    },
+    relaunch: {
+      // A detached shell outlives this process and reopens the app *after* it exits, so
+      // there is never a moment with two instances competing to be the zmx leader.
+      let reopen = Process()
+      reopen.executableURL = URL(fileURLWithPath: "/bin/sh")
+      reopen.arguments = ["-c", "sleep 1; /usr/bin/open \"\(installedApp.path)\""]
+      try? reopen.run()
+      await MainActor.run { NSApplication.shared.terminate(nil) }
+    })
+
+  /// Tests never touch the network or /Applications — override with a fixture.
+  static let testValue = UpdateInstallClient(
+    install: { _, _ in throw UpdateInstallFailure.mountFailed },
+    relaunch: {})
+
+  private static func download(
+    _ url: URL, progress: @escaping @Sendable (Double) -> Void
+  ) async throws -> URL {
+    var request = URLRequest(url: url)
+    request.timeoutInterval = 60
+    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+    let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+    guard status == 200 else { throw UpdateInstallFailure.downloadFailed(status: status) }
+    let expected = response.expectedContentLength
+
+    let destination = FileManager.default.temporaryDirectory
+      .appendingPathComponent("graphcode-update-\(UUID().uuidString).dmg")
+    FileManager.default.createFile(atPath: destination.path, contents: nil)
+    let file = try FileHandle(forWritingTo: destination)
+    defer { try? file.close() }
+
+    var buffer = Data()
+    buffer.reserveCapacity(1 << 16)
+    var written: Int64 = 0
+    var reported = 0.0
+    for try await byte in bytes {
+      buffer.append(byte)
+      if buffer.count == 1 << 16 {
+        try file.write(contentsOf: buffer)
+        written += Int64(buffer.count)
+        buffer.removeAll(keepingCapacity: true)
+        // Every percent, not every chunk — each report becomes an action in the store.
+        let fraction = expected > 0 ? Double(written) / Double(expected) : 0
+        if fraction - reported >= 0.01 {
+          reported = fraction
+          progress(fraction)
+        }
+      }
+    }
+    try file.write(contentsOf: buffer)
+    progress(1)
+    return destination
+  }
+
+  private static func attach(_ image: URL) async throws -> URL {
+    let output = try await run(
+      "/usr/bin/hdiutil", ["attach", image.path, "-nobrowse", "-readonly", "-plist"])
+    guard
+      let plist = try? PropertyListSerialization.propertyList(
+        from: Data(output.utf8), format: nil) as? [String: Any],
+      let entities = plist["system-entities"] as? [[String: Any]],
+      let mountPoint = entities.compactMap({ $0["mount-point"] as? String }).first
+    else { throw UpdateInstallFailure.mountFailed }
+    return URL(fileURLWithPath: mountPoint)
+  }
+
+  private static func appInside(_ mountPoint: URL) throws -> URL {
+    let contents = try? FileManager.default.contentsOfDirectory(
+      at: mountPoint, includingPropertiesForKeys: nil)
+    guard let app = contents?.first(where: { $0.pathExtension == "app" }) else {
+      throw UpdateInstallFailure.nothingToInstall
+    }
+    return app
+  }
+
+  /// The image is notarized and downloaded over TLS, but the swap below runs with this
+  /// user's rights — nothing goes into /Applications without carrying the same team's
+  /// Developer ID signature as every release.
+  private static func verifySignature(of app: URL) async throws {
+    do {
+      try await run("/usr/bin/codesign", ["--verify", "--deep", "--strict", app.path])
+      let details = try await run("/usr/bin/codesign", ["-d", "--verbose=2", app.path])
+      guard details.contains("TeamIdentifier=D3VJSNKD86") else {
+        throw UpdateInstallFailure.signatureRejected
+      }
+    } catch {
+      throw UpdateInstallFailure.signatureRejected
+    }
+  }
+
+  /// Stage-then-swap, the way `DaemonBootstrap` installs helpers: the copy happens off
+  /// to the side and the moment of truth is two renames, so a failure part-way leaves
+  /// either the old app or the new one — never half of each. The running app's own
+  /// bundle moving aside is fine; its files stay open.
+  private static func swapIntoApplications(_ app: URL) async throws {
+    let fm = FileManager.default
+    let staged = URL(fileURLWithPath: "/Applications/.graphcode-update.app")
+    let aside = URL(fileURLWithPath: "/Applications/.graphcode-previous.app")
+    try? fm.removeItem(at: staged)
+    try? fm.removeItem(at: aside)
+    do {
+      try await run("/usr/bin/ditto", [app.path, staged.path])
+      if fm.fileExists(atPath: installedApp.path) {
+        try fm.moveItem(at: installedApp, to: aside)
+      }
+      do {
+        try fm.moveItem(at: staged, to: installedApp)
+      } catch {
+        try? fm.moveItem(at: aside, to: installedApp)
+        throw error
+      }
+      try? fm.removeItem(at: aside)
+    } catch {
+      try? fm.removeItem(at: staged)
+      throw UpdateInstallFailure.swapFailed(error.localizedDescription)
+    }
+  }
+
+  @discardableResult
+  private static func run(_ tool: String, _ arguments: [String]) async throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: tool)
+    process.arguments = arguments
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+    return try await withCheckedThrowingContinuation { continuation in
+      process.terminationHandler = { finished in
+        let output = stdout.fileHandleForReading.readDataToEndOfFile()
+        let errors = stderr.fileHandleForReading.readDataToEndOfFile()
+        if finished.terminationStatus == 0 {
+          continuation.resume(
+            returning: String(bytes: output + errors, encoding: .utf8) ?? "")
+        } else {
+          let reason = String(bytes: errors, encoding: .utf8) ?? ""
+          continuation.resume(
+            throwing: UpdateInstallFailure.swapFailed(
+              "\(tool.split(separator: "/").last ?? "tool") failed: \(reason)"))
+        }
+      }
+      do {
+        try process.run()
+      } catch {
+        continuation.resume(throwing: error)
+      }
+    }
+  }
+}
+
+extension DependencyValues {
+  var updateInstallClient: UpdateInstallClient {
+    get { self[UpdateInstallClient.self] }
+    set { self[UpdateInstallClient.self] = newValue }
+  }
+}

--- a/graphcode/Sources/Features/App/AppFeature+Updates.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Updates.swift
@@ -2,13 +2,19 @@ import ComposableArchitecture
 import Foundation
 
 /// Check for Updates — the app-menu item, the check against GitHub's releases on the
-/// install's channel (issue #27; beta channel #33), and the two alerts `AppView` hosts
-/// for the outcome.
+/// install's channel (issue #27; beta channel #33), the in-place install (#37), and the
+/// alerts `AppView` hosts for the outcomes.
 ///
-/// The update itself is a download, not an in-place swap: dragging the DMG's app over
-/// /Applications *is* the whole installation — `DaemonBootstrap` re-stages the bundled
-/// helpers on next launch — so the flow's job ends at putting the right DMG in front of
-/// the human, in the browser, where a large download has progress and resume for free.
+/// Install Update downloads the DMG and swaps it into /Applications itself — see
+/// `UpdateInstallClient`; `DaemonBootstrap` re-stages the bundled helpers on the next
+/// launch, so the swap plus a relaunch is the whole installation. The browser download
+/// stays as the fallback when an install fails, so nobody is ever stranded.
+///
+/// One trap shapes the state here: SwiftUI clears an alert's `isPresented` binding
+/// *before* running the tapped button's action, so any action that needs the offer must
+/// read `offeredUpdate` (kept until the next check) rather than `availableUpdate` (the
+/// presentation, already nil by then). That was #35 — shipped builds whose Download
+/// button did nothing.
 extension AppFeature {
   /// A completed check's one-sentence outcome, for the alert that reports it. Only the
   /// "nothing to do" outcomes land here — an actual update gets the richer alert driven
@@ -62,7 +68,9 @@ extension AppFeature {
         state.isCheckingForUpdates = false
         if let update {
           state.availableUpdate = update
+          state.offeredUpdate = update
         } else {
+          state.offeredUpdate = nil
           state.updateNotice = .upToDate(current: updateClient.currentVersion())
         }
         return .none
@@ -73,12 +81,13 @@ extension AppFeature {
         return .none
 
       case .updateDownloadTapped:
-        guard let update = state.availableUpdate else { return .none }
+        guard let update = state.offeredUpdate else { return .none }
         state.availableUpdate = nil
+        state.updateInstallFailure = nil
         return .run { _ in await openURL(update.downloadURL) }
 
       case .updateReleaseNotesTapped:
-        guard let update = state.availableUpdate else { return .none }
+        guard let update = state.offeredUpdate else { return .none }
         state.availableUpdate = nil
         return .run { _ in await openURL(update.releaseNotesURL) }
 
@@ -88,6 +97,61 @@ extension AppFeature {
 
       case .updateNoticeDismissed:
         state.updateNotice = nil
+        return .none
+
+      case .updateInstallTapped:
+        guard let update = state.offeredUpdate, state.updateInstallProgress == nil
+        else { return .none }
+        state.availableUpdate = nil
+        state.updateInstallProgress = 0
+        return .run { send in
+          // The client's progress callback is synchronous; the stream carries its
+          // reports back into this effect so every send stays inside its lifetime.
+          let (progress, reporter) = AsyncStream<Double>.makeStream()
+          do {
+            async let pump: Void = {
+              for await fraction in progress {
+                await send(.updateInstallProgressed(fraction))
+              }
+            }()
+            try await updateInstallClient.install(update.downloadURL) {
+              reporter.yield($0)
+            }
+            reporter.finish()
+            await pump
+            await send(.updateInstallFinished(.success(update.version)))
+          } catch {
+            reporter.finish()
+            await send(.updateInstallFinished(.failure(error)))
+          }
+        }
+
+      case .updateInstallProgressed(let fraction):
+        // Progress can land after the install already finished or failed; a bar that
+        // reappears posthumously is worse than a dropped tick.
+        if state.updateInstallProgress != nil { state.updateInstallProgress = fraction }
+        return .none
+
+      case .updateInstallFinished(.success):
+        state.updateInstallProgress = nil
+        state.isUpdateReadyToRelaunch = true
+        return .none
+
+      case .updateInstallFinished(.failure(let error)):
+        state.updateInstallProgress = nil
+        state.updateInstallFailure = error.localizedDescription
+        return .none
+
+      case .updateInstallFailureDismissed:
+        state.updateInstallFailure = nil
+        return .none
+
+      case .updateRelaunchTapped:
+        state.isUpdateReadyToRelaunch = false
+        return .run { _ in await updateInstallClient.relaunch() }
+
+      case .updateRelaunchDismissed:
+        state.isUpdateReadyToRelaunch = false
         return .none
 
       default:

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -85,12 +85,17 @@ struct AppFeature {
     var jumpQuery = ""
     var jumpSelection = 0
 
-    /// Check for Updates — see `AppFeature+Updates.swift`. The newer release a check
-    /// found (the offer alert is up while non-nil), the "nothing to do" outcome (up to
-    /// date, or why the check failed), and the in-flight flag the menu item disables on.
+    /// Check for Updates — see `AppFeature+Updates.swift`. `availableUpdate` is the
+    /// offer alert's presentation; `offeredUpdate` is the same update kept past the
+    /// alert's dismissal, because SwiftUI clears the presentation binding *before* it
+    /// runs the tapped button's action (#35).
     var availableUpdate: AvailableUpdate?
+    var offeredUpdate: AvailableUpdate?
     var updateNotice: UpdateNotice?
     var isCheckingForUpdates = false
+    var updateInstallProgress: Double?
+    var updateInstallFailure: String?
+    var isUpdateReadyToRelaunch = false
 
     /// State changes seen since launch, for the activity strip — see
     /// `AppFeature+Activity.swift`. Bounded, and deliberately not persisted.
@@ -195,6 +200,12 @@ struct AppFeature {
     case updateReleaseNotesTapped
     case updateAlertDismissed
     case updateNoticeDismissed
+    case updateInstallTapped
+    case updateInstallProgressed(Double)
+    case updateInstallFinished(Result<String, any Error>)
+    case updateInstallFailureDismissed
+    case updateRelaunchTapped
+    case updateRelaunchDismissed
     /// The Quick Chats section's actions — see `State.quickChats`.
     case newQuickChatTapped
     /// The Quick Chats header row: shows the chats' own canvas, the way a folder row
@@ -218,6 +229,7 @@ struct AppFeature {
   @Dependency(\.terminalLayoutStore) var terminalLayoutStore
   @Dependency(\.quickChatStore) var quickChatStore
   @Dependency(\.updateClient) var updateClient
+  @Dependency(\.updateInstallClient) var updateInstallClient
   @Dependency(\.openURL) var openURL
   /// Only for the cases where a workspace goes away because the *loop* did. Merely
   /// switching to another loop leaves its surfaces alive on purpose — see
@@ -434,7 +446,9 @@ struct AppFeature {
       // Every update action is handled by `updatesReducer`, in
       // `AppFeature+Updates.swift` — listed here only so this switch stays exhaustive.
       case .checkForUpdatesTapped, .updateCheckCompleted, .updateDownloadTapped,
-        .updateReleaseNotesTapped, .updateAlertDismissed, .updateNoticeDismissed:
+        .updateReleaseNotesTapped, .updateAlertDismissed, .updateNoticeDismissed,
+        .updateInstallTapped, .updateInstallProgressed, .updateInstallFinished,
+        .updateInstallFailureDismissed, .updateRelaunchTapped, .updateRelaunchDismissed:
         return .none
 
       // Every Quick Chats action is handled by `quickChatsReducer`, in

--- a/graphcode/Sources/Features/App/AppView.swift
+++ b/graphcode/Sources/Features/App/AppView.swift
@@ -185,35 +185,10 @@ struct AppView: View {
           + "will be permanently deleted.")
     }
     // Check for Updates — hosted here like every other dialog, so the answer can open
-    // over a terminal as readily as over a canvas. Two alerts because the outcomes ask
-    // different things of you: a found update offers verbs, the rest is one sentence.
-    .alert(
-      "GraphCode \(store.availableUpdate?.version ?? "") is available",
-      isPresented: Binding(
-        get: { store.availableUpdate != nil },
-        set: { if !$0 { store.send(.updateAlertDismissed) } }
-      )
-    ) {
-      Button("Download Update") { store.send(.updateDownloadTapped) }
-      Button("Release Notes") { store.send(.updateReleaseNotesTapped) }
-      Button("Later", role: .cancel) { store.send(.updateAlertDismissed) }
-    } message: {
-      Text(
-        "You're running \(store.availableUpdate?.currentVersion ?? ""). The download "
-          + "opens in your browser — drag GraphCode into Applications to install it, "
-          + "and the app takes care of its helpers on the next launch.")
-    }
-    .alert(
-      store.updateNotice?.title ?? "",
-      isPresented: Binding(
-        get: { store.updateNotice != nil },
-        set: { if !$0 { store.send(.updateNoticeDismissed) } }
-      )
-    ) {
-      Button("OK") { store.send(.updateNoticeDismissed) }
-    } message: {
-      Text(store.updateNotice?.message ?? "")
-    }
+    // over a terminal as readily as over a canvas. In a modifier of its own: four
+    // alerts and an overlay on top of this chain is more than the type-checker will
+    // sit through.
+    .modifier(UpdateDialogs(store: store))
   }
 
   /// The open loop's trailing panel, toggled from where macOS puts an inspector toggle.

--- a/graphcode/Sources/Features/App/UpdateDialogs.swift
+++ b/graphcode/Sources/Features/App/UpdateDialogs.swift
@@ -1,0 +1,84 @@
+import ComposableArchitecture
+import SwiftUI
+
+/// Check for Updates' dialogs and the install-progress indicator, applied to `AppView`'s
+/// dialog host. Every button reads `offeredUpdate`, never the presenting alert's own
+/// state: SwiftUI clears an alert's presentation binding *before* it runs the tapped
+/// button's action, which is how the shipped Download button managed to do nothing (#35).
+struct UpdateDialogs: ViewModifier {
+  let store: StoreOf<AppFeature>
+
+  func body(content: Content) -> some View {
+    content
+      .alert(
+        "GraphCode \(store.offeredUpdate?.version ?? "") is available",
+        isPresented: Binding(
+          get: { store.availableUpdate != nil },
+          set: { if !$0 { store.send(.updateAlertDismissed) } }
+        )
+      ) {
+        Button("Install Update") { store.send(.updateInstallTapped) }
+        Button("Release Notes") { store.send(.updateReleaseNotesTapped) }
+        Button("Later", role: .cancel) { store.send(.updateAlertDismissed) }
+      } message: {
+        Text(
+          "You're running \(store.offeredUpdate?.currentVersion ?? ""). Install "
+            + "downloads the update and puts it in Applications; you pick the moment "
+            + "to relaunch.")
+      }
+      .alert(
+        store.updateNotice?.title ?? "",
+        isPresented: Binding(
+          get: { store.updateNotice != nil },
+          set: { if !$0 { store.send(.updateNoticeDismissed) } }
+        )
+      ) {
+        Button("OK") { store.send(.updateNoticeDismissed) }
+      } message: {
+        Text(store.updateNotice?.message ?? "")
+      }
+      .alert(
+        "Update installed",
+        isPresented: Binding(
+          get: { store.isUpdateReadyToRelaunch },
+          set: { if !$0 { store.send(.updateRelaunchDismissed) } }
+        )
+      ) {
+        Button("Relaunch Now") { store.send(.updateRelaunchTapped) }
+        Button("Later", role: .cancel) { store.send(.updateRelaunchDismissed) }
+      } message: {
+        Text(
+          "GraphCode \(store.offeredUpdate?.version ?? "") is in Applications and "
+            + "takes over on the next launch. Sessions keep running through a relaunch "
+            + "— the daemon holds them, not the window.")
+      }
+      .alert(
+        "Couldn't install the update",
+        isPresented: Binding(
+          get: { store.updateInstallFailure != nil },
+          set: { if !$0 { store.send(.updateInstallFailureDismissed) } }
+        )
+      ) {
+        Button("Download in Browser") { store.send(.updateDownloadTapped) }
+        Button("Cancel", role: .cancel) { store.send(.updateInstallFailureDismissed) }
+      } message: {
+        Text(
+          "\(store.updateInstallFailure ?? "") The browser download still works — "
+            + "drag GraphCode into Applications to install it.")
+      }
+      .overlay(alignment: .bottomTrailing) {
+        if let fraction = store.updateInstallProgress {
+          HStack(spacing: 8) {
+            ProgressView(value: min(fraction, 1))
+              .frame(width: 110)
+            Text(fraction < 1 ? "Downloading update…" : "Installing…")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+          .padding(10)
+          .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+          .padding(12)
+        }
+      }
+  }
+}

--- a/graphcode/Sources/Features/Settings/SettingsModel.swift
+++ b/graphcode/Sources/Features/Settings/SettingsModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import GraphcodeKit
 import Observation
 
@@ -22,7 +23,23 @@ final class SettingsModel {
     }
   }
 
+  /// The update channel as a switch (#36) — app-only, so `UserDefaults` rather than
+  /// `GraphcodeSettings`: the daemon never checks for updates, and `UpdateClient` reads
+  /// the same `updateChannel` key. Starts on the install's effective channel — a beta
+  /// build reads as on — and the first flip writes an explicit override either way.
+  var betaUpdates: Bool {
+    didSet {
+      UserDefaults.standard.set(betaUpdates ? "beta" : "stable", forKey: "updateChannel")
+    }
+  }
+
   private init() {
     settings = GraphcodeSettingsStore.load()
+    let version =
+      Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
+    betaUpdates =
+      UpdateChannel.channel(
+        for: version, override: UserDefaults.standard.string(forKey: "updateChannel"))
+      == .beta
   }
 }

--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -124,6 +124,21 @@ struct SettingsView: View {
         .font(.caption2)
         .foregroundStyle(.secondary)
       }
+
+      Section {
+        Toggle("Get beta releases", isOn: $model.betaUpdates)
+      } header: {
+        Text("Updates")
+      } footer: {
+        Text(
+          "On, Check for Updates offers pre-releases as well as stable releases — "
+            + "newer features, less soak time. Off, stable releases only. A beta "
+            + "install starts on; switching off keeps it as it is until the next "
+            + "stable ships."
+        )
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+      }
     }
     .formStyle(.grouped)
   }

--- a/graphcode/Sources/GraphcodeApp.swift
+++ b/graphcode/Sources/GraphcodeApp.swift
@@ -69,7 +69,7 @@ struct GraphcodeApp: App {
         Button("Check for Updates…") {
           Self.store.send(.checkForUpdatesTapped)
         }
-        .disabled(Self.store.isCheckingForUpdates)
+        .disabled(Self.store.isCheckingForUpdates || Self.store.updateInstallProgress != nil)
       }
       CommandGroup(after: .help) {
         Button("GraphCode Basics") {

--- a/graphcode/Tests/CheckForUpdatesTests.swift
+++ b/graphcode/Tests/CheckForUpdatesTests.swift
@@ -367,11 +367,15 @@ struct CheckForUpdatesTests {
 
   @Test
   @MainActor
-  func downloadOpensTheDMGInTheBrowserAndTakesTheAlertDown() async throws {
+  func downloadStillWorksAfterSwiftUIAlreadyDismissedTheAlert() async throws {
+    // The order SwiftUI actually delivers (#35): the alert's presentation binding is
+    // cleared — sending updateAlertDismissed — *before* the tapped button's action
+    // runs. The download must survive that, which is what `offeredUpdate` is for.
     let release = try fixtureRelease()
     let update = try #require(AppUpdate.available(current: "0.1.14", release: release))
     var state = AppFeature.State()
     state.availableUpdate = update
+    state.offeredUpdate = update
 
     let opened = OpenedURLsBox()
     let store = TestStore(initialState: state) {
@@ -384,6 +388,7 @@ struct CheckForUpdatesTests {
     }
     store.exhaustivity = .off
 
+    await store.send(.updateAlertDismissed)
     await store.send(.updateDownloadTapped)
     await store.finish()
 

--- a/graphcode/Tests/UpdateInstallTests.swift
+++ b/graphcode/Tests/UpdateInstallTests.swift
@@ -1,0 +1,158 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import graphcode
+
+/// Direct install (issue #37): the flow from the offer alert's Install Update through
+/// download progress to the relaunch prompt, and the browser fallback when it fails.
+/// Every test dismisses the alert before tapping — the order SwiftUI actually delivers
+/// (#35) — so a regression to reading presentation state fails here, not in the field.
+@Suite
+struct UpdateInstallTests {
+
+  private func offeredState() throws -> (AppFeature.State, AvailableUpdate) {
+    let release = try JSONDecoder().decode(
+      UpdateRelease.self,
+      from: Data(
+        """
+        {
+          "tag_name": "0.1.16-beta2",
+          "html_url": "https://example.com/releases/tag/0.1.16-beta2",
+          "assets": [
+            {
+              "name": "graphcode-macos-arm64.dmg",
+              "browser_download_url": "https://example.com/0.1.16-beta2/graphcode-macos-arm64.dmg"
+            }
+          ]
+        }
+        """.utf8))
+    let update = try #require(AppUpdate.available(current: "0.1.16-beta1", release: release))
+    var state = AppFeature.State()
+    state.availableUpdate = update
+    state.offeredUpdate = update
+    return (state, update)
+  }
+
+  @Test
+  @MainActor
+  func installDownloadsWithProgressAndOffersTheRelaunch() async throws {
+    let (state, update) = try offeredState()
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateInstallClient.install = { dmg, progress in
+        #expect(dmg == update.downloadURL)
+        progress(0.5)
+        progress(1)
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.updateAlertDismissed)
+    await store.send(.updateInstallTapped)
+    #expect(store.state.updateInstallProgress == 0)
+    await store.receive(\.updateInstallFinished)
+
+    // The bar is down, the relaunch prompt is up, and nothing reads as failed.
+    #expect(store.state.updateInstallProgress == nil)
+    #expect(store.state.isUpdateReadyToRelaunch)
+    #expect(store.state.updateInstallFailure == nil)
+  }
+
+  private actor CounterBox {
+    var hits = 0
+    func bump() { hits += 1 }
+  }
+
+  @Test
+  @MainActor
+  func relaunchNowRelaunchesAndLaterJustWaits() async throws {
+    var (state, _) = try offeredState()
+    state.availableUpdate = nil
+    state.isUpdateReadyToRelaunch = true
+
+    let relaunches = CounterBox()
+    func store() -> TestStoreOf<AppFeature> {
+      let store = TestStore(initialState: state) {
+        AppFeature()
+      } withDependencies: {
+        $0.updateInstallClient.relaunch = { await relaunches.bump() }
+      }
+      store.exhaustivity = .off
+      return store
+    }
+
+    let later = store()
+    await later.send(.updateRelaunchDismissed)
+    #expect(!later.state.isUpdateReadyToRelaunch)
+    #expect(await relaunches.hits == 0)
+
+    let now = store()
+    await now.send(.updateRelaunchTapped)
+    await now.finish()
+    #expect(!now.state.isUpdateReadyToRelaunch)
+    #expect(await relaunches.hits == 1)
+  }
+
+  @Test
+  @MainActor
+  func aFailedInstallExplainsItselfAndTheBrowserFallbackStillWorks() async throws {
+    let (state, update) = try offeredState()
+    let opened = URLsBox()
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateInstallClient.install = { _, _ in
+        throw UpdateInstallFailure.signatureRejected
+      }
+      $0.openURL = OpenURLEffect { url in
+        await opened.append(url)
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.updateAlertDismissed)
+    await store.send(.updateInstallTapped)
+    await store.receive(\.updateInstallFinished)
+
+    #expect(store.state.updateInstallProgress == nil)
+    #expect(!store.state.isUpdateReadyToRelaunch)
+    #expect(
+      store.state.updateInstallFailure
+        == UpdateInstallFailure.signatureRejected.localizedDescription)
+
+    // The failure alert's fallback: the same browser download as before #37.
+    await store.send(.updateDownloadTapped)
+    await store.finish()
+    #expect(store.state.updateInstallFailure == nil)
+    #expect(await opened.urls == [update.downloadURL])
+  }
+
+  private actor URLsBox {
+    var urls: [URL] = []
+    func append(_ url: URL) { urls.append(url) }
+  }
+
+  @Test
+  @MainActor
+  func aSecondInstallTapWhileOneRunsIsIgnored() async throws {
+    let (state, _) = try offeredState()
+    let installs = CounterBox()
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateInstallClient.install = { _, _ in
+        await installs.bump()
+        try await Task.sleep(for: .seconds(100))
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.updateInstallTapped)
+    await store.send(.updateInstallTapped)
+    #expect(await installs.hits == 1)
+    await store.skipInFlightEffects()
+  }
+}


### PR DESCRIPTION
Closes #35, closes #36, closes #37.

**#35 — the offer alert's dead buttons.** SwiftUI clears an alert's `isPresented` binding *before* running the tapped button's action; the binding's setter sent `updateAlertDismissed`, which nilled `State.availableUpdate`, so `updateDownloadTapped` hit its guard on empty state and silently did nothing — in every shipped build since 0.1.15-beta1. The offer now lives on in `offeredUpdate`, which dismissal does not clear, and every button reads that. The regression test sends dismissed-then-tapped, the order SwiftUI actually delivers.

**#36 — beta opt-in in Settings.** An Updates section with a *Get beta releases* toggle over the same `updateChannel` default the check reads (#33). It starts on the install's effective channel — a beta build reads as on — and the first flip writes an explicit override either way.

**#37 — direct install.** *Install Update* in the offer alert: `UpdateInstallClient` downloads the DMG (progress reported into a bottom-trailing indicator), mounts it, verifies the app inside carries the team's Developer ID signature, stage-then-swaps it into /Applications, and offers *Relaunch Now / Later*. Any failure surfaces its reason with a *Download in Browser* fallback — the pre-#37 path, so nobody is stranded. `DaemonBootstrap` re-stages helpers on next launch; sessions live in the daemon and survive the relaunch, which a detached `open` performs only after this instance exits (no two-instance zmx leader fight).

Tests: full suite green — 631 tests in 68 suites. `swiftlint` and `swift format lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)