### PR TITLE
Deliver large messages: type them in PTY-queue-sized chunks

### DIFF
--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -34,15 +34,42 @@ public enum ZmxSessionLauncher {
   /// Returns false when there's no live session to deliver into, so the caller can
   /// report an undelivered message rather than assume it landed.
   static func sendArguments(_ text: String, toNode node: LoopNode) -> [String] {
-    // Same newline flattening as a launch prompt, and for the same reason: `zmx`
-    // terminates what it types with `\r`, so an embedded newline would truncate the
-    // message at the first line.
-    let singleLine =
-      text
-      .replacingOccurrences(of: "\r\n", with: " ")
-      .replacingOccurrences(of: "\r", with: " ")
-      .replacingOccurrences(of: "\n", with: " ")
-    return ["send", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName, singleLine]
+    ["send", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName, flattened(text)]
+  }
+
+  /// The most a single `zmx send` may carry. One send is one uninterrupted write into
+  /// the session's PTY, and a PTY's kernel input queue holds 4 KB: measured on macOS
+  /// 26, a 3.7 KB message typed as one write arrives intact and a 7.3 KB one vanishes
+  /// *entirely* — while `zmx send` still exits 0, so every layer above reported the
+  /// message delivered. Half the queue leaves room for whatever the session's TUI has
+  /// not yet drained when the write lands.
+  static let maxSendChunkBytes = 2048
+
+  /// The beat between chunks — what gives the session's TUI time to drain one write
+  /// out of the PTY queue before the next lands on top of it.
+  static let interChunkDelay: Duration = .milliseconds(150)
+
+  /// The flattened message, cut into pieces a single `zmx send` can carry. Cuts fall
+  /// on character boundaries — a UTF-8 sequence split across two PTY writes would
+  /// reassemble in the composer only by luck of scheduling.
+  static func messageChunks(_ text: String, limit: Int = maxSendChunkBytes) -> [String] {
+    let flat = flattened(text)
+    guard flat.utf8.count > limit else { return flat.isEmpty ? [] : [flat] }
+    var chunks: [String] = []
+    var current = ""
+    var currentBytes = 0
+    for character in flat {
+      let size = character.utf8.count
+      if currentBytes + size > limit, !current.isEmpty {
+        chunks.append(current)
+        current = ""
+        currentBytes = 0
+      }
+      current.append(character)
+      currentBytes += size
+    }
+    if !current.isEmpty { chunks.append(current) }
+    return chunks
   }
 
   /// Wraps a backend command in an **interactive login** shell, so it resolves the same
@@ -195,12 +222,20 @@ public enum ZmxSessionLauncher {
     }
     guard ZmxLocator.isInstalled, !text.isEmpty else { return false }
     guard await sessionExists(node) else { return false }
-    guard
-      let session = try? PTYProcessSession(
-        executable: ZmxLocator.binaryURL.path,
-        arguments: sendArguments(text, toNode: node))
-    else { return false }
-    guard await session.waitUntilFinished() else { return false }
+    // Typed in PTY-queue-sized pieces rather than one write — see `maxSendChunkBytes`
+    // for what a single oversized write silently does. The pieces just accumulate in
+    // the composer, exactly as the text and the later `\r` already do; nothing is
+    // submitted until the one Enter below.
+    let sessionName = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
+    for (index, chunk) in messageChunks(text).enumerated() {
+      if index > 0 { try? await Task.sleep(for: interChunkDelay) }
+      guard
+        let session = try? PTYProcessSession(
+          executable: ZmxLocator.binaryURL.path,
+          arguments: ["send", sessionName, chunk])
+      else { return false }
+      guard await session.waitUntilFinished() else { return false }
+    }
     // Typed is not sent: submit as a second, separate keystroke — see `submitArguments`.
     try? await Task.sleep(for: submitDelay)
     guard
@@ -627,7 +662,10 @@ public enum ZmxSessionLauncher {
   static let maximumTypedCommandBytes = 800
 
   /// Newlines are the one thing quoting can't save us from — see `arguments(forNode:)`.
-  private static func flattened(_ text: String) -> String {
+  /// Messages flatten the same way and for the same reason (`sendArguments`,
+  /// `messageChunks`): `zmx` terminates what it types with `\r`, so an embedded
+  /// newline would truncate at the first line.
+  static func flattened(_ text: String) -> String {
     text
       .replacingOccurrences(of: "\r\n", with: " ")
       .replacingOccurrences(of: "\r", with: " ")
@@ -788,9 +826,15 @@ public enum ZmxSessionLauncher {
   static func remoteSendInvocation(
     _ text: String, toNode node: LoopNode, at location: RemoteProjectLocation
   ) -> [String] {
-    let send = quotedCommand(["zmx"] + sendArguments(text, toNode: node))
+    // Chunked like the local path — the remote host's PTY queue is no bigger than
+    // ours — but chained into the one ssh round-trip, with the same drain beat
+    // between writes.
+    let sessionName = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
+    let sends = messageChunks(text)
+      .map { quotedCommand(["zmx", "send", sessionName, $0]) }
+      .joined(separator: " && sleep 0.15 && ")
     let submit = quotedCommand(["zmx"] + submitArguments(forNode: node))
-    let script = "\(send) && sleep 0.4 && \(submit)"
+    let script = "\(sends) && sleep 0.4 && \(submit)"
     return location.sshInvocation(remoteCommand: location.remoteLoginShellCommand(script))
   }
 

--- a/graphcode/Tests/RemoteSessionLaunchTests.swift
+++ b/graphcode/Tests/RemoteSessionLaunchTests.swift
@@ -101,6 +101,22 @@ struct RemoteSessionLaunchTests {
   }
 
   @Test
+  func aLargeRemoteMessageIsChunkedIntoTheSameRoundTrip() throws {
+    // The remote host's PTY queue is no bigger than ours, so an oversized single write
+    // vanishes there the same way — the chunks ride the one ssh dial, drain beats
+    // between them, and still submit with a single Enter at the end.
+    let node = LoopNode(title: "hi", loopType: .goalBased, goal: GoalSpec(summary: "g"))
+    let message = "REPORT " + String(repeating: "GC-01-ABCDEFGHIJ ", count: 500)  // 8.5 KB
+    let invocation = ZmxSessionLauncher.remoteSendInvocation(message, toNode: node, at: location)
+
+    let remoteCommand = try #require(invocation.last)
+    let sends = remoteCommand.components(separatedBy: "send").count - 1
+    #expect(sends > 2)  // several text chunks plus the Enter
+    #expect(remoteCommand.contains("sleep 0.15"))
+    #expect(remoteCommand.contains("sleep 0.4"))
+  }
+
+  @Test
   func aRemoteKillReachesTheRemoteZmx() throws {
     // Stop and delete route their kill by project path; without this a remote loop's
     // session outlived its node forever — the local zmx had nothing to kill.
@@ -238,7 +254,8 @@ struct RemoteSessionLaunchTests {
     #expect(script.contains("ExitOnForwardFailure=yes"))
     // The remote bind path is anchored to the remote home the pre-dial printed;
     // nothing local knows it.
-    #expect(script.contains("\"$H\"'/.graphcode/graphcoded.sock:/Users/u/.graphcode/graphcoded.sock'"))
+    #expect(
+      script.contains("\"$H\"'/.graphcode/graphcoded.sock:/Users/u/.graphcode/graphcoded.sock'"))
     // Reconnects while its daemon lives, dies with it — an orphan would fight the
     // restarted daemon's forwarder for the bind forever.
     #expect(script.contains("kill -0 $PPID"))

--- a/graphcode/Tests/ZmxSessionLauncherTests.swift
+++ b/graphcode/Tests/ZmxSessionLauncherTests.swift
@@ -249,4 +249,59 @@ struct ZmxSessionLauncherTests {
       ZmxSessionLauncher.activityLabelArguments(forNode: node)
         == ["get", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName, "activity"])
   }
+
+  // MARK: - Message chunking
+
+  // Why chunks exist at all: one `zmx send` is one uninterrupted PTY write, and a
+  // message bigger than the PTY's 4 KB input queue vanished *entirely* — while every
+  // layer above, `zmx send`'s exit 0 included, reported it delivered. Measured, not
+  // theorized: 3.7 KB in one write arrived byte-exact, 7.3 KB arrived as nothing.
+
+  @Test
+  func aShortMessageIsOneChunkUnchanged() {
+    #expect(ZmxSessionLauncher.messageChunks("task done") == ["task done"])
+    #expect(ZmxSessionLauncher.messageChunks("") == [])
+  }
+
+  @Test
+  func chunksReassembleToExactlyTheFlattenedMessage() {
+    let message = String(repeating: "GC-01-ABCDEFGHIJ ", count: 500)  // 8.5 KB
+    let chunks = ZmxSessionLauncher.messageChunks(message)
+
+    #expect(chunks.count > 1)
+    #expect(chunks.joined() == ZmxSessionLauncher.flattened(message))
+  }
+
+  @Test
+  func noChunkExceedsWhatOnePTYWriteCanCarry() {
+    let message = String(repeating: "x", count: 10_000)
+    for chunk in ZmxSessionLauncher.messageChunks(message) {
+      #expect(chunk.utf8.count <= ZmxSessionLauncher.maxSendChunkBytes)
+    }
+  }
+
+  @Test
+  func aMultibyteCharacterIsNeverSplitAcrossChunks() {
+    // A UTF-8 sequence split across two PTY writes reassembles in the composer only by
+    // luck of scheduling. Repeating a 4-byte character makes every possible cut point
+    // mid-character unless the chunker counts bytes per character.
+    let message = String(repeating: "🐛", count: 1_500)  // 6 KB of 4-byte characters
+    let chunks = ZmxSessionLauncher.messageChunks(message)
+
+    #expect(chunks.count > 1)
+    #expect(chunks.joined() == message)
+    for chunk in chunks {
+      #expect(chunk.utf8.count <= ZmxSessionLauncher.maxSendChunkBytes)
+      #expect(chunk.unicodeScalars.allSatisfy { $0.value == "🐛".unicodeScalars.first!.value })
+    }
+  }
+
+  @Test
+  func chunkingFlattensNewlinesBeforeCutting() {
+    // Flatten-then-cut, not cut-then-flatten: a cut landing between `\r` and `\n`
+    // would turn one newline into two spaces and the reassembled message would not
+    // match what a single small send produces.
+    let chunks = ZmxSessionLauncher.messageChunks("line one\r\nline two")
+    #expect(chunks == ["line one line two"])
+  }
 }


### PR DESCRIPTION
Follow-up to #64, fixing the ~4 KB silent-drop found during the 10-loop fan-out test.

## The bug

A message bigger than the PTY's 4 KB kernel input queue, typed as **one** `zmx send`, vanished entirely — while every layer reported success: `zmx send` exited 0, so `ZmxSessionLauncher.send()` returned true, so the daemon skipped its staged-to-memory fallback, so the CLI printed `delivered`. Ten loops delivered 1000 lines that way and **zero arrived**.

Measured, not theorized, and independent of daemon build (reproduced under both Debug and Release):

| Single-write size | Outcome |
|---|---|
| 3.7 KB / 50 lines | arrives byte-exact |
| 7.3–7.5 KB / 100 lines | vanishes entirely, still reports `delivered` |

## The fix

Rather than reporting the loss, delivery now avoids it: the flattened message is cut into **2 KB chunks on character boundaries** and typed as successive `zmx send` calls with a 150 ms drain beat between writes. This is the same mechanics the existing text-then-Enter dance already relies on — chunks just accumulate in the composer until the single `\r` submits, so the target still receives **one** message. The remote path chains its chunks into the same single ssh round-trip.

- 2 KB = half the 4 KB queue, leaving room for whatever the TUI hasn't drained
- Chunk cuts never split a UTF-8 character (pinned by a 6 KB-of-emoji test)
- Flatten-then-cut, so a cut can't land between `\r` and `\n`
- Any chunk failing still returns false → the staged-to-memory fallback stays honest

## Verification

- **708 tests / 74 suites pass** (6 new)
- **Live end-to-end**: built this daemon, swapped launchd to it, sent the exact 7.5 KB / 100-line single message that vanished under the unchunked daemon — it arrived **byte-exact as one message**; Release daemon restored afterwards
- Short messages are unchanged: one chunk, identical argv to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)