### PR TITLE
0.1.29 (build 98): CLI reliability and chunked large-message delivery

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -54,8 +54,8 @@ let project = Project(
                 // (#33). Before that the suffix lived on the tag only, so betas 48/49
                 // of the 0.1.15 line read "0.1.15" and are told by the build number
                 // apart.
-                "CFBundleShortVersionString": "0.1.29-beta1",
-                "CFBundleVersion": "97",
+                "CFBundleShortVersionString": "0.1.29",
+                "CFBundleVersion": "98",
             ]),
             resources: [
                 "graphcode/Resources/**"


### PR DESCRIPTION
Stable release of the 0.1.29 line — same content as 0.1.29-beta1, version suffix dropped for the stable tag.