### PR TITLE
docs: disable the subscribe form until a Buttondown account exists

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,5 +6,6 @@ description: Graphs of live, steerable Claude Code sessions on macOS
 # render only when their value is present, so an empty value ships nothing at all.
 # Cloudflare › Web Analytics › add graphcode.app › copy the beacon token.
 cloudflare_analytics_token:
-# The username in your Buttondown account URL.
-buttondown_username: scgopi
+# The username in your Buttondown account URL. Fill in only once the account exists —
+# the embed endpoint 404s for an unregistered username and the subscriber is lost.
+buttondown_username:


### PR DESCRIPTION
The newsletter form on graphcode.app posts to `buttondown.com/api/emails/embed-subscribe/scgopi`, which returns **404** — that Buttondown account was never created. Anyone who subscribed got an error page in a new tab and their address was thrown away.

Blanking `buttondown_username` lets the existing `{% if site.buttondown_username %}` guard drop the form from the page entirely. The markup and CSS stay in place, so re-enabling is a one-word change once an account exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)