### PR TITLE
CLI reliability: subcommand help, socket redial, and retry-safe exit codes

### DIFF
--- a/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
+++ b/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
@@ -89,12 +89,38 @@ public enum GraphcodeCommand: Equatable, Sendable {
       --into <path>        spawn into a different project (--kind spawn only); this is
                            how the global graph dispatches work into a project
 
+    EXIT CODES
+      0   done
+      1   bad usage, or graphcoded refused the command
+      69  graphcoded unreachable — nothing was sent, so retrying is safe
+      75  sent but never acknowledged — it may have been applied. Check `graphcode
+          status` rather than re-running: create, send and memo are not idempotent.
+
     Everything talks to graphcoded, not to the app, so these work whether or not a
     window is open.
     """
 
-  // swiftlint:disable:next cyclomatic_complexity
   public static func parse(_ arguments: [String]) throws -> GraphcodeCommand {
+    do {
+      return try parseVerb(arguments)
+    } catch is HelpRequested {
+      return .help
+    }
+  }
+
+  /// Thrown from wherever `--help` turns up in place of the argument that was expected.
+  /// `graphcode node create --help` used to fail with "missing project-path", because the
+  /// only help check was on the first argument and everything after a verb was read
+  /// positionally — so the one moment a caller admits they don't know the arguments was
+  /// the one moment they were required to supply them.
+  private struct HelpRequested: Error {}
+
+  private static func isHelpFlag(_ argument: String) -> Bool {
+    argument == "--help" || argument == "-h"
+  }
+
+  // swiftlint:disable:next cyclomatic_complexity
+  private static func parseVerb(_ arguments: [String]) throws -> GraphcodeCommand {
     var arguments = arguments
     guard !arguments.isEmpty else { return .help }
 
@@ -160,6 +186,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
       let from = try takeUUID(&arguments, name: "from-id")
       let to = try takeUUID(&arguments, name: "to-id")
       let flags = parseFlags(arguments)
+      if flags["help"] != nil { throw HelpRequested() }
       var spec = EdgeSpec()
       if let raw = flags["kind"] {
         guard let kind = EdgeKind(rawValue: raw) else {
@@ -191,6 +218,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
 
   private static func parseDraft(_ arguments: [String]) throws -> NodeDraft {
     let flags = parseFlags(arguments)
+    if flags["help"] != nil { throw HelpRequested() }
     guard let title = flags["title"] else { throw ParseError.missingArgument("--title") }
     guard let rawType = flags["type"] else { throw ParseError.missingArgument("--type") }
 
@@ -260,6 +288,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
   /// daemon can tell "leave alone" (absent) from "clear" (empty string / 0).
   private static func parseUpdate(_ arguments: [String]) throws -> NodeUpdate {
     let flags = parseFlags(arguments)
+    if flags["help"] != nil { throw HelpRequested() }
 
     var pollIntervalSeconds: Double?
     if let raw = flags["poll"] {
@@ -327,7 +356,11 @@ public enum GraphcodeCommand: Equatable, Sendable {
     return flags
   }
 
+  /// Positional arguments only — never the trailing words of `node send`/`node memo`,
+  /// which are joined rather than taken. That is what keeps `--help` meaning help here
+  /// while staying literal text in a message somebody wants to transmit.
   private static func take(_ arguments: inout [String], name: String) throws -> String {
+    if let first = arguments.first, isHelpFlag(first) { throw HelpRequested() }
     guard !arguments.isEmpty, !arguments[0].hasPrefix("--") else {
       throw ParseError.missingArgument(name)
     }

--- a/GraphcodeKit/Sources/IPC/DaemonSocketClient.swift
+++ b/GraphcodeKit/Sources/IPC/DaemonSocketClient.swift
@@ -30,7 +30,61 @@ public struct DaemonSocketClient: Sendable {
   /// arrives in milliseconds over a local socket.
   public static let defaultTimeout: TimeInterval = 10
 
-  public init(timeout: TimeInterval = DaemonSocketClient.defaultTimeout) throws {
+  /// How many times `init` dials before giving up.
+  ///
+  /// graphcoded is restarted by launchd and by its own upgrades, so a burst of CLI calls
+  /// that straddles a restart gets `ECONNREFUSED` — or a socket path that has momentarily
+  /// vanished — from a daemon that is about to be perfectly healthy. Redialing is safe in
+  /// a way retrying a *command* is not: nothing has been written yet, so there is no
+  /// half-applied mutation to duplicate. Anything past the first `send` is deliberately
+  /// left to the caller.
+  public static let defaultDialAttempts = 4
+
+  private static let dialBackoff: [TimeInterval] = [0.05, 0.15, 0.35]
+
+  public init(
+    timeout: TimeInterval = DaemonSocketClient.defaultTimeout,
+    dialAttempts: Int = DaemonSocketClient.defaultDialAttempts
+  ) throws {
+    let budget = max(1, dialAttempts)
+    var descriptor: Int32?
+    for attempt in 0..<budget {
+      do {
+        descriptor = try Self.dial()
+        break
+      } catch {
+        guard Self.isTransient(error), attempt < budget - 1 else { throw error }
+        Thread.sleep(forTimeInterval: Self.dialBackoff[min(attempt, Self.dialBackoff.count - 1)])
+      }
+    }
+    guard let connected = descriptor else { throw ClientError.daemonNotRunning }
+    Self.applyReceiveTimeout(timeout, to: connected)
+    fileDescriptor = connected
+  }
+
+  /// Wraps an already-connected descriptor. Exists so the timeout and framing behaviour
+  /// can be exercised over a `socketpair` — the public `init` dials the daemon's fixed
+  /// socket path, which a test can't stand in for without disturbing the real daemon.
+  init(fileDescriptor: Int32, timeout: TimeInterval = DaemonSocketClient.defaultTimeout) {
+    Self.applyReceiveTimeout(timeout, to: fileDescriptor)
+    self.fileDescriptor = fileDescriptor
+  }
+
+  /// Only failures that mean "not accepting connections *yet*". A permissions failure or a
+  /// bad path fails identically however long you wait, and retrying those just delays the
+  /// error the caller needs to see.
+  static func isTransient(_ error: Error) -> Bool {
+    switch error {
+    case ClientError.daemonNotRunning:
+      return true
+    case ClientError.connectionFailed(let code):
+      return code == ECONNREFUSED || code == ENOENT || code == EAGAIN || code == EINTR
+    default:
+      return false
+    }
+  }
+
+  private static func dial() throws -> Int32 {
     let path = DaemonSocketPath.url.path
     guard FileManager.default.fileExists(atPath: path) else {
       throw ClientError.daemonNotRunning
@@ -56,34 +110,26 @@ public struct DaemonSocketClient: Sendable {
       }
     }
     guard connected == 0 else {
+      // Captured before `close`, which is itself a syscall and may overwrite `errno` —
+      // reading it afterwards reported whatever closing did, not why dialling failed.
+      let code = errno
       close(descriptor)
-      throw ClientError.connectionFailed(errno: errno)
+      throw ClientError.connectionFailed(errno: code)
     }
+    return descriptor
+  }
 
-    // `SO_RCVTIMEO` rather than a watchdog thread: it makes the blocking `read(2)` inside
-    // `FramedMessageIO` return `EAGAIN` on its own, which keeps this type synchronous and
-    // needs no cancellation plumbing. Without it a caller waiting on an event the daemon
-    // never sends — because nothing it sent would cause one — blocks forever with no
-    // output at all, which is exactly how `status` used to hang.
+  /// `SO_RCVTIMEO` rather than a watchdog thread: it makes the blocking `read(2)` inside
+  /// `FramedMessageIO` return `EAGAIN` on its own, which keeps this type synchronous and
+  /// needs no cancellation plumbing. Without it a caller waiting on an event the daemon
+  /// never sends — because nothing it sent would cause one — blocks forever with no
+  /// output at all, which is exactly how `status` used to hang.
+  private static func applyReceiveTimeout(_ timeout: TimeInterval, to descriptor: Int32) {
     var interval = timeval(
       tv_sec: Int(timeout),
       tv_usec: Int32((timeout - timeout.rounded(.down)) * 1_000_000))
     setsockopt(
       descriptor, SOL_SOCKET, SO_RCVTIMEO, &interval, socklen_t(MemoryLayout<timeval>.size))
-
-    fileDescriptor = descriptor
-  }
-
-  /// Wraps an already-connected descriptor. Exists so the timeout and framing behaviour
-  /// can be exercised over a `socketpair` — the public `init` dials the daemon's fixed
-  /// socket path, which a test can't stand in for without disturbing the real daemon.
-  init(fileDescriptor: Int32, timeout: TimeInterval = DaemonSocketClient.defaultTimeout) {
-    var interval = timeval(
-      tv_sec: Int(timeout),
-      tv_usec: Int32((timeout - timeout.rounded(.down)) * 1_000_000))
-    setsockopt(
-      fileDescriptor, SOL_SOCKET, SO_RCVTIMEO, &interval, socklen_t(MemoryLayout<timeval>.size))
-    self.fileDescriptor = fileDescriptor
   }
 
   public func send(_ command: DaemonCommand) throws {

--- a/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
@@ -86,11 +86,13 @@ public enum RemoteGraphAccess {
     # host's sessions (RemoteGraphAccess.swift is the source of truth). It speaks
     # graphcoded's framed-JSON protocol over the unix socket ssh forwards here -- a
     # deliberate subset: the verbs a loop needs to fan out, report back, and remember.
+    import errno
     import json
     import os
     import socket
     import struct
     import sys
+    import time
     import uuid
 
     SESSION_PREFIX = "graphcode-"
@@ -118,13 +120,29 @@ public enum RemoteGraphAccess {
       --metric <cmd>         performance measure; last stdout line must be a number
       --direction <d>        minimize | maximize (default: maximize)
 
+    EXIT CODES
+      0   done
+      1   bad usage, or graphcoded refused the command
+      69  graphcoded unreachable -- nothing was sent, so retrying is safe
+      75  sent but never acknowledged -- it may have been applied. Check `graphcode
+          status` rather than re-running: create, send and memo are not idempotent.
+
     <project-path> is this project's ssh:// path -- your briefing states it exactly.
     The remaining verbs (update, pilot, arm, edge, usage) run from the Mac's own shell."""
 
 
-    def fail(message):
+    # The same exit codes the Swift CLI uses, because a wrapper on either side of the ssh
+    # link has to tell "you typed it wrong" from "graphcoded wasn't there" from "it may
+    # well have been applied" -- only the middle one is safe to retry blindly, since
+    # create/send/memo are not idempotent.
+    EXIT_USAGE = 1
+    EXIT_UNAVAILABLE = 69
+    EXIT_AMBIGUOUS = 75
+
+
+    def fail(message, code=EXIT_USAGE):
         sys.stderr.write("graphcode: %s\n" % message)
-        sys.exit(1)
+        sys.exit(code)
 
 
     def socket_path():
@@ -138,19 +156,42 @@ public enum RemoteGraphAccess {
         return os.path.join(support, "graphcoded.sock")
 
 
+    # Dialling is retried; nothing past the first send is. Nothing has been written when a
+    # dial fails, so a redial cannot duplicate a mutation. It matters more here than it
+    # does on the Mac: this socket is an ssh forward, so it disappears and comes back
+    # whenever the link is re-established, and a fan-out that happened to land in that
+    # window used to fail outright.
+    DIAL_ATTEMPTS = 4
+    DIAL_BACKOFF = (0.05, 0.15, 0.35)
+    RETRYABLE_DIAL_ERRNOS = (errno.ECONNREFUSED, errno.ENOENT, errno.EAGAIN, errno.EINTR)
+
+
     class Daemon:
         def __init__(self):
             path = socket_path()
-            if not os.path.exists(path):
+            problem = None
+            for attempt in range(DIAL_ATTEMPTS):
+                if os.path.exists(path):
+                    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    sock.settimeout(10)
+                    try:
+                        sock.connect(path)
+                        self.sock = sock
+                        return
+                    except OSError as error:
+                        sock.close()
+                        problem = error
+                        if error.errno not in RETRYABLE_DIAL_ERRNOS:
+                            break
+                else:
+                    problem = None
+                if attempt < DIAL_ATTEMPTS - 1:
+                    time.sleep(DIAL_BACKOFF[min(attempt, len(DIAL_BACKOFF) - 1)])
+            if problem is None:
                 fail("graphcoded isn't reachable at %s -- the ssh forward from the Mac "
                      "may be down; it returns when graphcode there next launches a loop "
-                     "on this host." % path)
-            self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self.sock.settimeout(10)
-            try:
-                self.sock.connect(path)
-            except OSError as error:
-                fail("couldn't reach graphcoded: %s" % error)
+                     "on this host." % path, EXIT_UNAVAILABLE)
+            fail("couldn't reach graphcoded: %s" % problem, EXIT_UNAVAILABLE)
 
         def send(self, command):
             data = json.dumps(command).encode("utf-8")
@@ -161,7 +202,9 @@ public enum RemoteGraphAccess {
             while len(data) < count:
                 chunk = self.sock.recv(count - len(data))
                 if not chunk:
-                    fail("connection to graphcoded closed")
+                    fail("graphcoded closed the connection before answering. The command "
+                         "may still have been applied -- check with `graphcode status` "
+                         "rather than re-running it.", EXIT_AMBIGUOUS)
                 data += chunk
             return data
 
@@ -172,11 +215,12 @@ public enum RemoteGraphAccess {
                     event = json.loads(self.read_exactly(length).decode("utf-8"))
                 except socket.timeout:
                     fail("timed out waiting for graphcoded to answer. The command may "
-                         "still have been applied -- check with `graphcode status`.")
+                         "still have been applied -- check with `graphcode status`.",
+                         EXIT_AMBIGUOUS)
                 for key in keys:
                     if isinstance(event, dict) and key in event:
                         return key, event[key]
-            fail("graphcoded never acknowledged the command")
+            fail("graphcoded never acknowledged the command", EXIT_AMBIGUOUS)
 
         def open_project(self, path):
             self.send({"openProject": {"path": path}})
@@ -312,11 +356,25 @@ public enum RemoteGraphAccess {
         return draft
 
 
+    HELP_FLAGS = ("--help", "-h")
+
+
+    def wants_help(arguments):
+        # `--help` standing where an argument was expected asks for help, rather than being
+        # the parse error that missing argument would otherwise be. Only ever checked
+        # before a positional is consumed: the trailing words of send/memo are the message
+        # itself, where `--help` is text somebody may well want to transmit.
+        return bool(arguments) and arguments[0] in HELP_FLAGS
+
+
     def main(arguments):
         if not arguments or arguments[0] in ("help", "-h", "--help"):
             print(HELP)
             return
         verb = arguments.pop(0)
+        if wants_help(arguments):
+            print(HELP)
+            return
         if verb == "projects":
             daemon = Daemon()
             daemon.send({"listRecentProjects": {}})
@@ -337,9 +395,15 @@ public enum RemoteGraphAccess {
         if len(arguments) < 2:
             fail("missing node subcommand or project-path")
         subverb = arguments.pop(0)
+        if wants_help(arguments):
+            print(HELP)
+            return
         project = arguments.pop(0)
         if subverb == "create":
             flags = parse_flags(arguments)
+            if "help" in flags:
+                print(HELP)
+                return
             draft = make_draft(flags)
             create = {"createNode": {"_0": draft}}
             if flags.get("into"):

--- a/graphcode-cli/Sources/main.swift
+++ b/graphcode-cli/Sources/main.swift
@@ -10,9 +10,24 @@ import GraphcodeKit
 // Parsing and rendering live in `GraphcodeKit.GraphcodeCommand` so they're unit-testable
 // without spawning this binary; what's left here is the socket round-trip and exit codes.
 
-func fail(_ message: String) -> Never {
+/// Exit codes, so a caller can tell "you typed it wrong" from "graphcoded wasn't there"
+/// from "it may well have been applied" — the distinction that decides whether retrying is
+/// safe. Usage and daemon-reported errors stay on 1: that is what every existing caller
+/// already treats as failure, and moving it would break them to say nothing new.
+enum ExitCode {
+  static let usage: Int32 = 1
+  /// `EX_UNAVAILABLE`. graphcoded could not be reached and nothing was written, so
+  /// retrying the whole command is safe.
+  static let unavailable: Int32 = 69
+  /// `EX_TEMPFAIL`. The command went out but its outcome never came back. It may have been
+  /// applied — `node create`, `node send` and `node memo` are not idempotent, so this is
+  /// the one case a wrapper must not blindly retry.
+  static let ambiguous: Int32 = 75
+}
+
+func fail(_ message: String, code: Int32 = ExitCode.usage) -> Never {
   FileHandle.standardError.write(Data("graphcode: \(message)\n".utf8))
-  exit(1)
+  exit(code)
 }
 
 let command: GraphcodeCommand
@@ -33,9 +48,9 @@ let client: DaemonSocketClient
 do {
   client = try DaemonSocketClient()
 } catch DaemonSocketClient.ClientError.daemonNotRunning {
-  fail("graphcoded isn't running. Start it with `make daemon-install`.")
+  fail("graphcoded isn't running. Start it with `make daemon-install`.", code: ExitCode.unavailable)
 } catch {
-  fail("couldn't reach graphcoded: \(error)")
+  fail("couldn't reach graphcoded: \(error)", code: ExitCode.unavailable)
 }
 defer { client.closeConnection() }
 
@@ -228,7 +243,16 @@ do {
     """
     timed out waiting for graphcoded to answer. The command may still have been applied — \
     check with `graphcode status`.
-    """)
+    """, code: ExitCode.ambiguous)
+} catch FramedMessageIO.IOError.connectionClosed {
+  // graphcoded went away mid-exchange — a restart landing between the write and the
+  // broadcast. Whether it applied the command first is not knowable from here, and the
+  // mutating verbs are not idempotent, so this says "check" rather than "retry".
+  fail(
+    """
+    graphcoded closed the connection before answering. The command may still have been \
+    applied — check with `graphcode status` rather than re-running it.
+    """, code: ExitCode.ambiguous)
 } catch {
   fail("\(error)")
 }

--- a/graphcode/Tests/DaemonSocketClientTests.swift
+++ b/graphcode/Tests/DaemonSocketClientTests.swift
@@ -87,4 +87,26 @@ struct DaemonSocketClientTests {
     }
     #expect(received.project.path == "/tmp/wanted")
   }
+
+  /// Dialling is retried; anything after the first write is not. Nothing has been sent when
+  /// a dial fails, so a redial cannot duplicate a mutation — whereas `node create`, `node
+  /// send` and `node memo` are not idempotent, which is why a mid-exchange
+  /// `connectionClosed` must stay off this list however transient it looks.
+  @Test
+  func onlyPreWriteFailuresAreWorthRedialing() {
+    #expect(DaemonSocketClient.isTransient(DaemonSocketClient.ClientError.daemonNotRunning))
+    #expect(
+      DaemonSocketClient.isTransient(
+        DaemonSocketClient.ClientError.connectionFailed(errno: ECONNREFUSED)))
+    #expect(
+      DaemonSocketClient.isTransient(DaemonSocketClient.ClientError.connectionFailed(errno: ENOENT))
+    )
+
+    #expect(
+      !DaemonSocketClient.isTransient(
+        DaemonSocketClient.ClientError.connectionFailed(errno: EACCES))
+    )
+    #expect(!DaemonSocketClient.isTransient(DaemonSocketClient.ClientError.timedOut))
+    #expect(!DaemonSocketClient.isTransient(FramedMessageIO.IOError.connectionClosed))
+  }
 }

--- a/graphcode/Tests/GraphcodeCommandTests.swift
+++ b/graphcode/Tests/GraphcodeCommandTests.swift
@@ -342,6 +342,56 @@ struct GraphcodeCommandTests {
     }
   }
 
+  /// Asking a subcommand for help used to fail with "missing project-path" — the one
+  /// moment a caller admits they don't know the arguments was the one moment they had to
+  /// supply them.
+  @Test
+  func askingASubcommandForHelpShowsHelp() throws {
+    #expect(try GraphcodeCommand.parse(["node", "create", "--help"]) == .help)
+    #expect(try GraphcodeCommand.parse(["node", "--help"]) == .help)
+    #expect(try GraphcodeCommand.parse(["status", "--help"]) == .help)
+    #expect(try GraphcodeCommand.parse(["usage", "-h"]) == .help)
+    #expect(try GraphcodeCommand.parse(["edge", "create", "--help"]) == .help)
+    #expect(try GraphcodeCommand.parse(["node", "send", "--help"]) == .help)
+  }
+
+  @Test
+  func helpAmongTheFlagsShowsHelpRatherThanReportingAMissingTitle() throws {
+    #expect(try GraphcodeCommand.parse(["node", "create", "/tmp/p", "--help"]) == .help)
+    #expect(
+      try GraphcodeCommand.parse([
+        "node", "update", "/tmp/p", UUID().uuidString, "--help",
+      ]) == .help)
+  }
+
+  /// The counterweight to the two tests above: everything after a `send`/`memo` id is the
+  /// message, so `--help` there is text somebody wants transmitted, not a request for help.
+  @Test
+  func helpInsideAMessageStaysPartOfTheMessage() throws {
+    let id = UUID()
+    #expect(
+      try GraphcodeCommand.parse(["node", "send", "/tmp/p", id.uuidString, "try", "--help"])
+        == .sendMessage(projectPath: "/tmp/p", nodeID: id, text: "try --help"))
+    #expect(
+      try GraphcodeCommand.parse([
+        "node", "memo", "/tmp/p", id.uuidString, "--help", "is", "broken",
+      ])
+        == .memoNode(projectPath: "/tmp/p", nodeID: id, text: "--help is broken"))
+    // The sharpest version: `--help` as the whole message, with nothing around it to hint
+    // that it was meant literally.
+    #expect(
+      try GraphcodeCommand.parse(["node", "send", "/tmp/p", id.uuidString, "--help"])
+        == .sendMessage(projectPath: "/tmp/p", nodeID: id, text: "--help"))
+  }
+
+  /// A missing argument is still a missing argument — the help check must not swallow it.
+  @Test
+  func aMissingProjectPathIsStillAnErrorWhenNoHelpWasAsked() {
+    #expect(throws: GraphcodeCommand.ParseError.missingArgument("project-path")) {
+      try GraphcodeCommand.parse(["node", "create"])
+    }
+  }
+
   @Test
   func creatingALoopInsideAComposite() throws {
     // The CLI had no way to put a loop inside a composite at all, so the type could be

--- a/graphcode/Tests/SessionBriefingTests.swift
+++ b/graphcode/Tests/SessionBriefingTests.swift
@@ -210,17 +210,29 @@ struct SessionBriefingTests {
     // A loop is unattended by construction: nobody is watching the pane when the backend
     // asks whether it may edit a file, so a session on its interactive default sits at
     // that prompt while the graph reports it `running`.
+    // Settings are passed explicitly rather than left to default: `ZmxSessionLauncher`
+    // otherwise falls back to `GraphcodeSettingsStore.load()` and reads whatever this
+    // machine chose in the UI, so the assertion below turned on a toggle no test touched.
+    let defaults = GraphcodeSettings()
+
     let claude = try #require(
-      ZmxSessionLauncher.arguments(forNode: node(), projectPath: Self.project))
+      ZmxSessionLauncher.arguments(
+        forNode: node(), projectPath: Self.project, settings: defaults))
     let mode = try #require(claude.firstIndex(of: "--permission-mode"))
     #expect(claude[mode + 1] == "auto")
 
     let copilot = try #require(
       ZmxSessionLauncher.arguments(
-        forNode: node(backend: .copilotCLI), projectPath: Self.project))
-    // Some permission answer must be present — which one depends on this machine's
-    // settings, since the launcher reads the real store.
+        forNode: node(backend: .copilotCLI), projectPath: Self.project, settings: defaults))
     #expect(copilot.contains("--yolo") || copilot.contains("--allow-all-tools"))
+
+    // Codex answers the same question in its own vocabulary, and a loop left on its `ask`
+    // default waits at the first approval prompt exactly as the other two would.
+    let codex = try #require(
+      ZmxSessionLauncher.arguments(
+        forNode: node(backend: .codex), projectPath: Self.project, settings: defaults))
+    let approval = try #require(codex.firstIndex(of: "--ask-for-approval"))
+    #expect(codex[approval + 1] == "never")
   }
 
   @Test


### PR DESCRIPTION
Three **Reliability & polish** gaps, fixed in *both* implementations of the CLI — the Swift binary and the Python shim that remote sessions use — so they hold for every backend (Claude Code, Copilot, Codex), local or over ssh.

## What was wrong

| | Before | After |
|---|---|---|
| `graphcode node create --help` | `missing project-path`, exit 1 | prints help, exit 0 |
| `node --help`, `status --help`, `edge create --help` | exit 1 | exit 0 |
| graphcoded unreachable | exit 1, no retry | exit **69**, redials 4× (50/150/350 ms) |
| dropped after the command was sent | exit 1 | exit **75**, "check rather than re-run" |
| usage / daemon-refused errors | exit 1 | exit 1 (unchanged) |

## Retry is deliberately only the dial

`node create`, `node send` and `node memo` are **not idempotent**, and the daemon has no request/response correlation — the CLI treats the `.graphChanged` broadcast as its only acknowledgement. So a connection dropped *after* the write is genuinely ambiguous: it may have been applied. Retrying it could create two nodes or deliver a message twice.

Only the dial is retried, where nothing has been written yet. The ambiguous case is reported (75) instead, and `onlyPreWriteFailuresAreWorthRedialing` pins that distinction so it isn't later "fixed" into a blanket retry.

## The help fix can't eat a message

Everything after a `node send` / `node memo` id is the message, where `--help` may be text somebody wants transmitted. The check lives in the positional reader, which never consumes those trailing words. `helpInsideAMessageStaysPartOfTheMessage` covers it, including `--help` as the entire message.

## Two things found on the way

- `connect(2)`'s errno was read *after* `close(2)`, which can overwrite it — a failed dial could report why closing failed rather than why dialling did.
- `everySessionLaunchesWithPermissionsAlreadyAnswered` called the launcher without settings, so it read the developer's real `~/.graphcode/settings.json` and failed on any machine not set to `auto`. It now passes defaults explicitly, and covers **Codex** alongside Claude Code and Copilot.

## Verification

- **702 tests / 74 suites pass.**
- Exit codes and help checked against the **built binary**, not just the parser — including that help still works with no daemon running, and that `status` against the live daemon is unaffected.
- The shim lives inside a Swift raw string literal, so a syntax error there wouldn't surface at Swift compile time; it is extracted and `compile()`d, then exercised directly (help positions, `--help`-in-a-message → 69, usage → 1, retry backoff measured).

Not changed: the auto-wired `handoff` edge on `node create`. It looked surprising but is deliberate — created already-fired so it doesn't block a child the daemon has already started, and it exists so fanned-out loops don't render as separate entry points off the graph origin.