### PR TITLE
fix: sidebar goes stale after a daemon reconnect, so a deleted loop keeps its row (#47)

### DIFF
--- a/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
+++ b/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
@@ -13,8 +13,10 @@ public enum DaemonCommand: Codable, Sendable, Equatable {
   case listRecentProjects
   case openProject(path: String)
   /// Reopen whichever projects were showing in the sidebar when the app last quit. Sent
-  /// once at launch; the daemon replies with one `.graphChanged` per project, which is
-  /// exactly what `.openProject` produces, so the app needs no separate restore path.
+  /// at launch and again on every reconnect — joining is per-connection, so a client that
+  /// dialled again is joined to nothing until it asks a second time. The daemon replies
+  /// with one `.graphChanged` per project, which is exactly what `.openProject` produces,
+  /// so the app needs no separate restore path.
   case restoreOpenProjects
   /// Join the one always-resident global Orchestrator Graph. It arrives as an ordinary
   /// `.graphChanged` like any project's, distinguishable by its reserved

--- a/graphcode/Sources/Clients/OrchestratorClient.swift
+++ b/graphcode/Sources/Clients/OrchestratorClient.swift
@@ -84,6 +84,7 @@ private actor DaemonConnection {
           do {
             let fileDescriptor = try await ensureConnected()
             connectedDescriptor = fileDescriptor
+            if await isReconnect() { try await rejoinProjects() }
             while true {
               let data = try await readFrameAsync(from: fileDescriptor)
               let event = try JSONDecoder().decode(DaemonEvent.self, from: data)
@@ -98,6 +99,34 @@ private actor DaemonConnection {
       }
       continuation.onTermination = { _ in task.cancel() }
     }
+  }
+
+  /// Whether a connection has been established before this one — `AppFeature.task` sends
+  /// the join commands for the first, and `rejoinProjects` covers every one after it.
+  private var hasConnectedBefore = false
+
+  private func isReconnect() -> Bool {
+    defer { hasConnectedBefore = true }
+    return hasConnectedBefore
+  }
+
+  /// Re-announces which projects this client wants, on a socket that replaced one that
+  /// failed.
+  ///
+  /// `graphcoded` keys a client's joined projects by *connection*
+  /// (`ProjectRegistry.connectionProjectPaths`), and the app asked to join from
+  /// `AppFeature.task` — once, at launch. So a reconnect left the new socket attached to
+  /// no `GraphStore` at all: commands still arrived and still took effect, but every
+  /// broadcast went to the connection that had gone. The app looked connected and stayed
+  /// frozen on whatever it last knew, which is how deleting a loop could remove it from
+  /// the daemon's graph while its row sat in the sidebar until the next relaunch.
+  ///
+  /// The same two commands the launch path sends: the daemon's own open-projects set is
+  /// the right one to restore from, and the global graph is joined by name because it is
+  /// deliberately not in that set.
+  private func rejoinProjects() async throws {
+    try await send(.restoreOpenProjects)
+    try await send(.openGlobalGraph)
   }
 
   func send(_ command: DaemonCommand) async throws {

--- a/graphcode/Tests/OrchestratorClientTests.swift
+++ b/graphcode/Tests/OrchestratorClientTests.swift
@@ -56,6 +56,37 @@ struct OrchestratorClientTests {
     #expect(await received == .errorOccurred("late but connected"))
   }
 
+  @Test
+  func reconnectingRejoinsTheProjectsItHadOpen() async throws {
+    // Joining is per-connection on the daemon's side, and the app asked to join once, from
+    // `AppFeature.task`. So a client that lost its socket dialled again and was attached to
+    // no `GraphStore` at all: commands still arrived and still took effect, but no
+    // broadcast ever came back. Deleting a loop removed it from the daemon's graph and left
+    // its row in the sidebar until the next relaunch.
+    let daemon = try StubDaemon()
+    defer { daemon.stop() }
+    let client = OrchestratorClient.live(socketPath: daemon.socketPath)
+
+    let events = client.connect()
+    async let received = firstEvent(of: events)
+    try await client.send(.listRecentProjects)
+    let opening = try #require(await daemon.nextCommand())
+    #expect(opening == .listRecentProjects)
+
+    // The daemon hangs up, the way a restart does.
+    daemon.closeConnection(at: 0)
+
+    // The replacement socket announces itself instead of waiting to be spoken to.
+    let rejoin = try #require(await daemon.nextCommand(onConnection: 1))
+    #expect(rejoin == .restoreOpenProjects)
+    let joinGlobal = try #require(await daemon.nextCommand(onConnection: 1))
+    #expect(joinGlobal == .openGlobalGraph)
+
+    // And it's a live subscription, not merely an open socket.
+    try daemon.reply(.errorOccurred("after reconnect"), onConnection: 1)
+    #expect(await received == .errorOccurred("after reconnect"))
+  }
+
   private func firstEvent(of events: AsyncStream<DaemonEvent>) async -> DaemonEvent? {
     for await event in events { return event }
     return nil
@@ -132,12 +163,12 @@ private final class StubDaemon: @unchecked Sendable {
     lock.withLock { acceptedDescriptors.count }
   }
 
-  /// Reads one framed command off the first accepted connection, waiting for the accept
-  /// to land. Blocking reads run off the cooperative pool.
-  func nextCommand() async -> DaemonCommand? {
+  /// Reads one framed command off an accepted connection, waiting for the accept to land.
+  /// Blocking reads run off the cooperative pool.
+  func nextCommand(onConnection index: Int = 0) async -> DaemonCommand? {
     await withCheckedContinuation { continuation in
       DispatchQueue.global().async { [self] in
-        guard let descriptor = waitForFirstConnection(),
+        guard let descriptor = waitForConnection(at: index),
           let data = try? FramedMessageIO.readFrame(from: descriptor),
           let command = try? JSONDecoder().decode(DaemonCommand.self, from: data)
         else {
@@ -150,25 +181,40 @@ private final class StubDaemon: @unchecked Sendable {
   }
 
   /// Writes an event back the way `graphcoded` does — on the accepted connection.
-  func reply(_ event: DaemonEvent) throws {
-    guard let descriptor = waitForFirstConnection() else { throw StubError.noConnection }
+  func reply(_ event: DaemonEvent, onConnection index: Int = 0) throws {
+    guard let descriptor = waitForConnection(at: index) else { throw StubError.noConnection }
     try FramedMessageIO.writeFrame(try JSONEncoder().encode(event), to: descriptor)
+  }
+
+  /// Hangs up on one accepted connection, leaving the listener up — a daemon restart as
+  /// the client experiences it. The slot is blanked rather than removed so later
+  /// connections keep their indices, and so `stop` doesn't close the number twice.
+  func closeConnection(at index: Int) {
+    lock.withLock {
+      guard acceptedDescriptors.indices.contains(index), acceptedDescriptors[index] >= 0
+      else { return }
+      close(acceptedDescriptors[index])
+      acceptedDescriptors[index] = -1
+    }
   }
 
   func stop() {
     lock.withLock {
       guard !stopped else { return }
       stopped = true
-      for descriptor in acceptedDescriptors { close(descriptor) }
+      for descriptor in acceptedDescriptors where descriptor >= 0 { close(descriptor) }
       acceptedDescriptors = []
     }
     close(listenerDescriptor)
     try? FileManager.default.removeItem(at: socketPath)
   }
 
-  private func waitForFirstConnection() -> Int32? {
+  private func waitForConnection(at index: Int) -> Int32? {
     for _ in 0..<200 {
-      if let descriptor = lock.withLock({ acceptedDescriptors.first }) { return descriptor }
+      let descriptor = lock.withLock {
+        acceptedDescriptors.indices.contains(index) ? acceptedDescriptors[index] : nil
+      }
+      if let descriptor, descriptor >= 0 { return descriptor }
       usleep(25_000)
     }
     return nil


### PR DESCRIPTION
Fixes #47

## Root cause

The delete path was never the problem. `graphcoded` keys a client's joined projects by *connection* — `ProjectRegistry.connectionProjectPaths`, populated by `.openProject` / `.restoreOpenProjects` / `.openGlobalGraph` — and the app asks to join exactly once, from `AppFeature.task`. `DaemonConnection.events()` reconnects on any I/O failure (a daemon restart, a frame that failed to decode, a transient socket error) but never re-announces those projects, so the replacement socket is attached to no `GraphStore` at all. Commands still travel *up* it fine, because `ProjectRegistry` routes `.graphCommand` by looking the store up in `stores`, which doesn't care which connections are joined — so the loop really is deleted and really is persisted. Only the confirming `.graphChanged` broadcast is lost, because `GraphStore.notifyClients` writes to the connection that had gone. The sidebar is a pure function of `ProjectFeature.State.graph`, so it keeps rendering whatever it last heard.

That matches every part of the report: intermittent (only after a reconnect has occurred), gone daemon-side, and cured by a relaunch — which re-sends the join commands.

## Change

`DaemonConnection` now tracks whether it has connected before, and re-sends `.restoreOpenProjects` and `.openGlobalGraph` on every connection after the first. Three lines of behaviour plus their explanation.

Minimal by construction:

- **First connect is untouched** — `AppFeature.task` still owns the launch bootstrap, so there is no duplicated join, no second `recordOpened`, and no behaviour change on the happy path.
- **Reuses the launch commands rather than inventing a restore path.** The daemon's own persisted open-projects set is the correct set to rejoin; the global graph is joined by name because it's deliberately excluded from that set.
- **No new protocol surface.** An alternative fix was a `.reconnected` `DaemonEvent` for `AppFeature` to react to; that's a wire-format change for something the connection actor already knows.
- If a rejoin write fails, `send` invalidates and rethrows into the existing catch, so the next attempt retries the rejoin — there's no path that ends up connected-but-joined-to-nothing.

Also corrected the doc comment on `DaemonCommand.restoreOpenProjects`, which said "Sent once at launch" — that was precisely the assumption that broke.

Regression test `reconnectingRejoinsTheProjectsItHadOpen` extends the existing `StubDaemon` (per-connection `nextCommand`/`reply`, plus `closeConnection(at:)`) to hang up on the client and assert the replacement socket announces itself and is a live subscription.

## Verified in cloud

Static only — no Xcode or macOS SDK in this sandbox, so nothing here was compiled or run.

- Confirmed `DaemonCommand.restoreOpenProjects` and `.openGlobalGraph` exist as cases with no associated values (`GraphcodeKit/Sources/IPC/DaemonProtocol.swift`), matching how `AppFeature.task` sends them.
- Traced the whole path to confirm the diagnosis rather than assume it: `deleteNodeConfirmed` → `.graphCommand` → `ProjectRegistry.handle` (`stores[path]`, connection-independent) → `GraphStore.deleteNode` → `drainAndBroadcast` → `broadcast()` → `onGraphChanged` (persists) + `notifyClients()` (per-connection). Confirmed `GraphStore.handle`'s `.deleteNode` case has no early return that could skip the broadcast.
- Confirmed the sidebar renders purely from `project.graph` — `orderedRootNodes`/`flattenedNodeRows` in `AppSidebarView+Rows.swift` derive from `graph.startAnchors` and `graph.edges` with no cached node list — so a lingering row can only mean a stale `state.graph`, and `ProjectFeature`'s `.graphChanged` does replace it wholesale and prune `sidebarNodeOrder`.
- Grepped for every other join site: `.restoreOpenProjects` and `.openGlobalGraph` appear only in `AppFeature.task`, confirming there was no other rejoin path already covering this.
- Checked actor isolation on the new calls: `isReconnect()` and `rejoinProjects()` are isolated members of `DaemonConnection` called with `await` from the `nonisolated events()` Task, matching the adjacent `try await ensureConnected()` / `await invalidate(...)`. `ensureConnected` assigns `connection` before suspending, so the `send` inside `rejoinProjects` reuses the same socket rather than dialling a second one.
- Checked all call sites of the changed test helpers: `StubDaemon` is `private` to `OrchestratorClientTests.swift`; `nextCommand()` and `reply(_:)` kept default `onConnection: 0`, so both existing tests are unchanged, and `waitForFirstConnection` has no remaining references anywhere.
- Confirmed the existing `connectAndSendShareOneSocket` assertion (`acceptedConnectionCount == 1`, first command is `.listRecentProjects`) still holds, since the first connection sends nothing new.
- Confirmed `stop()` can't double-close: `closeConnection(at:)` blanks the slot to `-1` and `stop()` skips negatives.

## NOT verified — needs local Mac

- [ ] `make build-app`
- [ ] `make test` — in particular the new `reconnectingRejoinsTheProjectsItHadOpen`, which is timing-sensitive: it depends on the client's 1s reconnect backoff landing inside `waitForConnection`'s 5s poll. If it proves flaky on CI, the poll bound is the knob.
- [ ] Manual repro for #47: open a project with at least one loop; restart the daemon (or otherwise force the app's socket to drop) while the app stays open; delete a loop from the sidebar's right-click menu; confirm the row disappears immediately instead of persisting until relaunch.
- [ ] Confirm the rejoin doesn't disturb an open workspace — with a loop's terminal on screen, force a reconnect and check the terminal stays up and selection doesn't jump. (Reading `AppFeature`'s `.graphChanged`, already-known projects take the update branch rather than the "project opened" branch that clears `openLoop`, so this should hold; it's worth an eye on the real app.)

## Adjacent, deliberately not fixed here

Two things surfaced while tracing this. Both are pre-existing, neither is needed for #47, and each deserves its own change:

1. **Unsynchronised concurrent writes to one connection fd.** Every `GraphStore` for a given client shares that client's descriptor, and `FramedMessageIO.writeFrame` is two non-atomic `write(2)` calls. Two stores broadcasting at once (or `AppFeature.task`'s three merged `send`s at launch) can interleave header and payload and corrupt the frame stream. This is one plausible *trigger* for the reconnect that #47 then fails to recover from.
2. **The daemon never reaps the abandoned connection.** `invalidate` deliberately doesn't `close` the old descriptor, so `graphcoded`'s read loop for it never sees EOF and keeps it registered — meaning it keeps writing to a socket nobody reads. If that socket's buffer ever fills, `writeAll` blocks the `GraphStore` actor indefinitely.

---
_Generated by [Claude Code](https://claude.ai/code/session_0171cQZoT18e65EhhqFt9LS8)_