### PR TITLE
Presence readings reach clients instead of being silently dropped

### DIFF
--- a/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
+++ b/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
@@ -356,7 +356,7 @@ extension GraphcodeCommand {
       return lines.joined(separator: "\n")
     }
     for node in graph.nodes {
-      var line = "  \(node.id)  \(node.state)  \(node.loopType)  \(node.title)"
+      var line = "  \(node.id)  \(node.displayState)  \(node.loopType)  \(node.title)"
       if let reason = AttentionRollup.reason(for: node) {
         line += "  ← \(reason.displayName)"
       }

--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -298,12 +298,8 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     subGraph = try container.decodeIfPresent(LoopGraph.self, forKey: .subGraph)
     pilotState = try container.decodeIfPresent(PilotState.self, forKey: .pilotState) ?? .notPiloted
     usage = try container.decodeIfPresent(UsageSample.self, forKey: .usage)
-    // Never restored from disk as live facts — a session's last reported line, and what
-    // it was doing when it wrote it, are both about a session that is no longer running
-    // by the time a graph is reloaded. A persisted `busy` would be the exact lie this
-    // field was added to remove.
-    activity = nil
-    presence = nil
+    activity = try container.decodeIfPresent(String.self, forKey: .activity)
+    presence = try container.decodeIfPresent(PresenceReading.self, forKey: .presence)
     metricHistory =
       try container.decodeIfPresent([MetricSample].self, forKey: .metricHistory) ?? []
     createdBy = try container.decodeIfPresent(UUID.self, forKey: .createdBy)

--- a/GraphcodeKit/Sources/ProjectPersistence.swift
+++ b/GraphcodeKit/Sources/ProjectPersistence.swift
@@ -26,7 +26,12 @@ public struct ProjectPersistence: Sendable {
 
   public func loadGraph(path: String) -> LoopGraph? {
     guard let data = try? Data(contentsOf: fileURL(forProjectPath: path)) else { return nil }
-    return try? JSONDecoder().decode(LoopGraph.self, from: data)
+    guard var graph = try? JSONDecoder().decode(LoopGraph.self, from: data) else { return nil }
+    for index in graph.nodes.indices {
+      graph.nodes[index].presence = nil
+      graph.nodes[index].activity = nil
+    }
+    return graph
   }
 
   public func saveGraph(_ graph: LoopGraph) {

--- a/graphcode/Tests/PresenceReportingTests.swift
+++ b/graphcode/Tests/PresenceReportingTests.swift
@@ -169,13 +169,20 @@ struct PresenceReportingTests {
   }
 
   @Test
-  func aReadingIsNeverRestoredFromDisk() throws {
-    // A persisted `busy` would be the exact lie the field was added to remove: by the
-    // time a graph is reloaded, the session it described is gone.
+  func aReadingSurvivesTheWire() throws {
+    // The daemon encodes presence into the graph it sends to clients. The decoder must
+    // preserve it, or every surface sees `.running` for a loop whose agent stopped an
+    // hour ago — the exact failure the presence system was built to fix.
     let encoded = try JSONEncoder().encode(node(.running, .busy))
     let decoded = try JSONDecoder().decode(LoopNode.self, from: encoded)
 
-    #expect(decoded.presence == nil)
+    #expect(decoded.presence?.presence == .busy)
     #expect(decoded.displayState == .running)
+
+    let idleEncoded = try JSONEncoder().encode(node(.running, .idle))
+    let idleDecoded = try JSONDecoder().decode(LoopNode.self, from: idleEncoded)
+
+    #expect(idleDecoded.presence?.presence == .idle)
+    #expect(idleDecoded.displayState == .idle)
   }
 }

--- a/graphcode/Tests/ProjectPersistenceTests.swift
+++ b/graphcode/Tests/ProjectPersistenceTests.swift
@@ -74,6 +74,27 @@ struct ProjectPersistenceTests {
   }
 
   @Test
+  func stalePresenceIsStrippedOnLoad() {
+    let persistence = makePersistence()
+    let project = ProjectRef(path: "/tmp/presence-test", name: "presence-test")
+    var node = LoopNode(
+      title: "Worker",
+      loopType: .goalBased,
+      goal: GoalSpec(summary: "ship it"),
+      presence: PresenceReading(presence: .busy, confidence: .reported),
+      state: .running)
+    node.activity = "editing Foo.swift"
+    let graph = LoopGraph(project: project, nodes: [node])
+
+    persistence.saveGraph(graph)
+    let loaded = persistence.loadGraph(path: project.path)
+
+    #expect(loaded?.nodes.first?.presence == nil)
+    #expect(loaded?.nodes.first?.activity == nil)
+    #expect(loaded?.nodes.first?.state == .running)
+  }
+
+  @Test
   func recentProjectsAreSortedMostRecentlyOpenedFirst() {
     let persistence = makePersistence()
     let older = ProjectRef(path: "/tmp/older", name: "older", lastOpenedAt: Date())


### PR DESCRIPTION
## Summary

- `LoopNode.init(from:)` hardcoded `activity = nil` and `presence = nil`, which was correct for disk persistence but also ran on the daemon→client socket transport — so live presence readings the daemon polled were silently dropped before reaching any surface
- Every surface (sidebar, canvas cards, attention rollup, CLI status) saw `presence == nil`, causing `displayState` to always return raw `state` — goal loops read RUNNING whether the agent was working or had stopped an hour ago
- Decode both fields normally; stale-from-disk stripping moves to `ProjectPersistence.loadGraph`
- `graphcode status` now shows `displayState` instead of raw `state`

## Test plan

- [ ] `PresenceReportingTests.aReadingSurvivesTheWire` — presence round-trips through encode/decode
- [ ] `ProjectPersistenceTests.stalePresenceIsStrippedOnLoad` — disk load still strips stale readings
- [ ] Run `graphcode status` and verify idle loops show `idle` or `awaitingInput` instead of `running`
- [ ] Open the app sidebar and verify state indicators reflect actual session state

🤖 Generated with [Claude Code](https://claude.com/claude-code)