### PR TITLE
Worktree hygiene per folder: sweeper, lane chip, resolve-moment reclaim, per-folder policy (0.1.26-beta1)

### DIFF
--- a/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
+++ b/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
@@ -219,6 +219,14 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
   /// imposing — so it became a setting, defaulted to the behaviour people expected.
   public var autoSelectsModel: Bool
 
+  /// Per-folder worktree hygiene, keyed by the project's canonical path — the same key
+  /// the graph files use. Folders without an entry get `WorktreeHygienePolicy()`.
+  public var worktreePolicies: [String: WorktreeHygienePolicy]
+
+  public func worktreePolicy(forProjectPath path: String) -> WorktreeHygienePolicy {
+    worktreePolicies[path] ?? WorktreeHygienePolicy()
+  }
+
   /// Whether the window carries the activity strip along its bottom edge.
   ///
   /// **Off by default**, and the reason is the strip's own honesty: it is *derived*
@@ -242,7 +250,8 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     copilotPermissions: CopilotPermissions = .allowEverything,
     briefsSessionsAboutTheGraph: Bool = true,
     autoSelectsModel: Bool = false,
-    showsActivityStrip: Bool = false
+    showsActivityStrip: Bool = false,
+    worktreePolicies: [String: WorktreeHygienePolicy] = [:]
   ) {
     self.defaultBackend = defaultBackend.isSpiked ? defaultBackend : .claudeCode
     self.codexApprovals = codexApprovals
@@ -251,6 +260,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     self.briefsSessionsAboutTheGraph = briefsSessionsAboutTheGraph
     self.autoSelectsModel = autoSelectsModel
     self.showsActivityStrip = showsActivityStrip
+    self.worktreePolicies = worktreePolicies
   }
 
   /// Decoding tolerates a file written by an older or newer graphcode: a missing key takes
@@ -279,5 +289,8 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(Bool.self, forKey: .autoSelectsModel) ?? false
     showsActivityStrip =
       try container.decodeIfPresent(Bool.self, forKey: .showsActivityStrip) ?? false
+    worktreePolicies =
+      try container.decodeIfPresent(
+        [String: WorktreeHygienePolicy].self, forKey: .worktreePolicies) ?? [:]
   }
 }

