### PR TITLE
v0.1.21: rendering freeze fix, Graph view, zoom floor

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -54,8 +54,8 @@ let project = Project(
                 // (#33). Before that the suffix lived on the tag only, so betas 48/49
                 // of the 0.1.15 line read "0.1.15" and are told by the build number
                 // apart.
-                "CFBundleShortVersionString": "0.1.21-beta4",
-                "CFBundleVersion": "68",
+                "CFBundleShortVersionString": "0.1.21",
+                "CFBundleVersion": "69",
             ]),
             resources: [
                 "graphcode/Resources/**"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ nothing hands off to hang from, and every chain flowing right from there. A card
 painted by the state it is in, not by its kind — what you read off the canvas is which
 loops are running, which are done, and which are waiting on you.
 
+The **Graph** view (the pinned sidebar row above every folder) shows all projects on one
+canvas — every folder's lane hung off a single START node, so the whole workspace reads
+as one graph with one beginning.
+
 ## Install
 
 Requires **macOS 15+ on Apple Silicon** (arm64), with **Claude Code on your `PATH`** —
@@ -175,11 +179,11 @@ Design docs live in `docs/` and are kept local (gitignored) for now.
 - **Apple Silicon only.** GhosttyKit is built for the native architecture; there is no
   x86_64 slice, so a universal build won't link.
 - **Claude Code is the most complete backend.** Copilot CLI and Codex loops launch, run,
-  fan out, and receive message edges like Claude ones. Copilot presence is read from its
-  event log (local and remote), so a Copilot loop waiting for input shows as "NEEDS YOU";
-  usage stays Claude Code-only. The picker refuses pairings a backend can't host
-  (time-based needs the session to re-trigger itself; composites need verified
-  sub-agents).
+  fan out, resume after a reboot, and receive message edges like Claude ones. Copilot
+  presence is read from its event log (local and remote), so a Copilot loop waiting for
+  input shows as "NEEDS YOU"; usage stays Claude Code-only. The picker refuses pairings a
+  backend can't host (time-based needs the session to re-trigger itself; composites need
+  verified sub-agents).
 - **A new folder stops at Claude's trust prompt.** An unattended loop started by the daemon
   in a folder Claude hasn't seen waits at *"Do you trust this folder?"* and shows as
   `running` while doing nothing. Attach once and answer it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,6 +120,13 @@ That's what makes unattended and attended the same thing. The daemon starts a lo
 3 a.m.; you click its node at 9 and you're *in the session that did the work*, live,
 history above you, process still running.
 
+### The Graph view
+
+The **Graph** row at the top of the sidebar shows every project on one canvas — each
+folder's loops in its own lane, all hanging off a single **START** node. It's the
+overview you read to know what the whole workspace is doing without clicking into each
+project separately.
+
 ### Projects: local, cloned, or remote
 
 From the sidebar's ⊕ menu a project can be a **local folder**, a **repository cloned

--- a/graphcode/Sources/Features/Overview/GraphOverviewView.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverviewView.swift
@@ -152,9 +152,7 @@ struct GraphOverviewView: View {
     }
     var t = CanvasTransform.fitting(content, in: viewport)
     if let startNode {
-      t.offset = CGSize(
-        width: (viewport.width / 2 - startNode.x) * t.scale,
-        height: (viewport.height / 2 - startNode.y) * t.scale)
+      t.offset.height = (viewport.height / 2 - startNode.y) * t.scale
     }
     transform = t
   }


### PR DESCRIPTION
## Summary
- **Terminal rendering freeze fix**: reclaim focus on de-occlusion and deferred reclaim on resignFirstResponder
- **Graph view Start node**: all folders hang off a single START node, centered vertically
- **Zoom floor**: raised from 25% to 60%
- **Session resume**: Claude Code and Copilot sessions resume after reboot via `--resume`
- **Start node vertical centering**: initial view centers the START node vertically
- README and graphcode.app updated with Graph view description

## Test plan
- [ ] Open Graph view, verify START node centered vertically
- [ ] Zoom out, confirm floor at 60%
- [ ] Terminal surfaces don't freeze on tab/app switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)