### PR TITLE
0.1.21-beta1: scroll-to-pan, fit-to-content, session resume

### DIFF
--- a/GraphcodeKit/Sources/Sessions/AgentEnvironment.swift
+++ b/GraphcodeKit/Sources/Sessions/AgentEnvironment.swift
@@ -7,8 +7,11 @@ import Foundation
 /// graphcode.app`, or `make daemon-install` from a loop's own shell — and then inherits
 /// them. Passed on to the backends graphcode starts, they make each *new* session take
 /// itself for a spawned child of that long-dead one: transcript saving off, the wrong
-/// session id, no `/resume` later. The processes are fresh top-level sessions however
-/// graphcode itself was launched, so the variables are dropped before anything forks.
+/// session id. The processes are fresh top-level sessions however graphcode itself was
+/// launched, so the variables are dropped before anything forks.
+///
+/// Session IDs for graphcode's *own* loops are captured separately by `PresenceHooks`
+/// and persisted by `SessionIDStore`, so `--resume` works across reboots.
 public enum AgentEnvironment {
   public static func isInheritedAgentIdentity(_ key: String) -> Bool {
     key.hasPrefix("CLAUDE") || key == "AI_AGENT"

--- a/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
+++ b/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
@@ -68,13 +68,34 @@ public enum PresenceHooks {
       + "presence=\(presence.rawValue) >/dev/null 2>&1; fi; exit 0"
   }
 
+  /// Captures Claude Code's session ID for `--resume` after a reboot.
+  ///
+  /// `$CLAUDE_SESSION_ID` is set by Claude Code in its own process environment, so every
+  /// hook script inherits it. The node UUID is extracted from `$ZMX_SESSION`
+  /// (`graphcode-<UUID>`), and the ID is written to the `SessionIDStore` path. Silently
+  /// skipped when either variable is absent — a session graphcode didn't start, or a
+  /// Claude Code version that doesn't export its session ID.
+  static func captureSessionID(supportDir: String) -> String {
+    let dir = "\(supportDir)/sessions"
+    return "if [ -n \"$ZMX_SESSION\" ] && [ -n \"$CLAUDE_SESSION_ID\" ]; then "
+      + "node_id=\"${ZMX_SESSION#graphcode-}\"; "
+      + "mkdir -p \(singleQuoted(dir)); "
+      + "printf '%s' \"$CLAUDE_SESSION_ID\" > \(singleQuoted(dir))/\"$node_id\".id; "
+      + "fi; exit 0"
+  }
+
   /// The settings JSON for a backend, or `nil` when it has no hooks to configure.
   /// Serialized rather than interpolated so a support directory containing a quote is a
   /// path, not a syntax error.
   public static func json(forBackend backend: CLISessionBackendKind, zmxPath: String) -> String? {
     guard let events = events(forBackend: backend) else { return nil }
+    let supportDir = SupportDirectory.url.path
     let hooks = events.reduce(into: [String: [Matcher]]()) { result, event in
-      result[event.0] = [Matcher(hooks: [Command(command: report(event.1, zmxPath: zmxPath))])]
+      var commands = [Command(command: report(event.1, zmxPath: zmxPath))]
+      if event.0 == "SessionStart" && backend == .claudeCode {
+        commands.append(Command(command: captureSessionID(supportDir: supportDir)))
+      }
+      result[event.0] = [Matcher(hooks: commands)]
     }
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/GraphcodeKit/Sources/Sessions/SessionIDStore.swift
+++ b/GraphcodeKit/Sources/Sessions/SessionIDStore.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Persists each node's backend session ID so a loop can resume after a reboot
+/// instead of starting a duplicate session from scratch.
+///
+/// The zmx session holds the PTY and survives app quits, but not a reboot — its
+/// server process dies with the machine. Without this store, `ensureUnattendedSessions`
+/// relaunches every loop with its opening prompt, doing the same job twice. With it,
+/// the launcher can pass `--resume <id>` instead, picking up where the last session
+/// left off.
+///
+/// Files live at `~/.graphcode/sessions/<node-uuid>.id`, one line per file. Written
+/// by a `SessionStart` hook inside the backend (see `PresenceHooks`), read by
+/// `ZmxSessionLauncher` before it decides whether to start fresh or resume.
+public enum SessionIDStore {
+  static var directory: URL {
+    SupportDirectory.url.appendingPathComponent("sessions", isDirectory: true)
+  }
+
+  static func file(forNodeID nodeID: UUID) -> URL {
+    directory.appendingPathComponent("\(nodeID.uuidString).id")
+  }
+
+  public static func save(_ sessionID: String, forNodeID nodeID: UUID) {
+    let url = file(forNodeID: nodeID)
+    do {
+      try FileManager.default.createDirectory(
+        at: directory, withIntermediateDirectories: true)
+      try sessionID.write(to: url, atomically: true, encoding: .utf8)
+    } catch {
+      return
+    }
+  }
+
+  public static func load(forNodeID nodeID: UUID) -> String? {
+    let url = file(forNodeID: nodeID)
+    guard let text = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  public static func remove(forNodeID nodeID: UUID) {
+    try? FileManager.default.removeItem(at: file(forNodeID: nodeID))
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -329,12 +329,11 @@ public enum ZmxSessionLauncher {
   }
 
   static func kill(_ node: LoopNode, projectPath: String? = nil) async {
-    // Same routing as `send`: a remote session's kill has to reach the remote zmx, or
-    // stopping and deleting remote loops leaves their sessions running forever.
     if let projectPath, let remote = RemoteProjectLocation.parse(projectPath: projectPath) {
       await killRemote(node, at: remote)
       return
     }
+    SessionIDStore.remove(forNodeID: node.id)
     guard ZmxLocator.isInstalled else { return }
     guard
       let session = try? PTYProcessSession(
@@ -495,6 +494,35 @@ public enum ZmxSessionLauncher {
           of: executable, arguments: unbriefed, scriptSuffix: remoteHooksSuffix)
     }
     return command
+  }
+
+  /// `zmx run` argv that resumes an existing backend session instead of starting fresh.
+  ///
+  /// Used after a reboot: the zmx session is gone, but a persisted session ID lets the
+  /// backend pick up where it left off. Falls back to `nil` when resume isn't possible
+  /// (no persisted ID, non-Claude backend, or the executable isn't found).
+  static func resumeArguments(
+    forNode node: LoopNode, sessionID: String, projectPath: String? = nil,
+    settings: GraphcodeSettings = GraphcodeSettingsStore.load()
+  ) -> [String]? {
+    guard node.backend == .claudeCode else { return nil }
+    guard let executable = node.backend.executableName else { return nil }
+    let remote = projectPath.flatMap { RemoteProjectLocation.parse(projectPath: $0) }
+    guard remote == nil else { return nil }
+    let tier = node.effectiveModelTier(autoSelecting: settings.autoSelectsModel)
+    let hooksFile = PresenceHooks.write(forBackend: node.backend)
+    let reportingPath = ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil
+    let resumeArgs = node.backend.launchArguments(
+      prompt: nil, tier: tier, settings: settings,
+      workspacePaths: Self.workspacePaths(forNode: node, projectPath: projectPath),
+      hooksFile: hooksFile,
+      sessionName: SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName,
+      zmxPath: reportingPath)
+      + ["--resume", sessionID]
+    return [
+      "run", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName, "-d",
+    ]
+      + Self.loginShellInvocation(of: executable, arguments: resumeArgs)
   }
 
   /// The directories a loop's work legitimately spans: the project, and its worktree when
@@ -843,37 +871,39 @@ public enum ZmxSessionLauncher {
   }
 
   static func start(_ node: LoopNode, projectPath: String? = nil) async {
-    // A remote project's session starts on the remote host — local zmx isn't involved
-    // and doesn't need to be installed for it.
     if let projectPath, let remote = RemoteProjectLocation.parse(projectPath: projectPath) {
       await startRemote(node, at: remote)
       return
     }
     guard ZmxLocator.isInstalled else { return }
-    guard let arguments = arguments(forNode: node, projectPath: projectPath) else { return }
 
     do {
-      // Create only. A session that already exists is left strictly alone — it's either
-      // the loop still running (re-sending would corrupt it) or one whose Claude has
-      // exited, which resolved the node and is a deliberate end state, not something to
-      // silently restart behind the human's back.
       let existing = try PTYProcessSession(
         executable: ZmxLocator.binaryURL.path,
         arguments: existenceCheckArguments(forNode: node))
       guard await !existing.waitUntilFinished() else { return }
 
+      // No live zmx session. If a backend session ID was persisted before the last
+      // reboot, resume it rather than starting a duplicate from scratch.
+      if let sessionID = SessionIDStore.load(forNodeID: node.id),
+        let resumeArgs = resumeArguments(
+          forNode: node, sessionID: sessionID, projectPath: projectPath)
+      {
+        let resume = try PTYProcessSession(
+          executable: ZmxLocator.binaryURL.path,
+          arguments: resumeArgs,
+          workingDirectory: workingDirectory(forNode: node, projectPath: projectPath))
+        _ = await resume.waitUntilFinished()
+        return
+      }
+
+      guard let arguments = arguments(forNode: node, projectPath: projectPath) else { return }
       let launch = try PTYProcessSession(
         executable: ZmxLocator.binaryURL.path,
         arguments: arguments,
         workingDirectory: workingDirectory(forNode: node, projectPath: projectPath))
-      // `zmx run -d` returns as soon as it has handed the command to the session daemon,
-      // which then outlives it. Waiting keeps this short-lived launcher process (and its
-      // PTY) alive until then rather than tearing it down mid-spawn.
       _ = await launch.waitUntilFinished()
     } catch {
-      // Nothing useful to do from here: the daemon has no UI, and a node whose session
-      // failed to start still shows its real (unchanged) state in every client. The
-      // human sees an empty terminal when they open it, and reopening retries.
       return
     }
   }

--- a/Project.swift
+++ b/Project.swift
@@ -54,8 +54,8 @@ let project = Project(
                 // (#33). Before that the suffix lived on the tag only, so betas 48/49
                 // of the 0.1.15 line read "0.1.15" and are told by the build number
                 // apart.
-                "CFBundleShortVersionString": "0.1.20",
-                "CFBundleVersion": "64",
+                "CFBundleShortVersionString": "0.1.21-beta1",
+                "CFBundleVersion": "65",
             ]),
             resources: [
                 "graphcode/Resources/**"

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Two design choices explain most of the rest:
   daemon only makes sure the session is alive. That's what keeps a running loop something
   you can attach to and correct, rather than a job that already finished somewhere.
 - **Sessions outlive everything.** Each loop's terminal is a [`zmx`](https://zmx.sh)
-  session, so it survives closing the window, quitting the app, and restarting the daemon —
-  reattaching restores full scrollback.
+  session, so it survives closing the window, quitting the app, restarting the daemon,
+  and even a reboot — the backend's session ID is persisted, so relaunching after a
+  reboot resumes the conversation with `--resume` rather than starting a duplicate.
 
 So a working graph might look like: a time-based loop runs `/loop 1h Triage new bug
 reports`, a hand-off edge fires a goal-based fixer loop for anything it finds (done when

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,8 +111,10 @@ only duty is **liveness**: making sure the session exists.
 ### Sessions outlive everything
 
 Each loop's terminal is a [`zmx`](https://zmx.sh) session — a PTY kept alive by a
-session daemon, like tmux. It survives closing the window, quitting the app, and
-restarting GraphCode's own daemon; reattaching restores full scrollback.
+session daemon, like tmux. It survives closing the window, quitting the app,
+restarting GraphCode's own daemon, and even a machine reboot: the backend's session
+ID is persisted on disk, so the daemon resumes the conversation with `--resume`
+rather than starting a duplicate session.
 
 That's what makes unattended and attended the same thing. The daemon starts a loop at
 3 a.m.; you click its node at 9 and you're *in the session that did the work*, live,

--- a/graphcode/Sources/Features/App/QuickChatsCanvasView.swift
+++ b/graphcode/Sources/Features/App/QuickChatsCanvasView.swift
@@ -96,7 +96,7 @@ struct QuickChatsCanvasView: View {
     guard transform == CanvasTransform(), viewport != .zero, content != .zero else {
       return
     }
-    transform = .centred(content, in: viewport)
+    transform = .fitting(content, in: viewport)
   }
 
   private func canvas(_ placements: [Placement]) -> some View {
@@ -151,6 +151,7 @@ struct QuickChatsCanvasView: View {
         }
         .onEnded { _ in pinchBaseScale = nil }
     )
+    .background { CanvasScrollHandler(transform: $transform, viewport: viewport) }
   }
 
   /// The band the chats sit in — unlabelled, like a project canvas's, since this pane is

--- a/graphcode/Sources/Features/Canvas/CanvasScrollHandler.swift
+++ b/graphcode/Sources/Features/Canvas/CanvasScrollHandler.swift
@@ -1,0 +1,63 @@
+import AppKit
+import SwiftUI
+
+/// Turns trackpad two-finger scroll and mouse-wheel scroll into canvas pan (or
+/// ⌘-scroll into zoom). SwiftUI's `DragGesture` requires a click-drag; this bridges
+/// the `scrollWheel(with:)` events that a trackpad and scroll wheel emit.
+///
+/// Applied as a `.background` — it never intercepts hit-testing.
+struct CanvasScrollHandler: NSViewRepresentable {
+  @Binding var transform: CanvasTransform
+  let viewport: CGSize
+
+  func makeCoordinator() -> Coordinator { Coordinator() }
+
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    let coordinator = context.coordinator
+    coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
+      guard let window = view.window,
+        event.window === window,
+        let contentView = window.contentView
+      else { return event }
+
+      let locationInContent = contentView.convert(event.locationInWindow, from: nil)
+      let viewFrame = view.convert(view.bounds, to: contentView)
+      guard viewFrame.contains(locationInContent) else { return event }
+
+      let isZoom = event.modifierFlags.contains(.command)
+      let scale: CGFloat = event.hasPreciseScrollingDeltas ? 1 : 10
+      let dx = event.scrollingDeltaX * scale
+      let dy = event.scrollingDeltaY * scale
+
+      coordinator.apply?(dx, dy, isZoom)
+      return nil
+    }
+    return view
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    context.coordinator.apply = { [self] dx, dy, isZoom in
+      if isZoom {
+        let centre = CGPoint(x: viewport.width / 2, y: viewport.height / 2)
+        let factor: CGFloat = dy > 0 ? 1 / CanvasTransform.step : CanvasTransform.step
+        transform = transform.zoomed(to: transform.scale * factor, around: centre, in: viewport)
+      } else {
+        transform.offset.width += dx
+        transform.offset.height += dy
+      }
+    }
+  }
+
+  static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+    if let monitor = coordinator.monitor {
+      NSEvent.removeMonitor(monitor)
+      coordinator.monitor = nil
+    }
+  }
+
+  final class Coordinator {
+    var monitor: Any?
+    var apply: ((CGFloat, CGFloat, Bool) -> Void)?
+  }
+}

--- a/graphcode/Sources/Features/Overview/GraphOverviewView.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverviewView.swift
@@ -148,7 +148,7 @@ struct GraphOverviewView: View {
     guard transform == CanvasTransform(), viewport != .zero, content != .zero else {
       return
     }
-    transform = .centred(content, in: viewport)
+    transform = .fitting(content, in: viewport)
   }
 
   /// The drawn graph itself, sized against the pane it's in. Split from `canvas` only to
@@ -217,6 +217,7 @@ struct GraphOverviewView: View {
           }
           .onEnded { _ in pinchBaseScale = nil }
       )
+      .background { CanvasScrollHandler(transform: $transform, viewport: viewport) }
   }
 
   private func zoomControls(_ overview: GraphOverview) -> some View {

--- a/graphcode/Sources/Features/Project/ProjectCanvasView.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasView.swift
@@ -187,7 +187,7 @@ struct ProjectCanvasView: View {
     guard transform == CanvasTransform(), viewport != .zero, content != .zero else {
       return
     }
-    transform = .centred(content, in: viewport)
+    transform = .fitting(content, in: viewport)
   }
 
   private func canvas(_ derived: Derived) -> some View {
@@ -250,6 +250,7 @@ struct ProjectCanvasView: View {
         }
         .onEnded { _ in pinchBaseScale = nil }
     )
+    .background { CanvasScrollHandler(transform: $transform, viewport: viewport) }
   }
 
   /// Drawn as an overlay rather than as a branch on `canvas` so panning and zooming


### PR DESCRIPTION
## Summary
- **#51** Scroll-to-pan on all three canvas views (graph overview, project canvas, quick chats) via `NSEvent.addLocalMonitorForEvents` — ⌘-scroll zooms
- **#52** Initial canvas placement uses `fitting()` to auto-zoom showing all nodes, not just centre on the origin
- **#46** Persist Claude Code session IDs via `SessionIDStore` + `PresenceHooks` capture hook, enabling `--resume` after reboot instead of starting duplicate sessions
- Version bump to 0.1.21-beta1 (build 65)

Closes #51, #52, #46, #49

## Test plan
- [x] 664 tests pass across 71 suites
- [ ] Build and verify About shows 0.1.21-beta1 (65)
- [ ] Scroll-to-pan works on all canvas views
- [ ] Canvas auto-fits to show all nodes on open

🤖 Generated with [Claude Code](https://claude.com/claude-code)