--- a/GraphcodeKit/Sources/Domain/WorktreeHygiene.swift
+++ b/GraphcodeKit/Sources/Domain/WorktreeHygiene.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/// What git can say about one worktree, read once and carried as plain values.
+///
+/// `commitsNotLanded` comes from `git cherry` against the default branch, so squash and
+/// rebase merges count as landed. `git branch --merged` alone would call almost every
+/// reclaimable worktree unmerged on a squash-merge repo — the safe group would come back
+/// empty exactly where the feature is needed most.
+public struct WorktreeGitFacts: Codable, Equatable, Sendable {
+  /// The branch `commitsNotLanded` was measured against, for the row's summary line.
+  public var defaultBranch: String
+  /// Patches on this branch with no equivalent in the default branch.
+  public var commitsNotLanded: Int
+  /// Staged, unstaged **and untracked** files — untracked included, because that is
+  /// where a half-finished experiment lives.
+  public var dirtyFileCount: Int
+  /// Nothing ahead of upstream. A branch with no upstream counts as unpushed, not safe.
+  public var pushed: Bool
+  /// Admin file with no directory: zero risk, nothing on disk to lose.
+  public var prunable: Bool
+  public var sizeBytes: Int64?
+
+  public var landed: Bool { commitsNotLanded == 0 }
+  public var clean: Bool { dirtyFileCount == 0 }
+
+  public init(
+    defaultBranch: String,
+    commitsNotLanded: Int,
+    dirtyFileCount: Int,
+    pushed: Bool,
+    prunable: Bool = false,
+    sizeBytes: Int64? = nil
+  ) {
+    self.defaultBranch = defaultBranch
+    self.commitsNotLanded = commitsNotLanded
+    self.dirtyFileCount = dirtyFileCount
+    self.pushed = pushed
+    self.prunable = prunable
+    self.sizeBytes = sizeBytes
+  }
+}
+
+/// Whether any loop — running or stopped — still points at a worktree.
+///
+/// This signal is the reason hygiene lives in graphcode and not in a shell alias: git
+/// cannot know that a stopped loop's `worktreeBinding` still names this directory.
+public enum WorktreeLoopBinding: Equatable, Sendable {
+  case none
+  case stopped(loopTitle: String)
+  case running(loopTitle: String)
+
+  public var isRunning: Bool {
+    if case .running = self { return true }
+    return false
+  }
+}
+
+/// The three groups of the sweeper, ordered by what removing the worktree would lose.
+public enum WorktreeTier: Equatable, Sendable {
+  /// Landed, clean, pushed and unbound — or a stale admin file with no directory.
+  /// Preselected; the only tier automatic removal may ever touch.
+  case safeToRemove
+  /// Unmerged commits, uncommitted files, unpushed work, or a stopped loop still bound.
+  /// Never preselected: a human looks first.
+  case lookBeforeRemoving
+  /// A loop is running in it. Not selectable at all.
+  case inUse
+}
+
+/// One worktree, classified. The classifier is pure so the tier logic — the part that
+/// has to be right — is testable without a repository.
+public struct WorktreeAssessment: Identifiable, Equatable, Sendable {
+  public var ref: WorktreeRef
+  public var facts: WorktreeGitFacts
+  public var binding: WorktreeLoopBinding
+  /// The last loop that used this worktree, for the row subtitle.
+  public var loopTitle: String?
+  public var resolvedAt: Date?
+
+  public var id: String { ref.worktreePath }
+
+  public init(
+    ref: WorktreeRef,
+    facts: WorktreeGitFacts,
+    binding: WorktreeLoopBinding,
+    loopTitle: String? = nil,
+    resolvedAt: Date? = nil
+  ) {
+    self.ref = ref
+    self.facts = facts
+    self.binding = binding
+    self.loopTitle = loopTitle
+    self.resolvedAt = resolvedAt
+  }
+
+  public var tier: WorktreeTier {
+    if facts.prunable { return .safeToRemove }
+    if binding.isRunning { return .inUse }
+    if facts.landed && facts.clean && facts.pushed, case .none = binding {
+      return .safeToRemove
+    }
+    return .lookBeforeRemoving
+  }
+
+  /// The mono summary line under the branch name — what you'd lose, in its own words.
+  public var summary: String {
+    if facts.prunable { return "stale admin file · nothing on disk to lose" }
+    if binding.isRunning { return "a loop is running in it" }
+    if tier == .safeToRemove {
+      return "landed in \(facts.defaultBranch) · clean tree · no loop bound"
+    }
+    var reasons: [String] = []
+    if facts.commitsNotLanded > 0 {
+      let unit = facts.commitsNotLanded == 1 ? "commit" : "commits"
+      reasons.append("\(facts.commitsNotLanded) \(unit) not in \(facts.defaultBranch)")
+    }
+    if facts.dirtyFileCount > 0 {
+      let unit = facts.dirtyFileCount == 1 ? "file" : "files"
+      reasons.append("\(facts.dirtyFileCount) \(unit) uncommitted")
+    }
+    if !facts.pushed { reasons.append("not pushed") }
+    if case .stopped = binding {
+      reasons =
+        reasons.isEmpty
+        ? ["merged · but a stopped loop still points here"]
+        : reasons + ["a stopped loop still points here"]
+    }
+    return reasons.joined(separator: " · ")
+  }
+}
+
+extension WorktreeAssessment {
+  /// Derives the binding for one worktree from the loops of its project's graph. Matched
+  /// on the worktree path — the one fact `WorktreeRef` and a loop's binding share.
+  public static func binding(
+    forWorktreePath worktreePath: String, in nodes: [LoopNode]
+  ) -> WorktreeLoopBinding {
+    let bound = nodes.filter { $0.worktreeBinding?.worktreePath == worktreePath }
+    if let running = bound.first(where: { !$0.isResolved }) {
+      return .running(loopTitle: running.title)
+    }
+    if let stopped = bound.first {
+      return .stopped(loopTitle: stopped.title)
+    }
+    return .none
+  }
+}
+
+/// The per-folder policy — the real fix. A user who sets "Remove it" once never sees
+/// the sweeper again; the sweeper is only the backlog fix.
+public struct WorktreeHygienePolicy: Codable, Equatable, Sendable {
+  /// What happens when a loop resolves and its branch has landed. Automatic removal
+  /// only ever touches the safe tier; anything else waits for a human regardless.
+  public enum ResolveAction: String, Codable, CaseIterable, Sendable {
+    case remove
+    case ask
+    case keep
+
+    public var displayName: String {
+      switch self {
+      case .remove: return "Remove it"
+      case .ask: return "Ask me"
+      case .keep: return "Keep it"
+      }
+    }
+  }
+
+  public var onResolveLanded: ResolveAction
+  /// The lane chip turns amber past either threshold. A repo with four worktrees is
+  /// working as designed; the chip appears when the folder is genuinely accumulating.
+  public var noticeSizeBytes: Int64
+  public var noticeCount: Int
+
+  public init(
+    onResolveLanded: ResolveAction = .ask,
+    noticeSizeBytes: Int64 = 2 << 30,
+    noticeCount: Int = 8
+  ) {
+    self.onResolveLanded = onResolveLanded
+    self.noticeSizeBytes = noticeSizeBytes
+    self.noticeCount = noticeCount
+  }
+
+  /// A missing key takes its default, same bargain as `GraphcodeSettings`.
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    onResolveLanded =
+      try container.decodeIfPresent(ResolveAction.self, forKey: .onResolveLanded) ?? .ask
+    noticeSizeBytes =
+      try container.decodeIfPresent(Int64.self, forKey: .noticeSizeBytes) ?? 2 << 30
+    noticeCount = try container.decodeIfPresent(Int.self, forKey: .noticeCount) ?? 8
+  }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -54,8 +54,8 @@ let project = Project(
                 // (#33). Before that the suffix lived on the tag only, so betas 48/49
                 // of the 0.1.15 line read "0.1.15" and are told by the build number
                 // apart.
-                "CFBundleShortVersionString": "0.1.25",
-                "CFBundleVersion": "77",
+                "CFBundleShortVersionString": "0.1.26-beta1",
+                "CFBundleVersion": "78",
             ]),
             resources: [
                 "graphcode/Resources/**"

--- a/graphcode/Sources/Clients/GitClient.swift
+++ b/graphcode/Sources/Clients/GitClient.swift
@@ -12,6 +12,15 @@ struct GitClient: Sendable {
       WorktreeRef
   var listWorktrees: @Sendable (_ repositoryPath: String) async throws -> [WorktreeRef]
   var removeWorktree: @Sendable (_ worktree: WorktreeRef) async throws -> Void
+  /// Reads every linked worktree's hygiene signals — landed, clean, pushed, prunable,
+  /// size — in one call. The primary checkout is never a candidate and is not returned.
+  var inspectWorktrees: @Sendable (_ repositoryPath: String) async throws -> [WorktreeInspection]
+  /// Removes a worktree and deletes its branch. A prunable entry (admin file, no
+  /// directory) is pruned instead of removed. The directory must be fully committed —
+  /// `worktree remove` without `--force` refuses a dirty tree, which is the safety
+  /// footnote enforced by git itself.
+  var removeWorktreeAndBranch:
+    @Sendable (_ worktree: WorktreeRef, _ prunable: Bool) async throws -> Void
   /// Streams a `git clone --progress` into `destination`: progress lines while it runs,
   /// `.finished` on success, a thrown `GitClientError` on failure. Streaming is what lets
   /// the form show a live percentage instead of a spinner over a multi-minute network
@@ -24,6 +33,12 @@ struct GitClient: Sendable {
 enum GitCloneEvent: Equatable, Sendable {
   case progress(String)
   case finished
+}
+
+/// One linked worktree with its git facts attached — what the sweeper classifies.
+struct WorktreeInspection: Equatable, Sendable {
+  var ref: WorktreeRef
+  var facts: WorktreeGitFacts
 }
 
 enum GitClientError: Error, Equatable {
@@ -49,6 +64,35 @@ extension GitClient: DependencyKey {
     removeWorktree: { worktree in
       _ = try await run(
         "git", ["-C", worktree.repositoryPath, "worktree", "remove", worktree.worktreePath])
+    },
+    inspectWorktrees: { repositoryPath in
+      let output = try await run("git", ["-C", repositoryPath, "worktree", "list", "--porcelain"])
+      let repoPath = resolvedPath(repositoryPath)
+      let blocks = parseWorktreeBlocks(output)
+        .filter { $0.branch != nil && resolvedPath($0.path) != repoPath }
+      let defaultBranch = await discoverDefaultBranch(repositoryPath)
+      var inspections: [WorktreeInspection] = []
+      for block in blocks {
+        guard let branch = block.branch else { continue }
+        let ref = WorktreeRef(
+          id: branch, repositoryPath: repositoryPath, worktreePath: block.path, branch: branch)
+        let facts = await gitFacts(
+          for: block, defaultBranch: defaultBranch, repositoryPath: repositoryPath)
+        inspections.append(WorktreeInspection(ref: ref, facts: facts))
+      }
+      return inspections
+    },
+    removeWorktreeAndBranch: { worktree, prunable in
+      if prunable {
+        _ = try await run("git", ["-C", worktree.repositoryPath, "worktree", "prune"])
+      } else {
+        _ = try await run(
+          "git", ["-C", worktree.repositoryPath, "worktree", "remove", worktree.worktreePath])
+      }
+      // `-D`, not `-d`: the landed check was `git cherry`, which counts squash merges —
+      // exactly the branches `-d` would refuse. The reflog keeps the tip recoverable.
+      // A branch that is already gone shouldn't fail a removal that succeeded.
+      _ = try? await run("git", ["-C", worktree.repositoryPath, "branch", "-D", worktree.branch])
     },
     clone: { url, destination, branch, depth in
       runClone(url: url, destination: destination, branch: branch, depth: depth)
@@ -223,30 +267,100 @@ extension DependencyValues {
 /// refs/heads/<name>` (bare/detached worktrees, which have no branch line, are
 /// skipped — graphcode's worktree bindings are always on a named branch).
 private func parseWorktreeList(_ output: String, repositoryPath: String) -> [WorktreeRef] {
-  var refs: [WorktreeRef] = []
-  var currentPath: String?
-  var currentBranch: String?
+  parseWorktreeBlocks(output).compactMap { block in
+    guard let branch = block.branch else { return nil }
+    return WorktreeRef(
+      id: branch, repositoryPath: repositoryPath, worktreePath: block.path, branch: branch)
+  }
+}
+
+private struct WorktreeBlock {
+  var path: String
+  var branch: String?
+  var prunable = false
+}
+
+private func parseWorktreeBlocks(_ output: String) -> [WorktreeBlock] {
+  var blocks: [WorktreeBlock] = []
+  var current: WorktreeBlock?
 
   func flush() {
-    if let path = currentPath, let branch = currentBranch {
-      refs.append(
-        WorktreeRef(id: branch, repositoryPath: repositoryPath, worktreePath: path, branch: branch))
-    }
-    currentPath = nil
-    currentBranch = nil
+    if let block = current { blocks.append(block) }
+    current = nil
   }
 
   for line in output.split(separator: "\n", omittingEmptySubsequences: false) {
     if line.isEmpty {
       flush()
     } else if line.hasPrefix("worktree ") {
-      currentPath = String(line.dropFirst("worktree ".count))
+      flush()
+      current = WorktreeBlock(path: String(line.dropFirst("worktree ".count)))
     } else if line.hasPrefix("branch refs/heads/") {
-      currentBranch = String(line.dropFirst("branch refs/heads/".count))
+      current?.branch = String(line.dropFirst("branch refs/heads/".count))
+    } else if line.hasPrefix("prunable") {
+      current?.prunable = true
     }
   }
   flush()
-  return refs
+  return blocks
+}
+
+private func resolvedPath(_ path: String) -> String {
+  URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath().path
+}
+
+/// The branch `landed` is measured against: `origin/HEAD` when the remote declares one,
+/// then a local `main`/`master`, then whatever the primary checkout is on.
+private func discoverDefaultBranch(_ repositoryPath: String) async -> String {
+  if let head = try? await run(
+    "git", ["-C", repositoryPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
+  {
+    let name = head.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let slash = name.firstIndex(of: "/") {
+      return String(name[name.index(after: slash)...])
+    }
+  }
+  for candidate in ["main", "master"]
+  where
+    (try? await run(
+      "git", ["-C", repositoryPath, "rev-parse", "--verify", "--quiet", "refs/heads/\(candidate)"]))
+    != nil
+  {
+    return candidate
+  }
+  let current =
+    (try? await run("git", ["-C", repositoryPath, "symbolic-ref", "--short", "HEAD"])) ?? "main"
+  return current.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+/// Reads one worktree's signals. Every read fails toward the cautious answer — an
+/// unreadable status counts as dirty, a failed cherry as unlanded, a missing upstream
+/// as unpushed — so a git hiccup can only move a worktree *out* of the safe tier.
+private func gitFacts(
+  for block: WorktreeBlock, defaultBranch: String, repositoryPath: String
+) async -> WorktreeGitFacts {
+  if block.prunable {
+    return WorktreeGitFacts(
+      defaultBranch: defaultBranch, commitsNotLanded: 0, dirtyFileCount: 0, pushed: true,
+      prunable: true)
+  }
+  let branch = block.branch ?? ""
+  let cherry =
+    (try? await run("git", ["-C", repositoryPath, "cherry", defaultBranch, branch])) ?? "+"
+  let commitsNotLanded = cherry.split(separator: "\n").filter { $0.hasPrefix("+") }.count
+  let status = try? await run("git", ["-C", block.path, "status", "--porcelain"])
+  let dirtyFileCount = status.map { $0.split(separator: "\n").count } ?? 1
+  let ahead = try? await run(
+    "git", ["-C", block.path, "rev-list", "--count", "@{upstream}..HEAD"])
+  let pushed =
+    ahead.flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) } == 0
+  let size = (try? await run("du", ["-sk", block.path]))
+    .flatMap { $0.split(separator: "\t").first }
+    .flatMap { Int64($0.trimmingCharacters(in: .whitespaces)) }
+    .map { $0 * 1024 }
+  return WorktreeGitFacts(
+    defaultBranch: defaultBranch, commitsNotLanded: commitsNotLanded,
+    dirtyFileCount: dirtyFileCount, pushed: pushed, prunable: false, sizeBytes: size)
 }
 
 /// Runs a command and returns its standard output.

--- a/graphcode/Sources/Clients/GitClient.swift
+++ b/graphcode/Sources/Clients/GitClient.swift
@@ -365,19 +365,25 @@ private func gitFacts(
 
 /// Runs a command and returns its standard output.
 ///
-/// **Both pipes are drained before the process is waited on, and concurrently with each
-/// other.** The order matters and the previous order deadlocked: `waitUntilExit()` came
-/// first, and a child that writes more than the pipe buffer holds (64KB) blocks in
-/// `write` until someone reads — which nobody was going to, because the parent was parked
-/// in `waitUntilExit()` waiting for a child that could never exit. `git worktree list
-/// --porcelain` in a repository with enough worktrees is exactly that much output, and
-/// the symptom is not a slow picker but a `git` that never returns and a task that never
-/// completes.
+/// **Both pipes are drained before the exit status is read, and concurrently with each
+/// other.** The order matters and the previous order deadlocked: waiting came first,
+/// and a child that writes more than the pipe buffer holds (64KB) blocks in `write`
+/// until someone reads — which nobody was going to, because the parent was parked
+/// waiting for a child that could never exit. `git worktree list --porcelain` in a
+/// repository with enough worktrees is exactly that much output, and the symptom is not
+/// a slow picker but a `git` that never returns and a task that never completes.
 ///
 /// Draining them one after the other has the same bug one level down (filling stderr
 /// while the reader is blocked on stdout), hence `async let` rather than two sequential
-/// reads. By the time both have hit EOF the child has closed its descriptors, so the
-/// `waitUntilExit()` that follows is a formality rather than a wait.
+/// reads.
+///
+/// **The exit is awaited through `terminationHandler`, never `waitUntilExit()`.** That
+/// call blocks its thread, and the thread it blocked was sometimes the main one —
+/// worktree inspection runs off a `graphChanged` broadcast, and a missed termination
+/// event parked the whole app (and the hosted test runner) inside a wait for a child
+/// that had already exited. The handler is installed before `run()` so the exit can't
+/// be missed, and it resumes a continuation from Foundation's own background queue —
+/// nothing anywhere blocks.
 @discardableResult
 private func run(_ executable: String, _ arguments: [String]) async throws -> String {
   let process = Process()
@@ -389,6 +395,12 @@ private func run(_ executable: String, _ arguments: [String]) async throws -> St
   process.standardOutput = stdout
   process.standardError = stderr
 
+  let (exited, exitContinuation) = AsyncStream<Int32>.makeStream()
+  process.terminationHandler = { process in
+    exitContinuation.yield(process.terminationStatus)
+    exitContinuation.finish()
+  }
+
   try process.run()
 
   async let outputData = drain(stdout)
@@ -396,12 +408,13 @@ private func run(_ executable: String, _ arguments: [String]) async throws -> St
   let output = String(bytes: await outputData, encoding: .utf8) ?? ""
   let errorOutput = String(bytes: await errorData, encoding: .utf8) ?? ""
 
-  process.waitUntilExit()
+  var status: Int32 = -1
+  for await exitStatus in exited { status = exitStatus }
 
-  guard process.terminationStatus == 0 else {
+  guard status == 0 else {
     throw GitClientError.commandFailed(
       command: (["git"] + arguments).joined(separator: " "),
-      status: process.terminationStatus,
+      status: status,
       output: errorOutput.isEmpty ? output : errorOutput
     )
   }

--- a/graphcode/Sources/Features/App/AppFeature+Worktrees.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Worktrees.swift
@@ -1,0 +1,225 @@
+import ComposableArchitecture
+import Dependencies
+import Foundation
+import GraphcodeKit
+
+/// What the lane chip and the context menus say about one folder's worktrees without
+/// opening anything: `6 worktrees · 4 reclaimable`.
+struct WorktreeFolderStats: Equatable, Sendable {
+  var total = 0
+  var reclaimable = 0
+  var totalBytes: Int64 = 0
+}
+
+extension AppFeature {
+  /// The worktree-hygiene half of the app's actions, nested so the whole surface costs
+  /// `AppFeature.Action` a single case.
+  @CasePathable
+  enum Worktrees {
+    /// Any of the four routes in — lane chip, either context menu, `File ▸ Worktrees…`.
+    case sweepRequested(projectPath: String)
+    case sweepDismissed
+    case sweep(WorktreeSweepFeature.Action)
+    case statsLoaded(projectPath: String, WorktreeFolderStats)
+    case statsReloadRequested(projectPath: String)
+    case settingsRequested(projectPath: String)
+    case settingsDismissed
+  }
+}
+
+/// Per-folder policy reads, behind a dependency so the resolve-moment path is testable
+/// without a settings file on disk.
+struct WorktreePolicyClient: Sendable {
+  var policy: @Sendable (_ projectPath: String) -> WorktreeHygienePolicy
+}
+
+extension WorktreePolicyClient: DependencyKey {
+  static let liveValue = Self { path in
+    GraphcodeSettingsStore.load().worktreePolicy(forProjectPath: path)
+  }
+  static let testValue = Self { _ in WorktreeHygienePolicy() }
+}
+
+extension DependencyValues {
+  var worktreePolicyClient: WorktreePolicyClient {
+    get { self[WorktreePolicyClient.self] }
+    set { self[WorktreePolicyClient.self] = newValue }
+  }
+}
+
+/// Worktree hygiene, at the level that can see every project: opening the sweeper from
+/// any route, keeping the per-folder stats the chip and menus read, and acting on the
+/// resolve moment — the one instant a worktree becomes garbage knowably.
+///
+/// Composed **before** `AppFeature`'s main `Reduce`, which is what lets the
+/// `.graphChanged` handler read the *previous* graph out of state and diff it against
+/// the broadcast — the main reducer replaces it on the same action a moment later.
+struct AppWorktreesReducer: Reducer {
+  typealias State = AppFeature.State
+  typealias Action = AppFeature.Action
+
+  @Dependency(\.gitClient) var gitClient
+  @Dependency(\.worktreePolicyClient) var worktreePolicyClient
+
+  var body: some Reducer<AppFeature.State, AppFeature.Action> {
+    Reduce { state, action in
+      switch action {
+      case .worktrees(.sweepRequested(let path)):
+        guard let project = state.projects[id: path], Self.tracksWorktrees(path)
+        else { return .none }
+        state.worktreeSweep = WorktreeSweepFeature.State(
+          projectPath: path,
+          projectName: project.graph.project.name,
+          nodes: Array(project.graph.nodes))
+        return .none
+
+      case .worktrees(.sweepDismissed):
+        let path = state.worktreeSweep?.projectPath
+        state.worktreeSweep = nil
+        guard let path else { return .none }
+        return reloadStats(path, nodes: nodes(in: state, path))
+
+      // A removal changed what is on disk; the chip must not keep claiming the old
+      // count after the sheet closes.
+      case .worktrees(.sweep(.removalFinished)):
+        guard let path = state.worktreeSweep?.projectPath else { return .none }
+        return reloadStats(path, nodes: nodes(in: state, path))
+
+      case .worktrees(.statsLoaded(let path, let stats)):
+        state.worktreeStats[path] = stats
+        return .none
+
+      case .worktrees(.statsReloadRequested(let path)):
+        return reloadStats(path, nodes: nodes(in: state, path))
+
+      case .worktrees(.settingsRequested(let path)):
+        state.projectSettingsPath = path
+        return .none
+
+      case .worktrees(.settingsDismissed):
+        state.projectSettingsPath = nil
+        return .none
+
+      case .worktrees:
+        return .none
+
+      case .daemonEvent(.graphChanged(let graph)):
+        return graphChangedEffects(state, next: graph)
+
+      // The card's Reclaim: the project scope already cleared its offer on this same
+      // action; actually removing the worktree needs `GitClient`, which is this level's.
+      case .projects(.element(id: let path, action: .reclaimWorktreeTapped(let nodeID))):
+        guard let node = state.projects[id: path]?.graph.nodes[id: nodeID],
+          let ref = node.worktreeBinding
+        else { return .none }
+        return .run { send in
+          try? await gitClient.removeWorktreeAndBranch(ref, false)
+          await send(.worktrees(.statsReloadRequested(projectPath: path)))
+        }
+
+      default:
+        return .none
+      }
+    }
+  }
+
+  /// The global graph is not a folder and a remote project's worktrees live on another
+  /// machine — neither has anything local to sweep.
+  static func tracksWorktrees(_ path: String) -> Bool {
+    path != LoopGraphScope.globalPath && RemoteProjectLocation.parse(projectPath: path) == nil
+  }
+
+  /// `.git` is a directory in a primary checkout and a file in a linked worktree —
+  /// either means git has something to say about this folder. Checked before any
+  /// broadcast-driven git call so a plain folder never spawns `git` processes.
+  private static func isGitRepository(_ path: String) -> Bool {
+    FileManager.default.fileExists(
+      atPath: (path as NSString).appendingPathComponent(".git"))
+  }
+
+  private func nodes(in state: AppFeature.State, _ path: String) -> [LoopNode] {
+    Array(state.projects[id: path]?.graph.nodes ?? [])
+  }
+
+  /// What one broadcast means for hygiene: a project appearing or its binding set
+  /// changing refreshes the stats, and a loop crossing into resolution is the resolve
+  /// moment — assessed, then removed or offered per the folder's policy.
+  private func graphChangedEffects(
+    _ state: AppFeature.State, next graph: LoopGraph
+  ) -> Effect<AppFeature.Action> {
+    let path = graph.project.path
+    guard Self.tracksWorktrees(path), Self.isGitRepository(path) else { return .none }
+    let previous = state.projects[id: path]?.graph
+    let nodes = Array(graph.nodes)
+
+    let newlyResolved = nodes.filter { node in
+      node.isResolved && node.worktreeBinding != nil
+        && previous?.nodes[id: node.id].map { !$0.isResolved } == true
+    }
+    let bindingsChanged =
+      Set((previous?.nodes ?? []).compactMap(\.worktreeBinding?.worktreePath))
+      != Set(nodes.compactMap(\.worktreeBinding?.worktreePath))
+
+    var effects: [Effect<AppFeature.Action>] = []
+    if previous == nil || bindingsChanged || !newlyResolved.isEmpty {
+      effects.append(reloadStats(path, nodes: nodes))
+    }
+    for node in newlyResolved {
+      effects.append(resolveMoment(for: node, path: path, nodes: nodes))
+    }
+    return effects.isEmpty ? .none : .merge(effects)
+  }
+
+  private func reloadStats(_ path: String, nodes: [LoopNode]) -> Effect<AppFeature.Action> {
+    .run { send in
+      guard let inspections = try? await gitClient.inspectWorktrees(path) else { return }
+      let assessments = WorktreeSweepFeature.assessments(inspections, nodes: nodes)
+      let stats = WorktreeFolderStats(
+        total: assessments.count,
+        reclaimable: assessments.filter { $0.tier == .safeToRemove }.count,
+        totalBytes: assessments.compactMap(\.facts.sizeBytes).reduce(0, +))
+      await send(.worktrees(.statsLoaded(projectPath: path, stats)))
+    }
+  }
+
+  /// The good moment: the loop just resolved and the human still remembers what its
+  /// worktree was. The loop's own binding is excluded from the assessment — it is the
+  /// thing being reclaimed, not a reason to keep the worktree — but any *other* loop
+  /// still pointing there keeps the worktree out of the safe tier, and automatic
+  /// removal never touches anything but the safe tier regardless of the policy.
+  private func resolveMoment(
+    for node: LoopNode, path: String, nodes: [LoopNode]
+  ) -> Effect<AppFeature.Action> {
+    guard let ref = node.worktreeBinding else { return .none }
+    let policy = worktreePolicyClient.policy(path)
+    guard policy.onResolveLanded != .keep else { return .none }
+    let others = nodes.filter { $0.id != node.id }
+    let title = node.title
+    let nodeID = node.id
+    return .run { send in
+      guard let inspections = try? await gitClient.inspectWorktrees(path),
+        let inspection = inspections.first(where: { $0.ref.worktreePath == ref.worktreePath })
+      else { return }
+      let assessment = WorktreeAssessment(
+        ref: inspection.ref,
+        facts: inspection.facts,
+        binding: WorktreeAssessment.binding(
+          forWorktreePath: ref.worktreePath, in: others),
+        loopTitle: title)
+      guard assessment.tier == .safeToRemove else { return }
+      switch policy.onResolveLanded {
+      case .remove:
+        try? await gitClient.removeWorktreeAndBranch(inspection.ref, inspection.facts.prunable)
+        await send(.worktrees(.statsReloadRequested(projectPath: path)))
+      case .ask:
+        await send(
+          .projects(
+            .element(
+              id: path,
+              action: .worktreeReclaimOffered(nodeID: nodeID, assessment: assessment))))
+      case .keep:
+        break
+      }
+    }
+  }
+}

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -71,6 +71,13 @@ struct AppFeature {
     var pendingChatRename: QuickChat? { chatPendingRename.flatMap { quickChats[id: $0] } }
     var pendingChatDeletion: QuickChat? { chatPendingDeletion.flatMap { quickChats[id: $0] } }
 
+    /// Worktree hygiene — see `AppFeature+Worktrees.swift`. The sweeper sheet, the
+    /// per-folder stats the lane chip and menus read, and the folder whose settings
+    /// sheet is up.
+    var worktreeSweep: WorktreeSweepFeature.State?
+    var worktreeStats: [String: WorktreeFolderStats] = [:]
+    var projectSettingsPath: String?
+
     /// Up on first launch (`.task` checks the persisted flag) and whenever the
     /// sidebar's help button asks for it again.
     var showingOnboarding = false
@@ -206,6 +213,8 @@ struct AppFeature {
     case updateInstallFailureDismissed
     case updateRelaunchTapped
     case updateRelaunchDismissed
+    /// Worktree hygiene, one case for the whole surface — see `AppFeature+Worktrees.swift`.
+    case worktrees(Worktrees)
     /// The Quick Chats section's actions — see `State.quickChats`.
     case newQuickChatTapped
     /// The Quick Chats header row: shows the chats' own canvas, the way a folder row
@@ -247,6 +256,10 @@ struct AppFeature {
     quickChatsReducer
     jumpPaletteReducer
     updatesReducer
+    // Before the main Reduce on purpose: its `.graphChanged` diff needs the previous
+    // graph, which the main reducer replaces. See `AppFeature+Worktrees.swift`.
+    AppWorktreesReducer()
+      .ifLet(\.worktreeSweep, action: \.worktrees.sweep) { WorktreeSweepFeature() }
     Reduce { state, action in
       switch action {
       case .task:
@@ -522,7 +535,7 @@ struct AppFeature {
         guard let path = state.openLoop?.projectPath else { return .none }
         return .send(.projects(.element(id: path, action: .nodeTapped(nodeID))))
 
-      case .openLoop, .welcome, .projects:
+      case .openLoop, .welcome, .projects, .worktrees:
         return .none
       }
     }

--- a/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
@@ -118,6 +118,8 @@ extension AppSidebarView {
     Button("Move Up") { store.send(.projectMoveUpTapped(project.id)) }
     Button("Move Down") { store.send(.projectMoveDownTapped(project.id)) }
     Divider()
+    FolderHygieneMenuItems(store: store, projectPath: project.id)
+    Divider()
     Button("Close") { store.send(.projectCloseTapped(project.id)) }
     Button("Remove from GraphCode") { store.send(.projectRemoveTapped(project.id)) }
     Divider()

--- a/graphcode/Sources/Features/App/AppView.swift
+++ b/graphcode/Sources/Features/App/AppView.swift
@@ -189,6 +189,9 @@ struct AppView: View {
     // alerts and an overlay on top of this chain is more than the type-checker will
     // sit through.
     .modifier(UpdateDialogs(store: store))
+    // The sweeper and a folder's settings — same hosting rule, own modifier for the
+    // same type-checker reason. See `WorktreeDialogs`.
+    .modifier(WorktreeDialogs(store: store))
   }
 
   /// The open loop's trailing panel, toggled from where macOS puts an inspector toggle.

--- a/graphcode/Sources/Features/App/GraphcodeCommands.swift
+++ b/graphcode/Sources/Features/App/GraphcodeCommands.swift
@@ -28,6 +28,18 @@ struct GraphcodeCommands: Commands {
   }
 
   var body: some Commands {
+    // `File ▸ Worktrees…` — the sweeper for the focused folder, same sheet the lane
+    // chip and the context menus open. In File because it is about the folder on disk,
+    // not about any loop.
+    CommandGroup(after: .newItem) {
+      Divider()
+      Button("Worktrees…") {
+        guard let path = focusedFolderPath else { return }
+        store.send(.worktrees(.sweepRequested(projectPath: path)))
+      }
+      .disabled(focusedFolderPath == nil)
+    }
+
     CommandMenu("Loop") {
       Button("Jump to Loop…") { store.send(.jumpPaletteRequested) }
         .keyboardShortcut("k", modifiers: .command)
@@ -87,6 +99,17 @@ struct GraphcodeCommands: Commands {
         .keyboardShortcut("[", modifiers: .command)
         .disabled(!isSplit)
     }
+  }
+
+  /// The folder `File ▸ Worktrees…` acts on: the open loop's, else the selected one —
+  /// and only a local folder, since the global graph and a remote project have nothing
+  /// on this disk to sweep.
+  private var focusedFolderPath: String? {
+    let candidate = store.openLoop?.projectPath ?? store.selectedProjectPath
+    guard let candidate, AppWorktreesReducer.tracksWorktrees(candidate),
+      store.projects[id: candidate] != nil
+    else { return nil }
+    return candidate
   }
 
   private var railTitle: String {

--- a/graphcode/Sources/Features/Canvas/CanvasBand.swift
+++ b/graphcode/Sources/Features/Canvas/CanvasBand.swift
@@ -59,6 +59,14 @@ enum CanvasBand {
   }
 }
 
+/// The lane caption's worktree chip, resolved to plain values: `6 worktrees · 4
+/// reclaimable`. Grey while the folder is under its notice threshold, amber once it
+/// isn't — and it stays a chip either way: no badge, no modal, no red.
+struct WorktreeChipModel: Equatable {
+  let text: String
+  let isNotice: Bool
+}
+
 /// One band, drawn behind everything else on the canvas.
 ///
 /// Hit-testing is off: the band covers the whole lane, so a band that took clicks would
@@ -73,6 +81,10 @@ struct CanvasBandView: View {
   /// that card's leading edge. The rail spans them and a stub reaches each one.
   var entryPorts: [CGPoint] = []
   var onCaptionTapped: (() -> Void)?
+  /// Disk is the same kind of fact about the same folder as the loop count beside it.
+  /// Tapping it opens the sweeper already scoped to this folder.
+  var worktreeChip: WorktreeChipModel?
+  var onWorktreeChipTapped: (() -> Void)?
 
   var body: some View {
     ZStack(alignment: .topLeading) {
@@ -181,11 +193,47 @@ struct CanvasBandView: View {
             .font(.system(size: 10.5, design: .monospaced))
             .foregroundStyle(.white.opacity(0.5))
         }
+        if let worktreeChip {
+          chip(worktreeChip)
+            .onTapGesture { onWorktreeChipTapped?() }
+        }
       }
       .lineLimit(1)
       .fixedSize()
       .contentShape(Rectangle())
       .onTapGesture { onCaptionTapped?() }
+    }
+  }
+
+  private func chip(_ model: WorktreeChipModel) -> some View {
+    HStack(spacing: 5) {
+      if model.isNotice {
+        Circle()
+          .fill(Color(red: 1.0, green: 0.624, blue: 0.039))
+          .frame(width: 5, height: 5)
+      }
+      Text(model.text)
+        .font(.system(size: 10, design: .monospaced))
+        .foregroundStyle(
+          model.isNotice
+            ? Color(red: 1.0, green: 0.804, blue: 0.478).opacity(0.92)
+            : .white.opacity(0.55))
+    }
+    .padding(.vertical, 1)
+    .padding(.horizontal, 7)
+    .background(
+      model.isNotice
+        ? Color(red: 1.0, green: 0.624, blue: 0.039).opacity(0.12)
+        : Color.white.opacity(0.05),
+      in: RoundedRectangle(cornerRadius: 5)
+    )
+    .overlay {
+      RoundedRectangle(cornerRadius: 5)
+        .stroke(
+          model.isNotice
+            ? Color(red: 1.0, green: 0.624, blue: 0.039).opacity(0.28)
+            : Color.white.opacity(0.12),
+          lineWidth: 1)
     }
   }
 }

--- a/graphcode/Sources/Features/Canvas/LoopCardPresentation.swift
+++ b/graphcode/Sources/Features/Canvas/LoopCardPresentation.swift
@@ -20,6 +20,11 @@ struct LoopCardPresentation: Equatable {
     case none
     case progress(Progress)
     case action(Action)
+    /// The resolve moment: the loop finished, its branch landed, and its worktree can
+    /// go — offered here, on the card that owns it, while the human still remembers
+    /// what it was. A launch-time modal asking about twenty forgotten branches is the
+    /// version people learn to dismiss.
+    case reclaim
   }
 
   struct Progress: Equatable {
@@ -43,11 +48,26 @@ struct LoopCardPresentation: Equatable {
   /// The footer, already ordered: kind, branch, backend when it isn't the default, age.
   let meta: [String]
 
-  init(node: LoopNode, now: Date = Date()) {
+  init(node: LoopNode, now: Date = Date(), reclaimOffer: WorktreeAssessment? = nil) {
     word = node.displayState.displayWord(for: node.loopType)
-    liveLine = Self.liveLine(node)
-    detail = Self.detail(node, now: now)
+    if let reclaimOffer, node.isResolved {
+      liveLine = Self.reclaimLine(reclaimOffer)
+      detail = .reclaim
+    } else {
+      liveLine = Self.liveLine(node)
+      detail = Self.detail(node, now: now)
+    }
     meta = Self.meta(node, now: now)
+  }
+
+  /// `"landed in main · 312 MB left behind"` — what happened, and what staying costs.
+  private static func reclaimLine(_ assessment: WorktreeAssessment) -> String {
+    let landed = "landed in \(assessment.facts.defaultBranch)"
+    guard let bytes = assessment.facts.sizeBytes, bytes > 0 else {
+      return "\(landed) · worktree left behind"
+    }
+    let size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    return "\(landed) · \(size) left behind"
   }
 
   // MARK: - Live line

--- a/graphcode/Sources/Features/Canvas/LoopCardView.swift
+++ b/graphcode/Sources/Features/Canvas/LoopCardView.swift
@@ -30,6 +30,11 @@ struct LoopCardView: View {
   /// The two verbs an unwired loop offers. Nothing else on the card uses them.
   var onWireUp: (() -> Void)?
   var onMarkAsEntry: (() -> Void)?
+  /// The resolve moment's offer, when this folder's policy is "Ask me" — see
+  /// `ProjectFeature.State.worktreeReclaimOffers`.
+  var reclaimOffer: WorktreeAssessment?
+  var onReclaim: (() -> Void)?
+  var onKeep: (() -> Void)?
 
   enum Metrics {
     static let size = CGSize(width: 250, height: 106)
@@ -48,7 +53,7 @@ struct LoopCardView: View {
   private var needsAttention: Bool { reason != nil }
 
   var body: some View {
-    let card = LoopCardPresentation(node: node, now: now)
+    let card = LoopCardPresentation(node: node, now: now, reclaimOffer: reclaimOffer)
     return VStack(alignment: .leading, spacing: 7) {
       titleRow
       if entryRole == .unwired {
@@ -171,6 +176,25 @@ struct LoopCardView: View {
           in: RoundedRectangle(cornerRadius: 5))
       }
       .buttonStyle(.plain)
+    case .reclaim:
+      // Quiet, not amber: the loop finished well, and nothing here is asking for
+      // rescue — just whether a directory that already landed should keep its disk.
+      HStack(spacing: 7) {
+        Button("Reclaim") { onReclaim?() }
+          .buttonStyle(.plain)
+          .font(.system(size: 11, weight: .semibold))
+          .foregroundStyle(.white.opacity(0.82))
+          .padding(.vertical, 3)
+          .padding(.horizontal, 9)
+          .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 5))
+          .overlay {
+            RoundedRectangle(cornerRadius: 5).stroke(.white.opacity(0.14), lineWidth: 1)
+          }
+        Button("Keep") { onKeep?() }
+          .buttonStyle(.plain)
+          .font(.system(size: 11, weight: .semibold))
+          .foregroundStyle(.white.opacity(0.5))
+      }
     }
   }
 

--- a/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
@@ -81,10 +81,37 @@ extension GraphOverviewView {
         // edit it. The overview is for seeing the whole thing, not for rewiring it. The
         // global lane leads nowhere: this view already *is* it.
         onCaptionTapped: folder.isGlobal
-          ? nil : { store.send(.projectHeaderTapped(folder.path)) }
+          ? nil : { store.send(.projectHeaderTapped(folder.path)) },
+        worktreeChip: worktreeChip(for: folder),
+        onWorktreeChipTapped: {
+          store.send(.worktrees(.sweepRequested(projectPath: folder.path)))
+        }
       )
       .help(folder.isGlobal ? "Loops that belong to no folder" : folder.path)
+      // Only the caption row takes hits (the band itself must not swallow canvas pans),
+      // so this is a right-click on the caption — the same menu, same position, as the
+      // sidebar row's, because the band is the folder.
+      .contextMenu {
+        if !folder.isGlobal {
+          FolderHygieneMenuItems(store: store, projectPath: folder.path)
+          Divider()
+          Button("Close Folder") { store.send(.projectCloseTapped(folder.path)) }
+        }
+      }
     }
+  }
+
+  /// `6 worktrees · 4 reclaimable` — absent entirely until the folder has a worktree,
+  /// amber only past the folder's own notice threshold. A repo with four worktrees is
+  /// working as designed.
+  private func worktreeChip(for folder: GraphOverview.Folder) -> WorktreeChipModel? {
+    guard !folder.isGlobal, let stats = store.worktreeStats[folder.path], stats.total > 0
+    else { return nil }
+    let policy = SettingsModel.shared.settings.worktreePolicy(forProjectPath: folder.path)
+    let count = stats.total == 1 ? "1 worktree" : "\(stats.total) worktrees"
+    return WorktreeChipModel(
+      text: stats.reclaimable > 0 ? "\(count) · \(stats.reclaimable) reclaimable" : count,
+      isNotice: stats.totalBytes >= policy.noticeSizeBytes || stats.total >= policy.noticeCount)
   }
 
   /// One card per loop, all of them clickable — a composite is drawn as the single loop
@@ -132,7 +159,18 @@ extension GraphOverviewView {
       // The overview is read-only — rewiring happens on the folder's own canvas, which
       // is where you can see what you are rewiring. Both verbs go there.
       onWireUp: { store.send(.projectHeaderTapped(loop.projectPath)) },
-      onMarkAsEntry: { store.send(.projectHeaderTapped(loop.projectPath)) }
+      onMarkAsEntry: { store.send(.projectHeaderTapped(loop.projectPath)) },
+      // The resolve moment reads the same here as on the folder's own canvas — the
+      // offer lives in that project's scope either way.
+      reclaimOffer: store.projects[id: loop.projectPath]?.worktreeReclaimOffers[node.id],
+      onReclaim: {
+        store.send(
+          .projects(.element(id: loop.projectPath, action: .reclaimWorktreeTapped(node.id))))
+      },
+      onKeep: {
+        store.send(
+          .projects(.element(id: loop.projectPath, action: .keepWorktreeTapped(node.id))))
+      }
     )
     .contentShape(Rectangle())
     .onTapGesture { open(loop) }

--- a/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
@@ -35,7 +35,10 @@ extension ProjectCanvasView {
       onPrimaryAction: { store.send(.nodeTapped(node.id)) },
       // Starts the same edge drag the hover handle does, from this card.
       onWireUp: { dragSourceID = node.id },
-      onMarkAsEntry: { store.send(.markAsEntryTapped(node.id)) }
+      onMarkAsEntry: { store.send(.markAsEntryTapped(node.id)) },
+      reclaimOffer: store.worktreeReclaimOffers[node.id],
+      onReclaim: { store.send(.reclaimWorktreeTapped(node.id)) },
+      onKeep: { store.send(.keepWorktreeTapped(node.id)) }
     )
     .contentShape(Rectangle())
     // A composite has no session of its own to open (`LoopNode.firstInstruction` is nil

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -119,6 +119,12 @@ struct ProjectFeature {
     /// never steals focus.
     var pendingCreatedNodeID: UUID?
 
+    /// Loops whose worktree can be reclaimed right now — set at the resolve moment when
+    /// the folder's policy is "Ask me" (see `AppWorktreesReducer`), read by the card's
+    /// inline Reclaim/Keep. Keyed by node id; an offer outlives nothing: it drops the
+    /// moment its loop is deleted or answered.
+    var worktreeReclaimOffers: [UUID: WorktreeAssessment] = [:]
+
     var id: String { graph.project.path }
 
     init(graph: LoopGraph) {
@@ -187,6 +193,13 @@ struct ProjectFeature {
     case refreshUsageTapped
     case worktreesLoaded([WorktreeRef])
     case worktreeCreationFailed(String)
+    /// The resolve moment, when this folder's policy is "Ask me" — the card offers
+    /// Reclaim/Keep while the human still remembers what the worktree was.
+    case worktreeReclaimOffered(nodeID: UUID, assessment: WorktreeAssessment)
+    /// Clearing the offer is this scope's job; the removal itself needs `GitClient`
+    /// and happens in `AppWorktreesReducer`, which intercepts the same action.
+    case reclaimWorktreeTapped(UUID)
+    case keepWorktreeTapped(UUID)
   }
 
   @Dependency(\.gitClient) var gitClient
@@ -221,6 +234,11 @@ struct ProjectFeature {
             state.nodePositions[node.id] = position
           }
           state.graph = newGraph
+          // An offer only makes sense while its loop exists, stays resolved, and still
+          // points at the worktree — a restarted or deleted loop takes it with it.
+          state.worktreeReclaimOffers = state.worktreeReclaimOffers.filter { id, _ in
+            newGraph.nodes[id: id].map { $0.isResolved && $0.worktreeBinding != nil } == true
+          }
           // Keep the human's sidebar arrangement across broadcasts: drop ids the graph
           // no longer has, append ones it gained, and touch nothing else.
           let currentIDs = Set(newGraph.nodes.map(\.id))
@@ -337,6 +355,17 @@ struct ProjectFeature {
 
       case .worktreesLoaded(let worktrees):
         state.availableWorktrees = worktrees
+        return .none
+
+      case .worktreeReclaimOffered(let nodeID, let assessment):
+        // Only for a loop that still exists and is still resolved — the assessment ran
+        // against a snapshot, and the graph may have moved since.
+        guard state.graph.nodes[id: nodeID]?.isResolved == true else { return .none }
+        state.worktreeReclaimOffers[nodeID] = assessment
+        return .none
+
+      case .reclaimWorktreeTapped(let nodeID), .keepWorktreeTapped(let nodeID):
+        state.worktreeReclaimOffers[nodeID] = nil
         return .none
 
       case .nodeTapped:

--- a/graphcode/Sources/Features/Welcome/RemoteRepositoryFormView.swift
+++ b/graphcode/Sources/Features/Welcome/RemoteRepositoryFormView.swift
@@ -17,9 +17,10 @@ struct RemoteRepositoryFormView: View {
         TextField("Server", text: field(\.server), prompt: Text("build-box.local"))
           .autocorrectionDisabled()
           .font(.system(.body, design: .monospaced))
-        TextField("User", text: field(\.user), prompt: Text("same as local — optional"))
+        TextField("User", text: field(\.user), prompt: Text("your login on the server"))
+          .autocorrectionDisabled()
           .font(.system(.body, design: .monospaced))
-        TextField("Port", text: field(\.port), prompt: Text("22 — optional"))
+        TextField("Port", text: field(\.port), prompt: Text("22"))
           .font(.system(.body, design: .monospaced))
         TextField(
           "Path", text: field(\.remotePath),

--- a/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
+++ b/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
@@ -65,8 +65,13 @@ struct WelcomeFeature {
   /// arrangement the clone form uses, for the same reason.
   struct RemoteDraft: Equatable {
     var server = ""
-    var port = ""
-    var user = ""
+    /// User and port are prefilled, not optional. Left empty they fell through to
+    /// whatever ssh guessed — the local username, port 22 — and on machines where the
+    /// remote side differs the dial silently went to the wrong place and surfaced
+    /// later as an unreachable project. Every new remote identity now carries the
+    /// whole dial explicitly; the prefills are just ssh's own defaults made visible.
+    var port = "22"
+    var user = NSUserName()
     var remotePath = ""
     var isValidating = false
     var failureMessage: String?
@@ -80,12 +85,11 @@ struct WelcomeFeature {
       let path = remotePath.trimmingCharacters(in: .whitespaces)
       let userName = user.trimmingCharacters(in: .whitespaces)
       let portText = port.trimmingCharacters(in: .whitespaces)
-      guard !host.isEmpty, path.hasPrefix("/") else { return nil }
-      let portNumber = portText.isEmpty ? nil : Int(portText)
-      if !portText.isEmpty, portNumber == nil { return nil }
+      guard !host.isEmpty, path.hasPrefix("/"), !userName.isEmpty,
+        let portNumber = Int(portText), (1...65535).contains(portNumber)
+      else { return nil }
       return RemoteProjectLocation(
-        user: userName.isEmpty ? nil : userName, host: host, port: portNumber,
-        remotePath: path)
+        user: userName, host: host, port: portNumber, remotePath: path)
     }
 
     var canSubmit: Bool { location != nil && !isValidating }

--- a/graphcode/Sources/Features/Worktrees/FolderMenuItems.swift
+++ b/graphcode/Sources/Features/Worktrees/FolderMenuItems.swift
@@ -1,0 +1,34 @@
+import AppKit
+import ComposableArchitecture
+import SwiftUI
+
+/// The folder verbs worktree hygiene adds, shared between the sidebar row's menu and
+/// the lane caption's — a lane band *is* the folder, so right-clicking either place
+/// must offer the same things.
+///
+/// The trailing count on `Worktrees…` is the whole reason the item earns a slot: it
+/// answers "is there anything to reclaim" without opening anything. With nothing
+/// reclaimable the item stays, without a count.
+struct FolderHygieneMenuItems: View {
+  let store: StoreOf<AppFeature>
+  let projectPath: String
+
+  var body: some View {
+    if AppWorktreesReducer.tracksWorktrees(projectPath) {
+      Button(worktreesTitle) {
+        store.send(.worktrees(.sweepRequested(projectPath: projectPath)))
+      }
+      Button("Project Settings…") {
+        store.send(.worktrees(.settingsRequested(projectPath: projectPath)))
+      }
+      Button("Open in Finder") {
+        NSWorkspace.shared.open(URL(fileURLWithPath: projectPath))
+      }
+    }
+  }
+
+  private var worktreesTitle: String {
+    let reclaimable = store.worktreeStats[projectPath]?.reclaimable ?? 0
+    return reclaimable > 0 ? "Worktrees… \(reclaimable)" : "Worktrees…"
+  }
+}

--- a/graphcode/Sources/Features/Worktrees/ProjectSettingsView.swift
+++ b/graphcode/Sources/Features/Worktrees/ProjectSettingsView.swift
@@ -1,0 +1,128 @@
+import GraphcodeKit
+import SwiftUI
+
+/// One folder's settings — today, its worktree policy. The policy is the real fix the
+/// sweeper only backstops: a user who sets "Remove it" once never sees the sweeper
+/// again, which is the outcome to design for, not a cleanup screen they visit monthly.
+///
+/// Writes through `SettingsModel.shared` the way the app-wide settings scene does, so
+/// every change lands in `~/.graphcode/settings.json` the moment it is made.
+struct ProjectSettingsView: View {
+  let projectPath: String
+  let projectName: String
+
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      HStack(alignment: .firstTextBaseline, spacing: 9) {
+        Text("Project Settings")
+          .font(.system(size: 16, weight: .semibold))
+          .foregroundStyle(.white.opacity(0.95))
+        Text(projectName)
+          .font(.system(size: 12))
+          .foregroundStyle(.white.opacity(0.5))
+      }
+
+      VStack(alignment: .leading, spacing: 11) {
+        Text("WORKTREES")
+          .font(.system(size: 11, weight: .bold))
+          .tracking(0.66)
+          .foregroundStyle(.white.opacity(0.55))
+
+        VStack(alignment: .leading, spacing: 7) {
+          Text("When a loop resolves and its branch has landed")
+            .font(.system(size: 11.5, weight: .semibold))
+            .foregroundStyle(.white.opacity(0.85))
+          Picker("", selection: resolveAction) {
+            ForEach(WorktreeHygienePolicy.ResolveAction.allCases, id: \.self) { action in
+              Text(action.displayName).tag(action)
+            }
+          }
+          .pickerStyle(.segmented)
+          .labelsHidden()
+          Text(
+            "Only ever the safe tier — landed, clean, pushed, and bound to no loop. "
+              + "Anything else waits for you regardless of this setting."
+          )
+          .font(.system(size: 11))
+          .foregroundStyle(.white.opacity(0.6))
+        }
+
+        Divider().overlay(.white.opacity(0.08))
+
+        VStack(alignment: .leading, spacing: 7) {
+          Text("Mention it on the lane when this folder passes")
+            .font(.system(size: 11.5, weight: .semibold))
+            .foregroundStyle(.white.opacity(0.85))
+          HStack(spacing: 9) {
+            TextField("", value: noticeGigabytes, format: .number)
+              .textFieldStyle(.roundedBorder)
+              .frame(width: 64)
+            Text("GB").font(.system(size: 12)).foregroundStyle(.white.opacity(0.6))
+            Text("or").font(.system(size: 12)).foregroundStyle(.white.opacity(0.6))
+            TextField("", value: noticeCount, format: .number)
+              .textFieldStyle(.roundedBorder)
+              .frame(width: 64)
+            Text("worktrees").font(.system(size: 12)).foregroundStyle(.white.opacity(0.6))
+          }
+          Text(
+            "A repo with four worktrees is working as designed. The chip appears when "
+              + "the folder is genuinely accumulating — and it stays a chip: no badge, "
+              + "no modal, no red."
+          )
+          .font(.system(size: 11))
+          .foregroundStyle(.white.opacity(0.6))
+        }
+      }
+      .padding(15)
+      .background(Theme.draftField, in: RoundedRectangle(cornerRadius: 11))
+      .overlay {
+        RoundedRectangle(cornerRadius: 11).stroke(.white.opacity(0.1), lineWidth: 1)
+      }
+
+      HStack {
+        Spacer()
+        Button("Done") { dismiss() }
+          .keyboardShortcut(.defaultAction)
+      }
+    }
+    .padding(.horizontal, 22)
+    .padding(.top, 20)
+    .padding(.bottom, 18)
+    .frame(width: 470)
+    .background(Theme.sheet)
+  }
+
+  private var policy: WorktreeHygienePolicy {
+    SettingsModel.shared.settings.worktreePolicy(forProjectPath: projectPath)
+  }
+
+  private func update(_ transform: (inout WorktreeHygienePolicy) -> Void) {
+    var updated = policy
+    transform(&updated)
+    SettingsModel.shared.settings.worktreePolicies[projectPath] = updated
+  }
+
+  private var resolveAction: Binding<WorktreeHygienePolicy.ResolveAction> {
+    Binding(
+      get: { policy.onResolveLanded },
+      set: { action in update { $0.onResolveLanded = action } })
+  }
+
+  /// Whole gigabytes are the honest granularity here: the threshold is a "genuinely
+  /// accumulating" line, not an accounting figure.
+  private var noticeGigabytes: Binding<Int> {
+    Binding(
+      get: { Int((Double(policy.noticeSizeBytes) / Double(1 << 30)).rounded()) },
+      set: { gigabytes in
+        update { $0.noticeSizeBytes = Int64(max(gigabytes, 1)) * Int64(1 << 30) }
+      })
+  }
+
+  private var noticeCount: Binding<Int> {
+    Binding(
+      get: { policy.noticeCount },
+      set: { count in update { $0.noticeCount = max(count, 1) } })
+  }
+}

--- a/graphcode/Sources/Features/Worktrees/WorktreeDialogs.swift
+++ b/graphcode/Sources/Features/Worktrees/WorktreeDialogs.swift
@@ -1,0 +1,35 @@
+import ComposableArchitecture
+import SwiftUI
+
+/// Hosts the two worktree-hygiene sheets on `AppView` — the sweeper and a folder's
+/// settings. In a modifier of its own for the reason `UpdateDialogs` is: both must open
+/// over a terminal as readily as over a canvas, and `AppView`'s dialog chain is already
+/// more than the type-checker will sit through.
+struct WorktreeDialogs: ViewModifier {
+  @Bindable var store: StoreOf<AppFeature>
+
+  func body(content: Content) -> some View {
+    content
+      .sheet(
+        isPresented: Binding(
+          get: { store.worktreeSweep != nil },
+          set: { if !$0 { store.send(.worktrees(.sweepDismissed)) } })
+      ) {
+        if let sweepStore = store.scope(state: \.worktreeSweep, action: \.worktrees.sweep) {
+          WorktreeSweepView(store: sweepStore)
+        }
+      }
+      .sheet(
+        isPresented: Binding(
+          get: { store.projectSettingsPath != nil },
+          set: { if !$0 { store.send(.worktrees(.settingsDismissed)) } })
+      ) {
+        if let path = store.projectSettingsPath {
+          ProjectSettingsView(
+            projectPath: path,
+            projectName: store.projects[id: path]?.graph.project.name
+              ?? (path as NSString).lastPathComponent)
+        }
+      }
+  }
+}

--- a/graphcode/Sources/Features/Worktrees/WorktreeSweepFeature.swift
+++ b/graphcode/Sources/Features/Worktrees/WorktreeSweepFeature.swift
@@ -1,0 +1,159 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+
+/// The worktree sweeper for one folder — the backlog fix, next to the policy that is the
+/// real one (`WorktreeHygienePolicy`).
+///
+/// Always scoped to a single folder: every route in (lane chip, context menu, File menu)
+/// opens it already knowing which project it is about, so there is no all-projects list
+/// to re-filter. Groups by `WorktreeTier` — what removing would lose — never by age.
+@Reducer
+struct WorktreeSweepFeature {
+  @ObservableState
+  struct State: Equatable, Identifiable {
+    let projectPath: String
+    let projectName: String
+    /// The graph's loops at the moment the sheet opened — what `unbound` is read from.
+    let nodes: [LoopNode]
+    /// `nil` while the first inspection runs; empty for a folder with no worktrees.
+    var assessments: [WorktreeAssessment]?
+    /// Selected worktree paths. The safe tier starts fully selected; the look tier is
+    /// never preselected; the in-use tier is not selectable at all.
+    var selection: Set<String> = []
+    var isRemoving = false
+    var failure: String?
+
+    var id: String { projectPath }
+
+    var safe: [WorktreeAssessment] { tiered(.safeToRemove) }
+    var look: [WorktreeAssessment] { tiered(.lookBeforeRemoving) }
+    var inUse: [WorktreeAssessment] { tiered(.inUse) }
+
+    var selected: [WorktreeAssessment] {
+      (assessments ?? []).filter { $0.tier != .inUse && selection.contains($0.id) }
+    }
+    var selectedBytes: Int64 {
+      selected.compactMap(\.facts.sizeBytes).reduce(0, +)
+    }
+    var totalBytes: Int64 {
+      (assessments ?? []).compactMap(\.facts.sizeBytes).reduce(0, +)
+    }
+
+    private func tiered(_ tier: WorktreeTier) -> [WorktreeAssessment] {
+      (assessments ?? []).filter { $0.tier == tier }
+    }
+  }
+
+  enum Action {
+    case task
+    case assessmentsLoaded([WorktreeAssessment])
+    case loadFailed(String)
+    case rowToggled(String)
+    case allSafeToggled
+    case removeTapped
+    case removalFinished(failure: String?)
+  }
+
+  @Dependency(\.gitClient) var gitClient
+
+  var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .task:
+        let path = state.projectPath
+        let nodes = state.nodes
+        return .run { send in
+          do {
+            let inspections = try await gitClient.inspectWorktrees(path)
+            await send(.assessmentsLoaded(Self.assessments(inspections, nodes: nodes)))
+          } catch {
+            await send(.loadFailed(String(describing: error)))
+          }
+        }
+
+      case .assessmentsLoaded(let assessments):
+        state.assessments = assessments
+        // Preselect the safe tier only — and only on the first load, so a refresh after
+        // a removal doesn't quietly re-tick boxes the human just made a decision about.
+        if state.selection.isEmpty && !state.isRemoving {
+          state.selection = Set(assessments.filter { $0.tier == .safeToRemove }.map(\.id))
+        } else {
+          state.selection.formIntersection(assessments.map(\.id))
+        }
+        state.isRemoving = false
+        return .none
+
+      case .loadFailed(let message):
+        state.assessments = state.assessments ?? []
+        state.isRemoving = false
+        state.failure = message
+        return .none
+
+      case .rowToggled(let id):
+        guard let assessment = state.assessments?.first(where: { $0.id == id }),
+          assessment.tier != .inUse
+        else { return .none }
+        if state.selection.contains(id) {
+          state.selection.remove(id)
+        } else {
+          state.selection.insert(id)
+        }
+        return .none
+
+      case .allSafeToggled:
+        let safeIDs = state.safe.map(\.id)
+        if safeIDs.allSatisfy({ state.selection.contains($0) }) {
+          state.selection.subtract(safeIDs)
+        } else {
+          state.selection.formUnion(safeIDs)
+        }
+        return .none
+
+      case .removeTapped:
+        let doomed = state.selected
+        guard !doomed.isEmpty, !state.isRemoving else { return .none }
+        state.isRemoving = true
+        state.failure = nil
+        return .run { send in
+          var failures: [String] = []
+          for assessment in doomed {
+            do {
+              try await gitClient.removeWorktreeAndBranch(
+                assessment.ref, assessment.facts.prunable)
+            } catch {
+              failures.append("\(assessment.ref.branch): \(String(describing: error))")
+            }
+          }
+          await send(
+            .removalFinished(failure: failures.isEmpty ? nil : failures.joined(separator: "\n")))
+        }
+
+      case .removalFinished(let failure):
+        state.failure = failure
+        state.selection = []
+        // Re-read rather than locally pruning the list: git is the authority on what a
+        // removal actually left behind.
+        return .send(.task)
+      }
+    }
+  }
+
+  /// Joins one folder's git facts with what only graphcode knows — which loops still
+  /// point at each worktree.
+  static func assessments(
+    _ inspections: [WorktreeInspection], nodes: [LoopNode]
+  ) -> [WorktreeAssessment] {
+    inspections.map { inspection in
+      let owner = nodes.first {
+        $0.worktreeBinding?.worktreePath == inspection.ref.worktreePath
+      }
+      return WorktreeAssessment(
+        ref: inspection.ref,
+        facts: inspection.facts,
+        binding: WorktreeAssessment.binding(
+          forWorktreePath: inspection.ref.worktreePath, in: nodes),
+        loopTitle: owner?.title)
+    }
+  }
+}

--- a/graphcode/Sources/Features/Worktrees/WorktreeSweepView.swift
+++ b/graphcode/Sources/Features/Worktrees/WorktreeSweepView.swift
@@ -1,0 +1,277 @@
+import AppKit
+import ComposableArchitecture
+import GraphcodeKit
+import SwiftUI
+
+/// The sweeper sheet — one folder's worktrees, grouped by what removing them would lose.
+///
+/// The grouping is the interface: safe rows arrive selected, look-before rows never do,
+/// and in-use rows can't be selected at all. The footer says exactly what the button
+/// will do before it does it, and the footnote carries the two safety facts (fully
+/// committed directories only; branches recoverable from the reflog).
+struct WorktreeSweepView: View {
+  @Bindable var store: StoreOf<WorktreeSweepFeature>
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 15) {
+      header
+      if let assessments = store.assessments {
+        if assessments.isEmpty {
+          emptyState
+        } else {
+          ScrollView {
+            VStack(alignment: .leading, spacing: 15) {
+              tierSection(
+                title: "Safe to remove", tint: Tint.safe, assessments: store.safe,
+                headerAccessory: safeSelectionToggle)
+              tierSection(
+                title: "Look before removing", tint: Tint.look, assessments: store.look)
+              tierSection(title: "In use", tint: Tint.inUse, assessments: store.inUse)
+            }
+          }
+          .frame(maxHeight: 460)
+        }
+      } else {
+        loadingState
+      }
+      if let failure = store.failure {
+        Text(failure)
+          .font(.system(size: 11))
+          .foregroundStyle(Color(red: 1.0, green: 0.541, blue: 0.502))
+          .lineLimit(3)
+      }
+      Divider().overlay(.white.opacity(0.08))
+      footer
+      Text(
+        "Branches are deleted too, and stay recoverable from the reflog for 90 days. "
+          + "Only directories whose contents are fully committed are ever removed."
+      )
+      .font(.system(size: 11))
+      .foregroundStyle(.white.opacity(0.5))
+    }
+    .padding(.horizontal, 22)
+    .padding(.top, 20)
+    .padding(.bottom, 18)
+    .frame(width: 640)
+    .background(Theme.sheet)
+    .task { await store.send(.task).finish() }
+  }
+
+  private enum Tint {
+    static let safe = Color(red: 0.494, green: 0.894, blue: 0.608)
+    static let look = Color(red: 1.0, green: 0.804, blue: 0.478)
+    static let inUse = Color.white.opacity(0.45)
+    static let safeFill = Color(red: 0.188, green: 0.820, blue: 0.345).opacity(0.06)
+    static let safeBorder = Color(red: 0.188, green: 0.820, blue: 0.345).opacity(0.2)
+    static let lookFill = Color(red: 1.0, green: 0.624, blue: 0.039).opacity(0.07)
+    static let lookBorder = Color(red: 1.0, green: 0.624, blue: 0.039).opacity(0.24)
+    static let inUseFill = Color.white.opacity(0.02)
+    static let inUseBorder = Color.white.opacity(0.07)
+  }
+
+  private var header: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 9) {
+      Text("Worktrees")
+        .font(.system(size: 16, weight: .semibold))
+        .foregroundStyle(.white.opacity(0.95))
+      Text(headerCaption)
+        .font(.system(size: 12))
+        .foregroundStyle(.white.opacity(0.5))
+    }
+  }
+
+  private var headerCaption: String {
+    guard let assessments = store.assessments, !assessments.isEmpty else {
+      return "in \(store.projectName)"
+    }
+    let count = assessments.count == 1 ? "1 of them" : "\(assessments.count) of them"
+    guard store.totalBytes > 0 else { return "in \(store.projectName) · \(count)" }
+    return "in \(store.projectName) · \(count) · \(Self.size(store.totalBytes)) total"
+  }
+
+  @ViewBuilder
+  private func tierSection(
+    title: String, tint: Color, assessments: [WorktreeAssessment],
+    headerAccessory: (() -> AnyView)? = nil
+  ) -> some View {
+    if !assessments.isEmpty {
+      VStack(alignment: .leading, spacing: 8) {
+        HStack(spacing: 8) {
+          Text(title.uppercased())
+            .font(.system(size: 11, weight: .bold))
+            .tracking(0.66)
+            .foregroundStyle(tint.opacity(0.85))
+          Text(sectionCount(assessments))
+            .font(.system(size: 10.5, design: .monospaced))
+            .foregroundStyle(.white.opacity(0.5))
+          Spacer()
+          if let headerAccessory { headerAccessory() }
+        }
+        ForEach(assessments) { assessment in
+          row(assessment)
+        }
+      }
+    }
+  }
+
+  private func sectionCount(_ assessments: [WorktreeAssessment]) -> String {
+    let bytes = assessments.compactMap(\.facts.sizeBytes).reduce(0, +)
+    guard bytes > 0 else { return "\(assessments.count)" }
+    return "\(assessments.count) · \(Self.size(bytes))"
+  }
+
+  private var safeSelectionToggle: (() -> AnyView)? {
+    guard store.safe.count > 1 else { return nil }
+    let allSelected = store.safe.allSatisfy { store.selection.contains($0.id) }
+    return {
+      AnyView(
+        Button(allSelected ? "Deselect all" : "Select all") {
+          store.send(.allSafeToggled)
+        }
+        .buttonStyle(.plain)
+        .font(.system(size: 11.5, weight: .semibold))
+        .foregroundStyle(Color(red: 0.424, green: 0.714, blue: 1.0)))
+    }
+  }
+
+  private func row(_ assessment: WorktreeAssessment) -> some View {
+    let tier = assessment.tier
+    let selected = tier != .inUse && store.selection.contains(assessment.id)
+    return HStack(spacing: 11) {
+      checkbox(selected: selected, selectable: tier != .inUse)
+      VStack(alignment: .leading, spacing: 3) {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+          Text(assessment.ref.branch)
+            .font(.system(size: 12, design: .monospaced))
+            .foregroundStyle(.white.opacity(tier == .inUse ? 0.6 : 0.9))
+          if let context = rowContext(assessment) {
+            Text(context)
+              .font(.system(size: 11.5))
+              .foregroundStyle(.white.opacity(tier == .inUse ? 0.45 : 0.55))
+          }
+        }
+        Text(assessment.summary)
+          .font(.system(size: 10.5, design: .monospaced))
+          .foregroundStyle(summaryInk(tier))
+      }
+      .lineLimit(1)
+      Spacer(minLength: 8)
+      if tier == .lookBeforeRemoving && !assessment.facts.prunable {
+        Button("Reveal") {
+          NSWorkspace.shared.activateFileViewerSelecting([
+            URL(fileURLWithPath: assessment.ref.worktreePath)
+          ])
+        }
+        .buttonStyle(.plain)
+        .font(.system(size: 11.5, weight: .semibold))
+        .foregroundStyle(Color(red: 0.424, green: 0.714, blue: 1.0))
+      }
+      Text(assessment.facts.sizeBytes.map(Self.size) ?? "—")
+        .font(.system(size: 11, design: .monospaced))
+        .foregroundStyle(.white.opacity(assessment.facts.sizeBytes == nil ? 0.4 : 0.55))
+    }
+    .padding(.vertical, 9)
+    .padding(.horizontal, 11)
+    .background(rowFill(tier), in: RoundedRectangle(cornerRadius: 9))
+    .overlay {
+      RoundedRectangle(cornerRadius: 9).stroke(rowBorder(tier), lineWidth: 1)
+    }
+    .contentShape(Rectangle())
+    .onTapGesture {
+      if tier != .inUse { store.send(.rowToggled(assessment.id)) }
+    }
+  }
+
+  private func rowContext(_ assessment: WorktreeAssessment) -> String? {
+    if assessment.facts.prunable { return "directory already gone" }
+    return assessment.loopTitle
+  }
+
+  private func summaryInk(_ tier: WorktreeTier) -> Color {
+    switch tier {
+    case .safeToRemove: return Tint.safe.opacity(0.8)
+    case .lookBeforeRemoving: return Tint.look.opacity(0.85)
+    case .inUse: return .white.opacity(0.45)
+    }
+  }
+
+  private func rowFill(_ tier: WorktreeTier) -> Color {
+    switch tier {
+    case .safeToRemove: return Tint.safeFill
+    case .lookBeforeRemoving: return Tint.lookFill
+    case .inUse: return Tint.inUseFill
+    }
+  }
+
+  private func rowBorder(_ tier: WorktreeTier) -> Color {
+    switch tier {
+    case .safeToRemove: return Tint.safeBorder
+    case .lookBeforeRemoving: return Tint.lookBorder
+    case .inUse: return Tint.inUseBorder
+    }
+  }
+
+  private func checkbox(selected: Bool, selectable: Bool) -> some View {
+    ZStack {
+      if selected {
+        RoundedRectangle(cornerRadius: 4).fill(Color.accentColor)
+        Image(systemName: "checkmark")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundStyle(.white)
+      } else {
+        RoundedRectangle(cornerRadius: 4)
+          .strokeBorder(.white.opacity(selectable ? 0.28 : 0.14), lineWidth: 1.5)
+      }
+    }
+    .frame(width: 15, height: 15)
+  }
+
+  private var footer: some View {
+    HStack(spacing: 12) {
+      Text(footerSummary)
+        .font(.system(size: 12))
+        .foregroundStyle(.white.opacity(0.62))
+      Spacer()
+      Button("Cancel") { dismiss() }
+        .keyboardShortcut(.cancelAction)
+      Button(removeTitle) { store.send(.removeTapped) }
+        .keyboardShortcut(.defaultAction)
+        .disabled(store.selected.isEmpty || store.isRemoving)
+    }
+  }
+
+  private var footerSummary: String {
+    let count = store.selected.count
+    guard count > 0 else { return "Nothing selected" }
+    let what = count == 1 ? "1 worktree" : "\(count) worktrees"
+    guard store.selectedBytes > 0 else { return "Removes \(what)" }
+    return "Removes \(what) · frees \(Self.size(store.selectedBytes))"
+  }
+
+  private var removeTitle: String {
+    store.isRemoving ? "Removing…" : "Remove \(store.selected.count)"
+  }
+
+  /// `412 MB`, the way the Finder would say it.
+  static func size(_ bytes: Int64) -> String {
+    ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+  }
+
+  private var loadingState: some View {
+    HStack(spacing: 8) {
+      ProgressView().controlSize(.small)
+      Text("Reading worktrees…")
+        .font(.system(size: 12))
+        .foregroundStyle(.white.opacity(0.55))
+    }
+    .frame(maxWidth: .infinity, minHeight: 80)
+  }
+
+  private var emptyState: some View {
+    Text("No worktrees in this folder.")
+      .font(.system(size: 12))
+      .foregroundStyle(.white.opacity(0.55))
+      .frame(maxWidth: .infinity, minHeight: 80)
+  }
+}

--- a/graphcode/Tests/RemoteRepositoryTests.swift
+++ b/graphcode/Tests/RemoteRepositoryTests.swift
@@ -203,8 +203,11 @@ struct RemoteRepositoryTests {
   // MARK: - The add form
 
   @Test
-  func theDraftRequiresAHostAndAnAbsolutePath() {
+  func theDraftRequiresAHostAnAbsolutePathAndTheWholeDial() {
     var draft = WelcomeFeature.RemoteDraft()
+    // User and port arrive prefilled with ssh's own defaults — visible, not implied.
+    #expect(!draft.user.isEmpty)
+    #expect(draft.port == "22")
     #expect(!draft.canSubmit)
     draft.server = "build-box"
     draft.remotePath = "~/widget"
@@ -213,6 +216,15 @@ struct RemoteRepositoryTests {
     draft.remotePath = "/home/dev/widget"
     #expect(draft.canSubmit)
     draft.port = "not-a-port"
+    #expect(draft.location == nil)
+    draft.port = "22"
+    // Clearing either half of the dial blocks submission: left empty they fell through
+    // to whatever ssh guessed, and on machines where the remote side differs the dial
+    // silently went to the wrong place.
+    draft.user = ""
+    #expect(draft.location == nil)
+    draft.user = "dev"
+    draft.port = ""
     #expect(draft.location == nil)
   }
 
@@ -241,7 +253,8 @@ struct RemoteRepositoryTests {
     await store.finish()
 
     #expect(store.state.remoteDraft == nil)
-    #expect(await opened.paths == ["ssh://dev@build-box/home/dev/widget"])
+    // The port rides in the identity now — every new remote path carries the full dial.
+    #expect(await opened.paths == ["ssh://dev@build-box:22/home/dev/widget"])
   }
 
   @Test

--- a/graphcode/Tests/WorktreeHygieneTests.swift
+++ b/graphcode/Tests/WorktreeHygieneTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// The worktree classifier — the part of hygiene that has to be right. A worktree
+/// wrongly called safe is someone's unpushed work deleted; one wrongly called unsafe
+/// just makes the safe group smaller. Every rule here leans the second way.
+@Suite
+struct WorktreeHygieneTests {
+  private func ref(_ branch: String = "fix-thing") -> WorktreeRef {
+    WorktreeRef(
+      id: branch, repositoryPath: "/repo", worktreePath: "/repo-\(branch)", branch: branch)
+  }
+
+  private func facts(
+    notLanded: Int = 0, dirty: Int = 0, pushed: Bool = true, prunable: Bool = false,
+    size: Int64? = 100
+  ) -> WorktreeGitFacts {
+    WorktreeGitFacts(
+      defaultBranch: "main", commitsNotLanded: notLanded, dirtyFileCount: dirty,
+      pushed: pushed, prunable: prunable, sizeBytes: size)
+  }
+
+  private func node(
+    boundTo worktree: WorktreeRef?, state: LoopState, title: String = "Usage"
+  ) -> LoopNode {
+    LoopNode(title: title, loopType: .goalBased, worktreeBinding: worktree, state: state)
+  }
+
+  @Test
+  func landedCleanPushedAndUnboundIsSafe() {
+    let assessment = WorktreeAssessment(ref: ref(), facts: facts(), binding: .none)
+
+    #expect(assessment.tier == .safeToRemove)
+    #expect(assessment.summary == "landed in main · clean tree · no loop bound")
+  }
+
+  @Test
+  func eachMissingSignalDropsToLookBeforeRemoving() {
+    // One at a time, because the trap is a classifier that only checks some of them.
+    #expect(
+      WorktreeAssessment(ref: ref(), facts: facts(notLanded: 4), binding: .none).tier
+        == .lookBeforeRemoving)
+    #expect(
+      WorktreeAssessment(ref: ref(), facts: facts(dirty: 2), binding: .none).tier
+        == .lookBeforeRemoving)
+    #expect(
+      WorktreeAssessment(ref: ref(), facts: facts(pushed: false), binding: .none).tier
+        == .lookBeforeRemoving)
+    #expect(
+      WorktreeAssessment(
+        ref: ref(), facts: facts(), binding: .stopped(loopTitle: "looper")
+      ).tier == .lookBeforeRemoving)
+  }
+
+  @Test
+  func aRunningLoopMakesItInUseWhateverGitSays() {
+    let assessment = WorktreeAssessment(
+      ref: ref(), facts: facts(), binding: .running(loopTitle: "Monitoring"))
+
+    #expect(assessment.tier == .inUse)
+    #expect(assessment.summary == "a loop is running in it")
+  }
+
+  @Test
+  func prunableIsAlwaysSafeAndSaysWhy() {
+    // Admin file with no directory: nothing on disk to lose, even with a stopped loop
+    // still pointing at the path it used to be.
+    let assessment = WorktreeAssessment(
+      ref: ref(), facts: facts(prunable: true, size: nil),
+      binding: .stopped(loopTitle: "old"))
+
+    #expect(assessment.tier == .safeToRemove)
+    #expect(assessment.summary == "stale admin file · nothing on disk to lose")
+  }
+
+  @Test
+  func theLookSummaryNamesWhatWouldBeLost() {
+    let unmergedAndDirty = WorktreeAssessment(
+      ref: ref(), facts: facts(notLanded: 4, dirty: 2), binding: .none)
+    #expect(unmergedAndDirty.summary == "4 commits not in main · 2 files uncommitted")
+
+    let onlyBound = WorktreeAssessment(
+      ref: ref(), facts: facts(), binding: .stopped(loopTitle: "looper"))
+    #expect(onlyBound.summary == "merged · but a stopped loop still points here")
+
+    let unpushed = WorktreeAssessment(ref: ref(), facts: facts(pushed: false), binding: .none)
+    #expect(unpushed.summary == "not pushed")
+  }
+
+  @Test
+  func bindingComesFromLoopsRunningOrStopped() {
+    let worktree = ref()
+    let running = node(boundTo: worktree, state: .running)
+    let stopped = node(boundTo: worktree, state: .stopped, title: "old")
+    let unrelated = node(boundTo: ref("other"), state: .running)
+
+    // A running loop outranks a stopped one pointing at the same path.
+    #expect(
+      WorktreeAssessment.binding(
+        forWorktreePath: worktree.worktreePath, in: [stopped, running, unrelated])
+        == .running(loopTitle: "Usage"))
+    #expect(
+      WorktreeAssessment.binding(forWorktreePath: worktree.worktreePath, in: [stopped])
+        == .stopped(loopTitle: "old"))
+    #expect(
+      WorktreeAssessment.binding(forWorktreePath: worktree.worktreePath, in: [unrelated])
+        == WorktreeLoopBinding.none)
+  }
+
+  @Test
+  func aResolvedLoopStillCountsAsStopped() {
+    // The whole reason this lives in graphcode: git cannot know a succeeded loop's
+    // binding still names this directory.
+    let worktree = ref()
+    let done = node(boundTo: worktree, state: .succeeded)
+
+    #expect(
+      WorktreeAssessment.binding(forWorktreePath: worktree.worktreePath, in: [done])
+        == .stopped(loopTitle: "Usage"))
+  }
+
+  @Test
+  func aReclaimOfferTurnsTheCardIntoTheResolveMoment() {
+    let offer = WorktreeAssessment(
+      ref: ref(), facts: facts(size: 312 * 1024 * 1024), binding: .none)
+    let done = node(boundTo: ref(), state: .succeeded)
+
+    let card = LoopCardPresentation(node: done, reclaimOffer: offer)
+
+    #expect(card.detail == .reclaim)
+    #expect(card.liveLine?.hasPrefix("landed in main") == true)
+    #expect(card.liveLine?.hasSuffix("left behind") == true)
+  }
+
+  @Test
+  func anOfferOnAnUnresolvedLoopIsIgnored() {
+    // The graph moved between the assessment and the render — a restarted loop's card
+    // must not offer to delete the worktree it is working in.
+    let offer = WorktreeAssessment(ref: ref(), facts: facts(), binding: .none)
+    let running = node(boundTo: ref(), state: .running)
+
+    #expect(LoopCardPresentation(node: running, reclaimOffer: offer).detail != .reclaim)
+  }
+
+  @Test
+  func policyDecodesFromAnEmptyObjectWithDefaults() throws {
+    let policy = try JSONDecoder().decode(
+      WorktreeHygienePolicy.self, from: Data("{}".utf8))
+
+    #expect(policy.onResolveLanded == .ask)
+    #expect(policy.noticeSizeBytes == 2 << 30)
+    #expect(policy.noticeCount == 8)
+  }
+
+  @Test
+  func settingsWithoutPoliciesDecodeToEmptyAndAnswerTheDefault() throws {
+    let settings = try JSONDecoder().decode(
+      GraphcodeSettings.self, from: Data("{}".utf8))
+
+    #expect(settings.worktreePolicies.isEmpty)
+    #expect(settings.worktreePolicy(forProjectPath: "/anything").onResolveLanded == .ask)
+  }
+
+  @Test
+  func settingsRoundTripKeepsAFolderPolicy() throws {
+    var settings = GraphcodeSettings()
+    settings.worktreePolicies["/repo"] = WorktreeHygienePolicy(
+      onResolveLanded: .remove, noticeSizeBytes: 1 << 30, noticeCount: 4)
+
+    let decoded = try JSONDecoder().decode(
+      GraphcodeSettings.self, from: JSONEncoder().encode(settings))
+
+    #expect(decoded.worktreePolicy(forProjectPath: "/repo").onResolveLanded == .remove)
+    #expect(decoded.worktreePolicy(forProjectPath: "/repo").noticeCount == 4)
+    #expect(decoded.worktreePolicy(forProjectPath: "/other").onResolveLanded == .ask)
+  }
+}

--- a/graphcode/Tests/WorktreeSweepFeatureTests.swift
+++ b/graphcode/Tests/WorktreeSweepFeatureTests.swift
@@ -1,0 +1,134 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// The sweeper's selection rules: the safe tier arrives selected, the look tier never
+/// does, the in-use tier can't be selected at all — and a removal re-reads git rather
+/// than trusting its own bookkeeping.
+@Suite
+struct WorktreeSweepFeatureTests {
+  private func inspection(
+    branch: String, dirty: Int = 0, size: Int64 = 100
+  ) -> WorktreeInspection {
+    WorktreeInspection(
+      ref: WorktreeRef(
+        id: branch, repositoryPath: "/repo", worktreePath: "/repo-\(branch)",
+        branch: branch),
+      facts: WorktreeGitFacts(
+        defaultBranch: "main", commitsNotLanded: 0, dirtyFileCount: dirty, pushed: true,
+        sizeBytes: size))
+  }
+
+  @Test
+  func loadingPreselectsOnlyTheSafeTier() async {
+    let safe = inspection(branch: "landed")
+    let dirty = inspection(branch: "wip", dirty: 2)
+    let store = TestStore(
+      initialState: WorktreeSweepFeature.State(
+        projectPath: "/repo", projectName: "repo", nodes: [])
+    ) {
+      WorktreeSweepFeature()
+    } withDependencies: {
+      $0.gitClient.inspectWorktrees = { _ in [safe, dirty] }
+    }
+
+    await store.send(.task)
+    await store.receive(\.assessmentsLoaded) {
+      $0.assessments = WorktreeSweepFeature.assessments([safe, dirty], nodes: [])
+      $0.selection = [safe.ref.worktreePath]
+    }
+  }
+
+  @Test
+  func anInUseRowCannotBeSelected() async {
+    let worktree = inspection(branch: "busy")
+    let runner = LoopNode(
+      title: "Monitoring", loopType: .goalBased, worktreeBinding: worktree.ref,
+      state: .running)
+    let store = TestStore(
+      initialState: WorktreeSweepFeature.State(
+        projectPath: "/repo", projectName: "repo", nodes: [runner])
+    ) {
+      WorktreeSweepFeature()
+    } withDependencies: {
+      $0.gitClient.inspectWorktrees = { _ in [worktree] }
+    }
+
+    await store.send(.task)
+    await store.receive(\.assessmentsLoaded) {
+      $0.assessments = WorktreeSweepFeature.assessments([worktree], nodes: [runner])
+    }
+    // No state change expected — the row is in use, so toggling it does nothing.
+    await store.send(.rowToggled(worktree.ref.worktreePath))
+  }
+
+  @Test
+  func removingReReadsGitRatherThanTrustingItself() async {
+    let safe = inspection(branch: "landed")
+    let dirty = inspection(branch: "wip", dirty: 2)
+    let remaining = LockIsolated([safe, dirty])
+    let removed = LockIsolated<[String]>([])
+    let store = TestStore(
+      initialState: WorktreeSweepFeature.State(
+        projectPath: "/repo", projectName: "repo", nodes: [])
+    ) {
+      WorktreeSweepFeature()
+    } withDependencies: {
+      $0.gitClient.inspectWorktrees = { _ in remaining.value }
+      $0.gitClient.removeWorktreeAndBranch = { ref, _ in
+        removed.withValue { $0.append(ref.branch) }
+        remaining.withValue { $0.removeAll { $0.ref.worktreePath == ref.worktreePath } }
+      }
+    }
+
+    await store.send(.task)
+    await store.receive(\.assessmentsLoaded) {
+      $0.assessments = WorktreeSweepFeature.assessments([safe, dirty], nodes: [])
+      $0.selection = [safe.ref.worktreePath]
+    }
+
+    await store.send(.removeTapped) {
+      $0.isRemoving = true
+    }
+    await store.receive(\.removalFinished) {
+      $0.selection = []
+    }
+    await store.receive(\.task)
+    await store.receive(\.assessmentsLoaded) {
+      $0.assessments = WorktreeSweepFeature.assessments([dirty], nodes: [])
+      $0.isRemoving = false
+    }
+
+    // Only what was selected — the dirty worktree was never touched.
+    #expect(removed.value == ["landed"])
+  }
+
+  @Test
+  func togglingTheSafeGroupDeselectsAndReselects() async {
+    let first = inspection(branch: "one")
+    let second = inspection(branch: "two")
+    let store = TestStore(
+      initialState: WorktreeSweepFeature.State(
+        projectPath: "/repo", projectName: "repo", nodes: [])
+    ) {
+      WorktreeSweepFeature()
+    } withDependencies: {
+      $0.gitClient.inspectWorktrees = { _ in [first, second] }
+    }
+
+    await store.send(.task)
+    await store.receive(\.assessmentsLoaded) {
+      $0.assessments = WorktreeSweepFeature.assessments([first, second], nodes: [])
+      $0.selection = [first.ref.worktreePath, second.ref.worktreePath]
+    }
+    await store.send(.allSafeToggled) {
+      $0.selection = []
+    }
+    await store.send(.allSafeToggled) {
+      $0.selection = [first.ref.worktreePath, second.ref.worktreePath]
+    }
+  }
+}


### PR DESCRIPTION
Implements the worktree-hygiene design (GraphCodeWorktreeDesigns.zip): loops create worktrees, and until now nothing removed them.

## What's in

- **Classifier** (GraphcodeKit): five signals — `landed` via `git cherry` against the discovered default branch (so squash/rebase merges count), `clean` including untracked, `pushed` (no upstream counts as unpushed), `unbound` from any loop running or stopped, `prunable` — grouped into three tiers by what removing would lose. Every git read fails toward the cautious answer.
- **GitClient**: `inspectWorktrees` (primary checkout never a candidate) and `removeWorktreeAndBranch` (`branch -D`, since `-d` refuses squash-merged branches; the reflog keeps tips recoverable).
- **Sweeper sheet**, always scoped to one folder. Safe tier preselected, look tier never, in-use tier unselectable. Footer states what the button does; footnote carries the safety facts.
- **Four routes in**: lane caption chip (`6 worktrees · 4 reclaimable`, grey under the per-folder notice threshold, amber past it), sidebar + lane-caption context menus (`Worktrees… N`), and `File ▸ Worktrees…`.
- **The resolve moment**: when a loop resolves and its branch has landed, the card offers Reclaim/Keep inline — governed by the per-folder policy (Remove it / Ask me / Keep it) in the new Project Settings sheet, persisted in `~/.graphcode/settings.json`. Automatic removal only ever touches the safe tier.

## Also fixed en route

- **Remote repository form**: User and Port are now required, prefilled with ssh's own defaults — left optional they fell through to whatever ssh guessed, which dialed the wrong place for some setups. Existing saved remote paths still parse.
- **Subprocess deadlock**: `GitClient.run` awaited children with `waitUntilExit()`, which blocks its thread; a missed termination event parked the app's main thread on a child that had already exited (caught red-handed by sampling a wedged test host). Exits are now awaited via `terminationHandler` + continuation — nothing blocks.

## Notes for review

- Deviation from the mock: look-tier rows get a quiet **Reveal** (Finder) instead of "Show diff"/"Show loop" — there's no diff viewer surface yet.
- `WorktreeAssessment.binding` excludes the resolving loop's own binding at the resolve moment; any *other* loop still bound keeps the worktree out of the safe tier.
- 684 tests pass, including new suites for the classifier, the sweeper reducer, and the remote-form dial requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbG2Xd7tX1dYPhFxjiabUu