### PR TITLE
0.1.21-beta1 (build 65): version bump for the daemon-reconnect fix (#48)

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -54,8 +54,8 @@ let project = Project(
                 // (#33). Before that the suffix lived on the tag only, so betas 48/49
                 // of the 0.1.15 line read "0.1.15" and are told by the build number
                 // apart.
-                "CFBundleShortVersionString": "0.1.20",
-                "CFBundleVersion": "64",
+                "CFBundleShortVersionString": "0.1.21-beta1",
+                "CFBundleVersion": "65",
             ]),
             resources: [
                 "graphcode/Resources/**"


### PR DESCRIPTION
Version bump only — this is the repo-side half of cutting `0.1.21-beta1`. **The build itself cannot be produced in the cloud sandbox and still has to run on your Mac** (see the checklist below).

## What this carries

`main` currently sits at `f275c57`, which merged #48 (`fix: sidebar goes stale after a daemon reconnect, so a deleted loop keeps its row`, issue #47). That fix is on `main` but is not in any release — `Project.swift` still shipped `0.1.20` / build 64, i.e. the v0.1.20 stable. This bump is what makes the next beta contain it.

## Change

`Project.swift` only, two lines:

- `CFBundleShortVersionString`: `0.1.20` → `0.1.21-beta1`
- `CFBundleVersion`: `64` → `65`

Following the convention recorded in the surrounding comment and in `0.1.19`/61 → `0.1.20-beta1`/62: since 0.1.15-beta3 a beta carries its **full suffixed version** in `CFBundleShortVersionString`, which is how Check for Updates knows the install is on the beta channel (#33). The build number increments monotonically.

## Verified in cloud

- `grep -rn "0\.1\.20"` across the repo (excluding `ThirdParty/` and `docs/`) returns exactly one hit — `Project.swift:57`. There is no second place carrying the version, so this is the whole bump.
- A beta's version is deliberately **not** read out of `Project.swift` by `make tap-bump`; that channel requires an explicit `VERSION=`, so nothing else needs editing for the tap.
- Diff re-read line by line: two string literals, no structural change, comments untouched.

## NOT verified — needs your Mac

Nothing here was compiled or built. There is no Xcode, macOS SDK, signing certificate, or notarization credential in this sandbox.

- [ ] `make generate` — Tuist regenerates the project with the new Info.plist values
- [ ] `make check` / `make test`
- [ ] `make build-app`, confirm About reports `0.1.21-beta1` and build `65`
- [ ] `make release-dmg SIGN_ID=... NOTARIZE=1`
- [ ] `gh release create 0.1.21-beta1` (beta tags carry **no** `v` prefix)
- [ ] `make tap-bump CHANNEL=beta VERSION=0.1.21-beta1` — run *after* the release exists, since the checksum is read back from the served asset
- [ ] Manual repro of #47 against the beta: open a project, force a daemon reconnect, delete a loop, confirm the sidebar row goes with it

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRtNLBrHUBWCPhxLKH1EKq)_