### PR TITLE
fix: fit-to-content clamped by the interactive zoom floor (#59)

### DIFF
--- a/graphcode/Sources/Features/Canvas/CanvasTransform.swift
+++ b/graphcode/Sources/Features/Canvas/CanvasTransform.swift
@@ -14,10 +14,16 @@ import Foundation
 /// The model it inverts, for a content point `p` and pane centre `c`:
 /// `screen = c + (p - c) * scale + offset`.
 struct CanvasTransform: Equatable {
-  /// Far enough out to take in a workspace of several folders, far enough in to read a
-  /// nested chip's title. Past 3× the cards are just big; below 0.25× they're texture.
+  /// How far a gesture or a zoom button may take the canvas. Past 3× the cards are just
+  /// big; below 0.6× a card's title stops being readable, which is as far out as zooming
+  /// by hand is worth doing.
   static let minScale: CGFloat = 0.6
   static let maxScale: CGFloat = 3
+  /// How far out *fit-to-content* may go, which is further than a gesture may: a
+  /// workspace several folders tall is a couple of thousand points across and cannot be
+  /// framed at 60%, and a fit that leaves half the graph outside the pane is not a fit.
+  /// Below 0.25× the cards are texture and there is nothing left to frame.
+  static let minFitScale: CGFloat = 0.25
   /// One press of the zoom buttons (and ⌘=/⌘-). A quarter step is small enough to land
   /// on the scale you wanted and large enough that holding the key gets somewhere.
   static let step: CGFloat = 1.25
@@ -61,7 +67,7 @@ struct CanvasTransform: Equatable {
     else { return Self() }
     let raw = min(viewport.width / content.width, viewport.height / content.height)
     // A little margin, so the outermost cards aren't flush against the pane's edges.
-    let scale = min(max(raw * 0.92, minScale), 1)
+    let scale = min(max(raw * 0.92, minFitScale), 1)
     return Self(scale: scale, offset: centringOffset(content, in: viewport, at: scale))
   }
 


### PR DESCRIPTION
Fixes #59

## Root cause

`CanvasTransform.fitting(_:in:)` clamped its computed fit scale to `CanvasTransform.minScale`, the same constant that bounds interactive zoom (pinch, ⌘-scroll, the zoom-out button). Commit e672542 ("0.1.21-beta4 (build 68): fix rendering freeze, zoom floor, start node centering") raised `minScale` from 0.25 to 0.6 for the interactive path, and fit-to-content silently inherited it. Any graph more than roughly 1.5× the viewport can no longer be framed: the 2400×1800-into-800×600 case in the issue wants 0.307 (with the existing 8% margin), gets clamped up to 0.6, and renders 1440×1080 — the graph overflows the pane in both axes, so ⌘9 and the fit button no longer do the one thing they exist to do.

## Change

Two lines of behaviour: add `minFitScale = 0.25` (the value the floor had before e672542, and the one the old doc comment still described) and use it as the lower clamp in `fitting(_:in:)`. `minScale` keeps its 0.6 value and its two interactive call sites — `zoomed(to:around:in:)` and `canZoomOut` — untouched, so zooming by hand still stops where a card title is readable while an explicit fit goes as far out as the graph needs.

Minimal on purpose: no call site changes, no test changes, no layout or metrics touched. The stale doc comment on `minScale` (it still claimed the floor was 0.25) is corrected in the same hunk since the constant it describes is the one being split.

Consequence worth naming for review: after a fit below 0.6, `canZoomOut` is `false` (correct — there is nothing useful further out) and the first zoom-in step snaps to 0.6 rather than to 0.38. That is a visible jump, but it is the existing clamp behaviour and strictly better than a fit that does not fit.

## Verified in cloud

Static only — no compiler was available. What was actually checked:

- `minFitScale` is declared as a `static let CGFloat` on `CanvasTransform` and referenced unqualified from the `static func fitting` in the same type, exactly as `minScale` was in that same expression. No new imports needed.
- `grep -rn 'minScale'` across the repo: the only remaining uses are `zoomed(to:around:in:)` line 38 and `canZoomOut` line 95, both intentionally unchanged, plus `CanvasTransformTests.scaleIsClampedSoAHardPinchCannotLoseTheGraph`, which asserts against `zoomed()` and is unaffected. No source file outside `CanvasTransform.swift` referenced the constant.
- All four `.fitting(...)` call sites read (`CanvasZoomControls:54`, `ProjectCanvasView:190`, `QuickChatsCanvasView:99`, `GraphOverviewView:153`); all take the returned transform whole, none assume a lower bound on `.scale`. `GraphOverviewView` only overwrites `offset.height`, which is scale-consistent.
- No persistence or re-clamping of a stored transform anywhere (grepped for encode/decode/UserDefaults/restore against `transform`), so a below-floor scale cannot be written out and re-read.
- Hand-evaluated the two failing tests against the new arithmetic:
  - `fittingPutsTheWholeGraphInViewAndCentresIt`: 2400×1800 in 800×600 → raw 0.3333 × 0.92 = 0.3067, above the new floor, so unclamped. Content renders 736×552, inside 800×600, scale < 1, and the centring offset puts the content centre exactly at the pane centre.
  - `fittingFramesEveryLaneBandIncludingItsCaption`: derived `GraphOverview.size` for 3 folders × 4 loops from `Metrics`/`CanvasBand` constants as 1382×1834 (bandWidth 1222, three 554-tall lanes) → scale 0.3010. Band corners map to x ∈ [216, 584], y ∈ [43, 557], all inside the viewport. Row count is 4 whether the nodes resolve to `.unwired` or fall through to the unreached-node loop, so the height does not depend on that.
  - `fittingNeverMagnifiesASmallGraph` (300×200 → 1) and the degenerate-size case both go through unchanged code paths.

## NOT verified — needs local Mac

Nothing here was compiled or executed. The release loop must confirm:

- [ ] `make build-app` — compiles.
- [ ] `make test` — in particular `CanvasTransformTests.fittingPutsTheWholeGraphInViewAndCentresIt` and `fittingFramesEveryLaneBandIncludingItsCaption`, the two failing tests in #59, plus the rest of `CanvasTransformTests` for no regression.
- [ ] Manual repro for #59: open a workspace with three or more folders of loops so the graph is a couple of thousand points tall, open the pinned **Graph** row, press ⌘9 (and the fit button). The whole graph, including the bottom lane band and every caption, should be inside the pane with a small margin; the readout should show well under 60%.
- [ ] Check the first paint of the Graph view on such a workspace — `GraphOverviewView.centreIfUntouched` fits on appear, so the initial view should now show the whole graph rather than a 60% crop.
- [ ] Sanity-check the zoom controls after a fit: zoom-out disabled, one zoom-in press jumping to 60%, ⌘0 returning to actual size.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9xECrKD9RQptRstHQbxBL)_