### PR TITLE
Fix rendering freeze, zoom floor 60%, start node centering

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -54,8 +54,8 @@ let project = Project(
                 // (#33). Before that the suffix lived on the tag only, so betas 48/49
                 // of the 0.1.15 line read "0.1.15" and are told by the build number
                 // apart.
-                "CFBundleShortVersionString": "0.1.21-beta3",
-                "CFBundleVersion": "67",
+                "CFBundleShortVersionString": "0.1.21-beta4",
+                "CFBundleVersion": "68",
             ]),
             resources: [
                 "graphcode/Resources/**"

--- a/graphcode/Sources/Features/Canvas/CanvasTransform.swift
+++ b/graphcode/Sources/Features/Canvas/CanvasTransform.swift
@@ -16,7 +16,7 @@ import Foundation
 struct CanvasTransform: Equatable {
   /// Far enough out to take in a workspace of several folders, far enough in to read a
   /// nested chip's title. Past 3× the cards are just big; below 0.25× they're texture.
-  static let minScale: CGFloat = 0.25
+  static let minScale: CGFloat = 0.6
   static let maxScale: CGFloat = 3
   /// One press of the zoom buttons (and ⌘=/⌘-). A quarter step is small enough to land
   /// on the scale you wanted and large enough that holding the key gets somewhere.

--- a/graphcode/Sources/Features/Overview/GraphOverviewView.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverviewView.swift
@@ -142,13 +142,21 @@ struct GraphOverviewView: View {
       height: transform.offset.height + dragOffset.height)
   }
 
-  /// Centres the graph, but only while the canvas is still where it started: once
-  /// someone has panned or zoomed, their view is theirs and nothing here moves it.
-  private func centreIfUntouched(in viewport: CGSize, content: CGSize) {
+  /// Centres the graph on its start node, but only while the canvas is still where it
+  /// started: once someone has panned or zoomed, their view is theirs.
+  private func centreIfUntouched(
+    in viewport: CGSize, content: CGSize, startNode: CGPoint?
+  ) {
     guard transform == CanvasTransform(), viewport != .zero, content != .zero else {
       return
     }
-    transform = .fitting(content, in: viewport)
+    var t = CanvasTransform.fitting(content, in: viewport)
+    if let startNode {
+      t.offset = CGSize(
+        width: (viewport.width / 2 - startNode.x) * t.scale,
+        height: (viewport.height / 2 - startNode.y) * t.scale)
+    }
+    transform = t
   }
 
   /// The drawn graph itself, sized against the pane it's in. Split from `canvas` only to
@@ -168,16 +176,16 @@ struct GraphOverviewView: View {
       // is rather than in the top-left corner with the lanes running off the bottom.
       .onAppear {
         viewport = proxy.size
-        centreIfUntouched(in: proxy.size, content: overview.size)
+        centreIfUntouched(in: proxy.size, content: overview.size, startNode: overview.startNode)
       }
       .onChange(of: proxy.size) { _, size in
         viewport = size
-        centreIfUntouched(in: size, content: overview.size)
+        centreIfUntouched(in: size, content: overview.size, startNode: overview.startNode)
       }
       // Folders arrive from the daemon after this view does, so the first paint has
       // nothing to centre on.
       .onChange(of: overview.size) { _, size in
-        centreIfUntouched(in: viewport, content: size)
+        centreIfUntouched(in: viewport, content: size, startNode: overview.startNode)
       }
     }
   }

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView+Visibility.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView+Visibility.swift
@@ -31,6 +31,14 @@ extension GhosttyTerminalNSView {
     guard lastOcclusion != visible else { return }
     lastOcclusion = visible
     ghostty_surface_set_occlusion(surface, visible)
+    if visible && isActive {
+      // libghostty's setVisible(true) only starts the display link when
+      // self.focused is also true. If focus was lost during the occlusion
+      // period (SwiftUI resigns it routinely), the link stays stopped and
+      // the surface appears frozen despite being visible. Re-asserting
+      // focus here restarts the link on de-occlusion.
+      focusIfKeyboardIsOnAHiddenSurface()
+    }
   }
 
   /// Tells libghostty which display this surface is on.

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView.swift
@@ -180,7 +180,13 @@ final class GhosttyTerminalNSView: NSView {
   override func resignFirstResponder() -> Bool {
     guard let surface else { return super.resignFirstResponder() }
     ghostty_surface_set_focus(surface, false)
-    return super.resignFirstResponder()
+    let resigned = super.resignFirstResponder()
+    if resigned && isActive && isVisible {
+      DispatchQueue.main.async { [weak self] in
+        MainActor.assumeIsolated { self?.focusIfKeyboardIsOnAHiddenSurface() }
+      }
+    }
+    return resigned
   }
 
   /// Whether this surface is *the* one the user is typing into — its tab is showing and


### PR DESCRIPTION
## Summary
- **Terminal rendering freeze**: reclaim focus on de-occlusion and deferred reclaim on resignFirstResponder — fixes surfaces that freeze while input still works
- **Zoom floor**: raised from 25% to 60% so the graph is always readable
- **Start node centering**: initial graph view centers on the START node instead of the content bounding box

## Test plan
- [ ] Open a loop workspace, verify terminal renders continuously
- [ ] Switch between apps and back, confirm terminal doesn't freeze
- [ ] Open Graph view, confirm START node is centered
- [ ] Zoom out with ⌘−, confirm it stops at 60%

🤖 Generated with [Claude Code](https://claude.com/claude-code)