### PR TITLE
fix: remote loops always read IDLE, whatever their agent is doing (#40)

### DIFF
--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -441,6 +441,14 @@ public actor GraphStore {
   @discardableResult
   private func refreshPresence() async -> Bool {
     guard let onReadPresence else { return false }
+    // A remote project's sessions live in the remote host's `zmx` daemon, and every
+    // reading here is taken from the local one — which has never heard of them, so the
+    // answer is always `.absent` and `displayState` demotes a working remote loop to
+    // IDLE. Taking no reading leaves `presence` nil, which every surface already treats
+    // as "no better information than `state`".
+    guard RemoteProjectLocation.parse(projectPath: graph.project.path) == nil else {
+      return false
+    }
     var changed = false
     for node in graph.nodes where !node.isResolved {
       let reading = await onReadPresence(node)

--- a/graphcode/Tests/PresencePollingTests.swift
+++ b/graphcode/Tests/PresencePollingTests.swift
@@ -140,6 +140,28 @@ struct PresencePollingTests {
   }
 
   @Test
+  func aRemoteProjectIsNeverAsked() async {
+    // A remote loop's session lives in the remote host's `zmx` daemon and the reader asks
+    // the local one, so every reading came back `.absent` — demoting a remote loop that
+    // was working to IDLE on every card, dot and rollup. No reading leaves `presence` nil,
+    // which reads as "no better information than `state`".
+    let probe = Probe()
+    var remote = LoopGraph(
+      scope: LoopGraphScope(projectPath: "ssh://user@host/srv/repo", name: "repo"))
+    remote.nodes.append(node("A", .running))
+    let store = GraphStore(graph: remote, onReadPresence: { await probe.read($0) })
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+
+    #expect(await probe.asked.isEmpty)
+    let updated = await store.graph.nodes.first
+    #expect(updated?.presence == nil)
+    #expect(updated?.displayState == .running)
+  }
+
+  @Test
   func theIntervalIsSlowEnoughToBeBackgroundNoise() {
     // Fifteen seconds is the lag a human sees between a loop finishing and its card
     // saying so. Worth pinning: dropping it to a second would multiply the subprocess


### PR DESCRIPTION
Refs #40 — deliberately **not** `Fixes #40`. This closes the "graph shows the wrong state" half of that issue; the survive-a-disconnect and re-attach half, and the sporadic `ssh failed, retry` hardening from the follow-up comment, are untouched and need the issue left open. See **Scope** below.

## Root cause

`GraphStore.refreshPresence` asks `CLISessionBackend.readPresence` per node, which lands in `ZmxSessionLauncher.presence(of:)` (or `codexPresence`/`CopilotSessionLog.presence`). All three gate on `ZmxSessionLauncher.sessionExists(_:)`, which runs `zmx get <session>` against the **local** zmx daemon. A remote project's sessions live in the remote host's zmx daemon — the local one has never heard of them — so the probe always exits non-zero and the reading is always `PresenceReading.absent`. `LoopNode.displayState` demotes `state == .running` to `.idle` on exactly that reading, so every remote loop read IDLE on its card pill, its sidebar dot, `GraphOverview`'s counts and `AttentionRollup`, from the moment presence polling landed (c13e0b7) regardless of what the agent was doing. Unlike `kill` and `send`, which were both taught to route over ssh by project path, the presence reader was never given the path at all.

## Change

One guard at the top of `refreshPresence`: if the store's project path parses as a `RemoteProjectLocation`, take no reading and return `false`. `presence` then stays `nil`, which `displayState` and every surface already treat as "no better information than `state`" — the documented fallback, and the behaviour that shipped before the field existed. A remote loop reads RUNNING until the graph says otherwise, which is honest rather than wrong.

Minimal because the alternative — actually reading remote presence — is a `zmx get` over ssh per node per 15s tick plus, for Copilot, reading `events.jsonl` on the far host, and it belongs with the rest of the remote-session hardening in #40 rather than in front of it. The guard also drops one local subprocess per remote loop per tick that was only ever producing a false answer.

One test added alongside the file's three existing cost/behaviour guards.

## Verified in cloud

Static only — no macOS SDK here, nothing was compiled or run.

- `RemoteProjectLocation.parse(projectPath:) -> RemoteProjectLocation?` is `public static` (`RemoteProjectLocation.swift:37`); `graph.project` is a `ProjectRef` (`LoopGraph.swift:23`) and `.path` a non-optional `String`. Both types are in `GraphcodeKit/Sources`, one buildable folder and one module with `GraphStore.swift` (`Project.swift`), so no import changes.
- Both callers of `refreshPresence()` handle an early `false`: `handle(.refreshUsage)` (`GraphStore.swift:279`) discards it under `@discardableResult`, and `pollPresence` (`:477`) early-returns without notifying clients — which is the existing nothing-changed path, not a new one.
- `grep`'d every writer of `node.presence`: `GraphStore.swift:448` is the only one, so nothing else can leave a stale reading behind the guard.
- `LoopNode.init(from:)` sets `presence = nil` unconditionally (`:301`), so a skipped poll leaves it nil permanently rather than resurrecting a persisted value.
- Checked the consumers of the demotion don't key off presence another way: `MessageBus.deliverability` and `LoopNode.isResolved` both read `state`; `AttentionRollup` reads `displayState`, which falls through to `state` when presence is nil.
- The global graph's reserved `graphcode://global` path does not parse as remote, so its polling is unchanged; the existing `PresencePollingTests` all use `/tmp/p` and are likewise unaffected.
- Test APIs confirmed against declarations: `LoopGraph(scope:)` defaults `nodes`/`edges`, `nodes` is `IdentifiedArrayOf<LoopNode>` (`.append`/`.first` as the file already uses), `store.graph` is `public private(set)`.
- Diff re-read line by line against `.swift-format` (2-space indent, 100-col); no line exceeds it and `respectsExistingLineBreaks` is on.

## NOT verified — needs local Mac

- [ ] `make build-app` — nothing in this PR has been through a compiler.
- [ ] `make test` — in particular the new `PresencePollingTests.aRemoteProjectIsNeverAsked`.
- [ ] Manual repro for #40: open a remote (`ssh://`) project with a loop whose agent is actively working. **Before:** its card reads IDLE and the sidebar dot is idle-coloured while the agent types. **After:** it reads RUNNING (from `state`) for as long as the graph considers it running.
- [ ] Confirm a **local** project's loops still demote correctly — a loop that finishes its turn must still fall from RUNNING to IDLE within ~15s. This is the behaviour the guard must not have caught by accident.
- [ ] Confirm the titlebar rollup and `GraphOverview` counts agree with the cards for a mixed local + remote workspace.

---
_Generated by [Claude Code](https://claude.ai/code/session_015WLppHoDeMDC9rmHmN5dgq)_