### PR TITLE
security: guard against argument/option injection in git and ssh invocations

### DIFF
--- a/GraphcodeKit/Sources/Domain/RemoteProjectLocation.swift
+++ b/GraphcodeKit/Sources/Domain/RemoteProjectLocation.swift
@@ -38,7 +38,8 @@ public struct RemoteProjectLocation: Equatable, Sendable {
     guard projectPath.hasPrefix("\(scheme)://"),
       let components = URLComponents(string: projectPath),
       components.scheme == scheme,
-      let host = components.host, !host.isEmpty,
+      let host = components.host, SafeArgument.isSafeSSHComponent(host),
+      components.user.map(SafeArgument.isSafeSSHComponent) ?? true,
       !components.path.isEmpty, components.path.hasPrefix("/")
     else { return nil }
     return RemoteProjectLocation(

--- a/GraphcodeKit/Sources/Domain/SafeArgument.swift
+++ b/GraphcodeKit/Sources/Domain/SafeArgument.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Guards the *argument injection* class: an untrusted string that begins with `-` being
+/// read as an option flag by a CLI graphcode shells out to (git, ssh, an agent backend),
+/// or a folder name that reaches into another directory. None of the values graphcode
+/// legitimately builds from human input — a branch name, an ssh host or login, a clone's
+/// destination folder — has any reason to start with a dash or to carry a path separator,
+/// so refusing those shapes costs nothing real and closes the whole class at once:
+/// git's `--upload-pack=<cmd>`, ssh's `-oProxyCommand=<cmd>`, a `..` that escapes the
+/// chosen parent.
+///
+/// This is the door check. It pairs with — does not replace — a literal `--` separator
+/// before the positional arguments of the commands that accept one (`git clone`,
+/// `git worktree add`): validation stops a hostile value at the door, `--` stops it at
+/// the parser.
+public enum SafeArgument {
+  /// A value a getopt-style parser would mistake for an option.
+  public static func looksLikeOption(_ value: String) -> Bool {
+    value.hasPrefix("-")
+  }
+
+  /// An ssh `user`/`host` token safe to hand to `ssh`. A real hostname or login name is
+  /// never empty, never starts with a dash, and never contains whitespace or control
+  /// characters — the shapes that would otherwise let a stored or typed value smuggle an
+  /// `-o…` option into the dial (the `--` in `sshInvocation` sits *after* the
+  /// destination, so it cannot protect the destination itself).
+  public static func isSafeSSHComponent(_ value: String) -> Bool {
+    !value.isEmpty
+      && !looksLikeOption(value)
+      && !value.contains(where: \.isWhitespace)
+      && !value.unicodeScalars.contains { $0.value < 0x20 }
+  }
+
+  /// A single path component safe to append to a chosen directory: one non-empty
+  /// segment, no `.`/`..` traversal, no separator, not option-shaped, no NUL. Rejecting
+  /// these is what keeps a clone's destination — and the failure-path `removeItem` that
+  /// follows it — inside the folder the human picked.
+  public static func isSafePathComponent(_ value: String) -> Bool {
+    !value.isEmpty
+      && value != "."
+      && value != ".."
+      && !looksLikeOption(value)
+      && !value.contains("/")
+      && !value.unicodeScalars.contains { $0.value == 0 }
+  }
+}

--- a/graphcode/Sources/Clients/GitClient.swift
+++ b/graphcode/Sources/Clients/GitClient.swift
@@ -56,7 +56,7 @@ extension GitClient: DependencyKey {
   static let liveValue = GitClient(
     createWorktree: { repositoryPath, worktreePath, branch in
       _ = try await run(
-        "git", ["-C", repositoryPath, "worktree", "add", "-b", branch, worktreePath])
+        "git", ["-C", repositoryPath, "worktree", "add", "-b", branch, "--", worktreePath])
       return WorktreeRef(
         id: branch,
         repositoryPath: repositoryPath,
@@ -70,7 +70,7 @@ extension GitClient: DependencyKey {
     },
     removeWorktree: { worktree in
       _ = try await run(
-        "git", ["-C", worktree.repositoryPath, "worktree", "remove", worktree.worktreePath])
+        "git", ["-C", worktree.repositoryPath, "worktree", "remove", "--", worktree.worktreePath])
     },
     inspectWorktrees: { repositoryPath in
       let output = try await run("git", ["-C", repositoryPath, "worktree", "list", "--porcelain"])
@@ -131,6 +131,7 @@ extension GitClient: DependencyKey {
       } else {
         var arguments = ["-C", worktree.repositoryPath, "worktree", "remove"]
         if force { arguments.append("--force") }
+        arguments.append("--")
         arguments.append(worktree.worktreePath)
         _ = try await run("git", arguments)
       }
@@ -259,7 +260,10 @@ private func cloneProcess(
   var arguments = ["git", "clone", "--progress"]
   if let branch, !branch.isEmpty { arguments += ["--branch", branch] }
   if let depth { arguments += ["--depth", String(depth)] }
-  arguments += [url, destinationPath]
+  // `--` before the positionals so a pasted URL like `--upload-pack=<cmd>` reaches git
+  // as a repository to clone, not an option to obey (git's clone-URL option injection,
+  // CVE-2017-1000117 shape). Documented git syntax: `clone [<options>] [--] <repo> [dir]`.
+  arguments += ["--", url, destinationPath]
 
   let process = Process()
   process.executableURL = URL(fileURLWithPath: "/usr/bin/env")

--- a/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
+++ b/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
@@ -40,10 +40,14 @@ struct WelcomeFeature {
       return trimmed.isEmpty ? derivedFolderName : trimmed
     }
 
-    /// `<location>/<name>`; nil until both halves are known.
+    /// `<location>/<name>`; nil until both halves are known, and nil when the leaf isn't
+    /// a plain folder name. The name reaches `git clone` as its destination and, on a
+    /// failed clone, `removeItem`; a `..` or `/` in it would place both outside the folder
+    /// the human picked, so the destination stays a single safe component of it.
     var destinationURL: URL? {
       let location = locationPath.trimmingCharacters(in: .whitespaces)
-      guard !location.isEmpty, !effectiveFolderName.isEmpty else { return nil }
+      guard !location.isEmpty, SafeArgument.isSafePathComponent(effectiveFolderName)
+      else { return nil }
       return URL(fileURLWithPath: location)
         .appendingPathComponent(effectiveFolderName).standardizedFileURL
     }
@@ -85,7 +89,8 @@ struct WelcomeFeature {
       let path = remotePath.trimmingCharacters(in: .whitespaces)
       let userName = user.trimmingCharacters(in: .whitespaces)
       let portText = port.trimmingCharacters(in: .whitespaces)
-      guard !host.isEmpty, path.hasPrefix("/"), !userName.isEmpty,
+      guard SafeArgument.isSafeSSHComponent(host), SafeArgument.isSafeSSHComponent(userName),
+        path.hasPrefix("/"),
         let portNumber = Int(portText), (1...65535).contains(portNumber)
       else { return nil }
       return RemoteProjectLocation(

--- a/graphcode/Tests/ArgumentInjectionTests.swift
+++ b/graphcode/Tests/ArgumentInjectionTests.swift
@@ -1,0 +1,99 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// The argument-injection guard (`SafeArgument`) and the boundaries that enforce it: a
+/// dash-leading value must never reach git's or ssh's option parser, and a clone's
+/// destination must never reach out of the folder the human picked. Every case here is a
+/// value a real branch, host, login, or folder name would never take.
+@Suite
+struct ArgumentInjectionTests {
+  // MARK: - The guard itself
+
+  @Test
+  func optionShapedValuesAreRejected() {
+    #expect(SafeArgument.looksLikeOption("--upload-pack=touch /tmp/pwned"))
+    #expect(SafeArgument.looksLikeOption("-oProxyCommand=x"))
+    #expect(!SafeArgument.looksLikeOption("github.com"))
+    #expect(!SafeArgument.looksLikeOption("my-branch"))
+  }
+
+  @Test
+  func safeSSHComponentAcceptsRealHostsAndLoginsOnly() {
+    #expect(SafeArgument.isSafeSSHComponent("build-box"))
+    #expect(SafeArgument.isSafeSSHComponent("192.168.0.10"))
+    #expect(SafeArgument.isSafeSSHComponent("dev"))
+    #expect(SafeArgument.isSafeSSHComponent("::1"))
+    // The injection shapes: an option-looking host/user, or one carrying whitespace or
+    // control characters, is refused.
+    #expect(!SafeArgument.isSafeSSHComponent(""))
+    #expect(!SafeArgument.isSafeSSHComponent("-oProxyCommand=calc"))
+    #expect(!SafeArgument.isSafeSSHComponent("-J jump"))
+    #expect(!SafeArgument.isSafeSSHComponent("host name"))
+    #expect(!SafeArgument.isSafeSSHComponent("host\tx"))
+  }
+
+  @Test
+  func safePathComponentIsOneInnocentSegment() {
+    #expect(SafeArgument.isSafePathComponent("widget"))
+    #expect(SafeArgument.isSafePathComponent("widget-fork"))
+    // Traversal, separators, option shapes, and the empty/dot names are all refused.
+    #expect(!SafeArgument.isSafePathComponent(""))
+    #expect(!SafeArgument.isSafePathComponent("."))
+    #expect(!SafeArgument.isSafePathComponent(".."))
+    #expect(!SafeArgument.isSafePathComponent("../../etc"))
+    #expect(!SafeArgument.isSafePathComponent("a/b"))
+    #expect(!SafeArgument.isSafePathComponent("-rf"))
+  }
+
+  // MARK: - Clone destination stays inside the picked folder
+
+  @Test
+  func aTraversingFolderNameYieldsNoDestination() {
+    var draft = WelcomeFeature.CloneDraft()
+    draft.repositoryURL = "https://github.com/acme/widget.git"
+    draft.locationPath = "/tmp/checkouts"
+    // A well-formed name still resolves as before.
+    #expect(draft.destinationURL?.path == "/tmp/checkouts/widget")
+    // A `..` or separator in the leaf disables the Clone button rather than escaping the
+    // parent (which the failure-path `removeItem` would otherwise delete outside it).
+    draft.folderName = "../../../etc"
+    #expect(draft.destinationURL == nil)
+    #expect(!draft.canSubmit)
+    draft.folderName = "nested/evil"
+    #expect(draft.destinationURL == nil)
+  }
+
+  // MARK: - Remote identity refuses a dash-leading host or user
+
+  @Test
+  func aDashLeadingHostOrUserDoesNotParse() {
+    // These would otherwise be read by ssh as `-oProxyCommand=…` / `-J …` options.
+    #expect(RemoteProjectLocation.parse(projectPath: "ssh://-evilhost/srv/repo") == nil)
+    #expect(RemoteProjectLocation.parse(projectPath: "ssh://-J@host/srv/repo") == nil)
+    // A legitimate remote identity is untouched.
+    #expect(
+      RemoteProjectLocation.parse(projectPath: "ssh://dev@build-box/srv/repo")
+        == RemoteProjectLocation(user: "dev", host: "build-box", remotePath: "/srv/repo"))
+  }
+
+  @Test
+  func theRemoteFormRefusesADashLeadingHostOrUser() {
+    var draft = WelcomeFeature.RemoteDraft()
+    draft.server = "-oProxyCommand=calc"
+    draft.user = "dev"
+    draft.remotePath = "/srv/repo"
+    #expect(draft.location == nil)
+    #expect(!draft.canSubmit)
+
+    draft.server = "build-box"
+    draft.user = "-J"
+    #expect(draft.location == nil)
+
+    draft.user = "dev"
+    #expect(draft.location != nil)
+  }
+}


### PR DESCRIPTION
## What & why

Untrusted strings were reaching the **positional arguments** of `git` / `ssh` without a check that they don't begin with `-`. A getopt-style parser then reads such a value as an **option, not data**:

| # | Severity | Vector | Impact |
|---|---|---|---|
| 1 | 🔴 High | Pasted **clone URL** → `git clone … <url>` (`GitClient.cloneProcess`) | `--upload-pack=<cmd>` ⇒ command execution (CVE-2017-1000117 shape) |
| 2 | 🔴 High | **ssh host/user** from the remote-project form or a stored `ssh://` path → `ssh <dest>` (`RemoteProjectLocation`) | dash-leading host/user ⇒ `-oProxyCommand=<cmd>` local exec; the existing `--` sits *after* the destination and cannot protect it |
| 3 | 🟡 Med | Clone **destination folder** name → path + failure-path `removeItem` (`WelcomeFeature.CloneDraft`) | `..` / `/` escapes the picked parent; a failed clone then deletes outside it |

The **empty flag-named folders** that were reported (`--m`, `--target`, …) are a downstream symptom of this same class — untrusted, dash-prefixed tokens flowing into tools that treat them as options.

## Changes

- **`SafeArgument`** (new, GraphcodeKit) — the door check: rejects option-shaped values, unsafe ssh host/user tokens (leading dash, whitespace, control chars), and path components that traverse or carry separators.
- **`GitClient`** — literal `--` separator before the positionals of `git clone` and `git worktree add` / `worktree remove`. Documented git syntax (`clone [<options>] [--] <repo> [dir]`); verified regression-safe against git 2.50.1.
- **`RemoteProjectLocation.parse`** + **`WelcomeFeature.RemoteDraft`** — refuse a dash-leading / whitespace / control host or user before it can reach the ssh dial.
- **`WelcomeFeature.CloneDraft.destinationURL`** — the destination must be a single safe path component.

Validation stops a hostile value at the door; `--` stops it at the parser. Both, deliberately.

## Tests

- New `ArgumentInjectionTests` (guard + every enforced boundary).
- **Full suite: 714 tests in 75 suites pass.**

## Deliberately deferred (regression risk > current benefit)

- **Agent-CLI prompt positional** (`BackendCommand.launchArguments`): a prompt starting with `-` is parsed as a flag by `claude`/`codex`. The prompt is semi-trusted (author's own text) and passes through zmx single-quoting as one argv element; a `--` fix depends on each backend CLI supporting `--`, which isn't verified. Left as-is.
- **Local briefing path unquoted** in the `zsh -c` string (`GhosttyTerminalView`): app-controlled `GRAPHCODE_SUPPORT_DIR` path, not untrusted input; the remote branch must stay unquoted for tilde expansion. Left as-is.

Note: the zmx launch-race that could type a flag-laden command into a live session is already closed by `atomicCheckOrRun` / `remoteEnsureInvocation`'s `||` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)