### PR TITLE
fix: resume remote loops after the remote host reboots

### DIFF
--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -1380,6 +1380,27 @@ public actor GraphStore {
     }
   }
 
+  /// The session half of `ensureUnattendedSessions`, for the repeating remote liveness
+  /// sweep (`ProjectRegistry.startRemoteLivenessSweep`). A remote host can reboot while
+  /// this daemon keeps running, and nothing else notices: the store was loaded long ago,
+  /// so the one call site that restarts loops after a reboot is the *local* machine's.
+  ///
+  /// Two deliberate differences from the load-time version, both because this runs on a
+  /// timer rather than once:
+  ///
+  /// - **No goal pollers.** `armGoalPoller` replaces the existing one, so re-arming every
+  ///   sweep would restart each poller's interval and a goal polled less often than the
+  ///   sweep would never fire at all. The pollers are already running; they are in-memory
+  ///   and a remote reboot doesn't touch them.
+  /// - **Resolved nodes are skipped whatever their loop type.** The load-time version
+  ///   restarts a `.stopped` time-based node, which is defensible once at boot and wrong
+  ///   every minute: a human who stopped a remote loop would watch it come back.
+  public func ensureUnattendedSessionsAlive() {
+    for node in graph.nodes where node.runsUnattended && !node.isResolved {
+      ensureSession(node)
+    }
+  }
+
   // MARK: - Broadcast
 
   private func broadcast() {

--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -118,6 +118,47 @@ public actor ProjectRegistry {
     presencePoller = nil
   }
 
+  // MARK: - Remote liveness
+
+  /// How often a remote project's unattended sessions are checked for existence.
+  ///
+  /// Local loops need no such sweep: their sessions die with the machine, and the machine
+  /// coming back restarts `graphcoded`, which loads the graph and calls
+  /// `ensureUnattendedSessions`. A *remote* host reboots — a Codespace stops on idle and
+  /// starts again — without this daemon restarting at all, so that one call site never
+  /// fires and every loop on that host stays dead until the app is relaunched.
+  ///
+  /// Unlike the presence poll this runs with no client attached, because a loop being
+  /// alive matters when nobody is watching and a reading does not. The cost is one ssh
+  /// per unattended remote loop per minute, multiplexed onto the host's existing
+  /// `ControlMaster` connection — a quarter of what the presence poll already spends per
+  /// loop while the app is open.
+  static let remoteLivenessSweepInterval: Duration = .seconds(60)
+
+  private var remoteSweeper: Task<Void, Never>?
+
+  /// Started by the first remote project this daemon loads and left running: a store is
+  /// never removed for being idle, and the sweep costs nothing on a tick where no project
+  /// is remote.
+  private func startRemoteLivenessSweep() {
+    guard remoteSweeper == nil, ensureSession != nil else { return }
+    remoteSweeper = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(for: Self.remoteLivenessSweepInterval)
+        guard !Task.isCancelled else { return }
+        await self?.sweepRemoteSessions()
+      }
+    }
+  }
+
+  /// Sequential across projects for the same reason `pollPresence` is: one burst of ssh
+  /// dials per tick is what the multiplexed connection exists to avoid.
+  private func sweepRemoteSessions() async {
+    for (path, store) in stores where RemoteProjectLocation.parse(projectPath: path) != nil {
+      await store.ensureUnattendedSessionsAlive()
+    }
+  }
+
   /// Sequential rather than concurrent across projects: each store's poll already spawns
   /// one subprocess per loop, and firing every project's at once would turn a quiet
   /// background tick into a burst of them.
@@ -273,6 +314,9 @@ public actor ProjectRegistry {
     // but not a reboot, so something has to restart it, and this is the moment the
     // persisted graph is first seen. Already-running sessions are left untouched.
     await newStore.ensureUnattendedSessions()
+    // The load-time ensure above is the *local* machine's reboot recovery. A remote host
+    // reboots on its own schedule, so its loops need a repeating check as well.
+    if RemoteProjectLocation.parse(projectPath: path) != nil { startRemoteLivenessSweep() }
     return newStore
   }
 

--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -129,10 +129,10 @@ public actor ProjectRegistry {
   /// fires and every loop on that host stays dead until the app is relaunched.
   ///
   /// Unlike the presence poll this runs with no client attached, because a loop being
-  /// alive matters when nobody is watching and a reading does not. The cost is one ssh
-  /// per unattended remote loop per minute, multiplexed onto the host's existing
-  /// `ControlMaster` connection — a quarter of what the presence poll already spends per
-  /// loop while the app is open.
+  /// alive matters when nobody is watching and a reading does not. On a healthy tick the
+  /// dial is a bare `zmx get` — `remoteEnsureInvocation` keeps the hooks write and the
+  /// file delivery behind that check precisely so this can be cheap — multiplexed onto
+  /// the host's existing `ControlMaster` connection.
   static let remoteLivenessSweepInterval: Duration = .seconds(60)
 
   private var remoteSweeper: Task<Void, Never>?
@@ -151,8 +151,16 @@ public actor ProjectRegistry {
     }
   }
 
-  /// Sequential across projects for the same reason `pollPresence` is: one burst of ssh
-  /// dials per tick is what the multiplexed connection exists to avoid.
+  /// The registry outlives the daemon in practice, but a `Task` holding only a weak
+  /// `self` would otherwise keep waking every minute after the registry it sweeps for is
+  /// gone — the same reason `GraphStore` cancels its goal pollers here.
+  deinit { remoteSweeper?.cancel() }
+
+  /// `ensureSession` is fire-and-forget by contract (`CLISessionBackend.ensureSession`
+  /// spawns a detached task), so this returns well before the dials it started finish and
+  /// the loop below is an ordering, not a throttle. What bounds the work is
+  /// `RemoteEnsureGate`: one ensure per node at a time, so a slow tick cannot pile a
+  /// second dial onto the same session.
   private func sweepRemoteSessions() async {
     for (path, store) in stores where RemoteProjectLocation.parse(projectPath: path) != nil {
       await store.ensureUnattendedSessionsAlive()

--- a/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
+++ b/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
@@ -75,25 +75,50 @@ public enum PresenceHooks {
   /// (`graphcode-<UUID>`), and the ID is written to the `SessionIDStore` path. Silently
   /// skipped when either variable is absent — a session graphcode didn't start, or a
   /// Claude Code version that doesn't export its session ID.
-  static func captureSessionID(supportDir: String) -> String {
-    let dir = "\(supportDir)/sessions"
-    return "if [ -n \"$ZMX_SESSION\" ] && [ -n \"$CLAUDE_CODE_SESSION_ID\" ]; then "
-      + "node_id=\"${ZMX_SESSION#graphcode-}\"; "
-      + "mkdir -p \(singleQuoted(dir)); "
-      + "printf '%s' \"$CLAUDE_CODE_SESSION_ID\" > \(singleQuoted(dir))/\"$node_id\".id; "
+  ///
+  /// `sessionsDirectory` is shell *text*, not a path, for the same reason
+  /// `remotePathExpression` is one: a hook that runs on another machine has to name that
+  /// machine's home directory, and only a shell there can expand it. A hook file carrying
+  /// this Mac's `/Users/<me>/.graphcode` wrote nothing at all on a Codespace, where
+  /// `/Users` doesn't exist and the agent user can't create it.
+  static func captureSessionID(sessionsDirectory: String) -> String {
+    "if [ -n \"$ZMX_SESSION\" ] && [ -n \"$CLAUDE_CODE_SESSION_ID\" ]; then "
+      + "node_id=\"${ZMX_SESSION#\(SurfaceRef.zmxSessionPrefix)}\"; "
+      + "mkdir -p \(sessionsDirectory); "
+      + "printf '%s' \"$CLAUDE_CODE_SESSION_ID\" > \(sessionsDirectory)/\"$node_id\".id; "
       + "fi; exit 0"
+  }
+
+  /// Where `captureSessionID` writes, as the shell text each side needs: a quoted
+  /// absolute path locally (the `SessionIDStore` directory), a `$HOME` expression
+  /// remotely.
+  static var localSessionsExpression: String {
+    singleQuoted(SupportDirectory.url.appendingPathComponent("sessions", isDirectory: true).path)
+  }
+
+  public static let remoteSessionsExpression = "\"$HOME/.graphcode/sessions\""
+
+  /// The remote twin of `SessionIDStore.file(forNodeID:)` — the file the remote
+  /// `SessionStart` hook wrote, as a shell expression the ensure dial can `cat`. The
+  /// name has to match what `captureSessionID` derives from `$ZMX_SESSION`, so both
+  /// come from `SurfaceRef`.
+  public static func remoteSessionIDExpression(forNodeID nodeID: UUID) -> String {
+    "\"$HOME/.graphcode/sessions/\(nodeID.uuidString).id\""
   }
 
   /// The settings JSON for a backend, or `nil` when it has no hooks to configure.
   /// Serialized rather than interpolated so a support directory containing a quote is a
   /// path, not a syntax error.
-  public static func json(forBackend backend: CLISessionBackendKind, zmxPath: String) -> String? {
+  public static func json(
+    forBackend backend: CLISessionBackendKind, zmxPath: String,
+    sessionsDirectory: String? = nil
+  ) -> String? {
     guard let events = events(forBackend: backend) else { return nil }
-    let supportDir = SupportDirectory.url.path
+    let sessions = sessionsDirectory ?? localSessionsExpression
     let hooks = events.reduce(into: [String: [Matcher]]()) { result, event in
       var commands = [Command(command: report(event.1, zmxPath: zmxPath))]
       if event.0 == "SessionStart" && backend == .claudeCode {
-        commands.append(Command(command: captureSessionID(supportDir: supportDir)))
+        commands.append(Command(command: captureSessionID(sessionsDirectory: sessions)))
       }
       result[event.0] = [Matcher(hooks: commands)]
     }
@@ -135,7 +160,9 @@ public enum PresenceHooks {
   public static let remotePathExpression = "$HOME/.graphcode/hooks/claude-code.json"
 
   /// The shell fragment a remote ensure/attach runs before creating the session: writes
-  /// the same hooks the local launcher writes, on the host where they will run. `zmx` by
+  /// the same hooks the local launcher writes, on the host where they will run — with
+  /// the captured session ID landing in *that* host's `~/.graphcode/sessions`, which is
+  /// where `ZmxSessionLauncher.remoteEnsureInvocation` reads it back to resume. `zmx` by
   /// bare name — the hook's `sh` inherits the agent's `PATH`, which came from the
   /// interactive login shell that found `zmx` in the first place (the same resolution
   /// the connection form validated). Errors are squelched: a host that can't take the
@@ -144,7 +171,11 @@ public enum PresenceHooks {
   /// launch fails visibly in the loop's own terminal, which beats silently running an
   /// unobservable session.
   public static func remoteWriteFragment() -> String? {
-    guard let json = json(forBackend: .claudeCode, zmxPath: "zmx") else { return nil }
+    guard
+      let json = json(
+        forBackend: .claudeCode, zmxPath: "zmx",
+        sessionsDirectory: remoteSessionsExpression)
+    else { return nil }
     // `|| true` so both call sites can chain it with `&&` — a failed write must never
     // block the launch it precedes.
     return "{ mkdir -p \"$HOME/.graphcode/hooks\" && printf '%s' \(singleQuoted(json))"

--- a/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
+++ b/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
@@ -99,11 +99,15 @@ public enum PresenceHooks {
   public static let remoteSessionsExpression = "\"$HOME/.graphcode/sessions\""
 
   /// The remote twin of `SessionIDStore.file(forNodeID:)` — the file the remote
-  /// `SessionStart` hook wrote, as a shell expression the ensure dial can `cat`. The
-  /// name has to match what `captureSessionID` derives from `$ZMX_SESSION`, so both
-  /// come from `SurfaceRef`.
+  /// `SessionStart` hook wrote, as a shell expression the ensure dial can `cat`.
+  ///
+  /// Composed from `remoteSessionsExpression` rather than restated: writer and reader
+  /// drifting apart would not fail loudly, it would make every remote resume fall
+  /// silently through to the opening prompt — the bug this whole path exists to end. The
+  /// file name matches what `captureSessionID` derives from `$ZMX_SESSION` for the same
+  /// reason it takes the prefix from `SurfaceRef`.
   public static func remoteSessionIDExpression(forNodeID nodeID: UUID) -> String {
-    "\"$HOME/.graphcode/sessions/\(nodeID.uuidString).id\""
+    "\(remoteSessionsExpression)/\"\(nodeID.uuidString).id\""
   }
 
   /// The settings JSON for a backend, or `nil` when it has no hooks to configure.

--- a/GraphcodeKit/Sources/Sessions/RemoteEnsureGate.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteEnsureGate.swift
@@ -1,30 +1,48 @@
 import Foundation
 
-/// One remote ensure per node at a time.
+/// One remote ensure per node at a time — as a **lease**, not a flag.
 ///
 /// `remoteEnsureInvocation` is create-only in a single remote shell, which closes the
 /// window between *its own* `zmx get` and `zmx run`. What it cannot close is the window
-/// between two ensures: an ssh dial that hangs rather than refuses is bounded by
-/// `ConnectTimeout`, `ServerAlive` and `runRemoteRetrying`'s backoff at well over a
-/// minute, so it is still in flight when the next `ProjectRegistry` liveness sweep comes
-/// round. Two dials whose checks both miss both run — and a `zmx run` that lands second
-/// types the entire launch command into the agent the first one started, which is the
-/// composer-bar leak the single-shell `||` exists to prevent.
+/// between two ensures: two dials whose checks both miss both run, and a `zmx run` that
+/// lands second types the entire launch command into the agent the first one started.
 ///
-/// Keyed by node rather than by host: two loops on one machine have no reason to wait
-/// for each other, and their sessions are distinct.
+/// **Why a lease and not a `Set`.** The dial this gates can hang without ever returning:
+/// `runRemoteRetrying` → `PTYProcessSession.waitCollectingOutput` ends only when the
+/// child's `terminationHandler` finishes the stream, and there is no timeout in that
+/// chain. `ssh` is invoked with `ControlMaster=auto`, and a *wedged* master — a laptop
+/// slept mid-session, a Codespace stopped while holding the socket — blocks a new client
+/// on the unix socket, where neither `ConnectTimeout` nor `ServerAliveInterval` applies.
+/// With a plain `Set` that node's entry would never be released and every later ensure
+/// would return immediately: the loop silently dead until the daemon restarts. That is a
+/// worse failure than the double-launch being prevented, so the entry expires.
+///
+/// `leaseDuration` is far longer than any healthy dial (three attempts at
+/// `ConnectTimeout=10` plus 1s and 2s backoff) and short enough that a wedge costs
+/// minutes, not the process lifetime. Re-dialling after it is safe in practice: a dial
+/// wedged before it reached the host ran nothing at all, and one wedged after `zmx run`
+/// leaves a session the next dial's `zmx get` finds.
+///
+/// Keyed by node rather than by host: two loops on one machine have no reason to wait for
+/// each other, and their sessions are distinct.
 actor RemoteEnsureGate {
   static let shared = RemoteEnsureGate()
 
-  private var inFlight: Set<UUID> = []
+  static let leaseDuration: TimeInterval = 300
 
-  /// `false` when an ensure for this node is already running, which the caller should
-  /// treat as "already handled" — the dial in flight is doing the same work.
-  func begin(_ nodeID: UUID) -> Bool {
-    inFlight.insert(nodeID).inserted
+  private var leases: [UUID: Date] = [:]
+
+  /// `false` when a live lease is held for this node, which the caller should treat as
+  /// "already handled" — the dial holding it is doing the same work.
+  func begin(_ nodeID: UUID, now: Date = Date()) -> Bool {
+    if let held = leases[nodeID], now.timeIntervalSince(held) < Self.leaseDuration {
+      return false
+    }
+    leases[nodeID] = now
+    return true
   }
 
   func end(_ nodeID: UUID) {
-    inFlight.remove(nodeID)
+    leases.removeValue(forKey: nodeID)
   }
 }

--- a/GraphcodeKit/Sources/Sessions/RemoteEnsureGate.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteEnsureGate.swift
@@ -32,17 +32,29 @@ actor RemoteEnsureGate {
 
   private var leases: [UUID: Date] = [:]
 
-  /// `false` when a live lease is held for this node, which the caller should treat as
-  /// "already handled" — the dial holding it is doing the same work.
-  func begin(_ nodeID: UUID, now: Date = Date()) -> Bool {
+  /// The moment a lease was taken, which is also proof of *which* lease it is. Returning
+  /// it rather than a bare `true` is what stops a dial from releasing a lease that is no
+  /// longer its own — see `end`.
+  ///
+  /// `nil` when a live lease is held for this node, which the caller should treat as
+  /// "already handled": the dial holding it is doing the same work.
+  func begin(_ nodeID: UUID, now: Date = Date()) -> Date? {
     if let held = leases[nodeID], now.timeIntervalSince(held) < Self.leaseDuration {
-      return false
+      return nil
     }
     leases[nodeID] = now
-    return true
+    return now
   }
 
-  func end(_ nodeID: UUID) {
+  /// Releases the lease only if it is still the one `token` was issued for.
+  ///
+  /// Unconditional removal loses exactly the race the lease exists to survive: dial A
+  /// wedges and its lease expires, dial B takes a fresh one, then A's ssh finally
+  /// returns and clears *B's* lease — leaving B in flight with the gate open, so the
+  /// next sweep tick starts a third dial alongside it. Both would miss on `zmx get`
+  /// (the host has just come back, its sessions are gone) and both would `zmx run`.
+  func end(_ nodeID: UUID, token: Date) {
+    guard leases[nodeID] == token else { return }
     leases.removeValue(forKey: nodeID)
   }
 }

--- a/GraphcodeKit/Sources/Sessions/RemoteEnsureGate.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteEnsureGate.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// One remote ensure per node at a time.
+///
+/// `remoteEnsureInvocation` is create-only in a single remote shell, which closes the
+/// window between *its own* `zmx get` and `zmx run`. What it cannot close is the window
+/// between two ensures: an ssh dial that hangs rather than refuses is bounded by
+/// `ConnectTimeout`, `ServerAlive` and `runRemoteRetrying`'s backoff at well over a
+/// minute, so it is still in flight when the next `ProjectRegistry` liveness sweep comes
+/// round. Two dials whose checks both miss both run — and a `zmx run` that lands second
+/// types the entire launch command into the agent the first one started, which is the
+/// composer-bar leak the single-shell `||` exists to prevent.
+///
+/// Keyed by node rather than by host: two loops on one machine have no reason to wait
+/// for each other, and their sessions are distinct.
+actor RemoteEnsureGate {
+  static let shared = RemoteEnsureGate()
+
+  private var inFlight: Set<UUID> = []
+
+  /// `false` when an ensure for this node is already running, which the caller should
+  /// treat as "already handled" — the dial in flight is doing the same work.
+  func begin(_ nodeID: UUID) -> Bool {
+    inFlight.insert(nodeID).inserted
+  }
+
+  func end(_ nodeID: UUID) {
+    inFlight.remove(nodeID)
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
@@ -24,10 +24,13 @@ public enum RemoteGraphAccess {
   /// not on your PATH" line stays true verbatim on both kinds of host.
   public static let cliInstallPath = "~/.graphcode/bin/graphcode"
 
-  /// Where the stamp of the last delivered shim lives, as a `$HOME` expression for the
-  /// remote shell that reads it. Beside the shim, so `installerScript`'s own `makedirs`
-  /// has already created the directory by the time anything writes here.
-  public static let deliveryStampPath = "\"$HOME/.graphcode/bin/.delivery-stamp\""
+  /// Where the stamp of the last delivered shim lives.
+  ///
+  /// One constant in the home-relative form both readers take: the installer expands it
+  /// with `os.path.expanduser`, and the ensure dial's `cat` gets it from the remote
+  /// shell's own tilde expansion. Two spellings of one path is exactly the drift that
+  /// would leave the stamp permanently mismatched and re-deliver on every tick.
+  public static let deliveryStampPath = "~/.graphcode/bin/.delivery-stamp"
 
   /// A content stamp for the shim, so an ensure can tell a host carrying the current CLI
   /// from one still carrying an older graphcode's.

--- a/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
@@ -24,6 +24,33 @@ public enum RemoteGraphAccess {
   /// not on your PATH" line stays true verbatim on both kinds of host.
   public static let cliInstallPath = "~/.graphcode/bin/graphcode"
 
+  /// Where the stamp of the last delivered shim lives, as a `$HOME` expression for the
+  /// remote shell that reads it. Beside the shim, so `installerScript`'s own `makedirs`
+  /// has already created the directory by the time anything writes here.
+  public static let deliveryStampPath = "\"$HOME/.graphcode/bin/.delivery-stamp\""
+
+  /// A content stamp for the shim, so an ensure can tell a host carrying the current CLI
+  /// from one still carrying an older graphcode's.
+  ///
+  /// This exists because the shim is the one delivered file that is re-executed
+  /// *throughout* a session's life rather than read once at startup: it speaks
+  /// `FramedMessageIO` framing and `DaemonProtocol` JSON to this daemon, so a host left
+  /// on an older copy breaks `graphcode node send` / `memo` / `resolve` for every loop
+  /// already running there — silently, and for as long as those sessions live. Delivery
+  /// therefore cannot simply be create-only like the hooks file.
+  ///
+  /// FNV-1a rather than a digest from CryptoKit: the question is only "same bytes or
+  /// not", and Swift's own `hashValue` is seeded per process, so it would report a change
+  /// on every daemon restart.
+  public static var cliShimStamp: String {
+    var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+    for byte in cliShimSource.utf8 {
+      hash ^= UInt64(byte)
+      hash &*= 0x0000_0100_0000_01b3
+    }
+    return String(hash, radix: 16)
+  }
+
   /// The remote twin of `SessionBriefing.directory(forProjectPath:)`.
   public static func briefingDirectory(forProjectPath projectPath: String) -> String {
     "~/.graphcode/briefings/\(SessionBriefing.slug(for: projectPath))"

--- a/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
@@ -24,13 +24,21 @@ public enum RemoteGraphAccess {
   /// not on your PATH" line stays true verbatim on both kinds of host.
   public static let cliInstallPath = "~/.graphcode/bin/graphcode"
 
-  /// Where the stamp of the last delivered shim lives.
+  /// Where the receipt for the last installed shim lives.
+  ///
+  /// **Named for the shim alone, and it covers the shim alone.** The briefing, wake
+  /// digest and prompt ride in the same delivery but are *not* what this stamps: they
+  /// change constantly (the wake digest on nearly every ensure), so hashing them would
+  /// fire delivery every tick and defeat the point. They stay correct through the other
+  /// half of the gate — a missing session always re-delivers
+  /// (`ZmxSessionLauncher.deliveryFragment`). Anyone adding a file to the manifest
+  /// should not assume this stamp speaks for it.
   ///
   /// One constant in the home-relative form both readers take: the installer expands it
   /// with `os.path.expanduser`, and the ensure dial's `cat` gets it from the remote
   /// shell's own tilde expansion. Two spellings of one path is exactly the drift that
   /// would leave the stamp permanently mismatched and re-deliver on every tick.
-  public static let deliveryStampPath = "~/.graphcode/bin/.delivery-stamp"
+  public static let shimStampPath = "~/.graphcode/bin/.shim-stamp"
 
   /// A content stamp for the shim, so an ensure can tell a host carrying the current CLI
   /// from one still carrying an older graphcode's.
@@ -87,7 +95,22 @@ public enum RemoteGraphAccess {
   /// content can't collide with a delimiter. Neutered with `|| true` because delivery
   /// must never block the launch it precedes — a session without its briefing is the
   /// old behaviour, which works.
-  public static func installerScript(files: [String: String]) -> String? {
+  /// `receipt` is a path and content written **after** every manifest entry has landed,
+  /// as proof that the whole delivery succeeded.
+  ///
+  /// It cannot simply be another manifest entry. The comprehension is not transactional
+  /// and iterates `sorted(m.items())`, where `.` (0x2E) sorts before `g` (0x67) — so a
+  /// receipt at `~/.graphcode/bin/.shim-stamp` would be written *before*
+  /// `~/.graphcode/bin/graphcode`, and a Codespace near its disk quota (the 16-byte
+  /// write succeeds, the 14.6 KB one hits `ENOSPC`) would end up claiming a shim it
+  /// never received — permanently, because the matching stamp then skips every later
+  /// delivery. The trailing statement is skipped outright if anything above it raises.
+  ///
+  /// No `makedirs` for the receipt: it is only reached once the shim it vouches for has
+  /// been written, and that write created the directory.
+  public static func installerScript(
+    files: [String: String], receipt: (path: String, content: String)? = nil
+  ) -> String? {
     guard !files.isEmpty else { return nil }
     let manifest = files.mapValues { Data($0.utf8).base64EncodedString() }
     guard let json = try? JSONSerialization.data(withJSONObject: manifest, options: [.sortedKeys])
@@ -98,10 +121,12 @@ public enum RemoteGraphAccess {
       + "[(os.makedirs(os.path.dirname(os.path.expanduser(p)),exist_ok=True), "
       + "open(os.path.expanduser(p),'wb').write(base64.b64decode(c)), "
       + "os.chmod(os.path.expanduser(p),0o755) if p.endswith('/graphcode') else None) "
-      + "for p,c in sorted(m.items())]"
-    return [
-      "python3", "-c", program, json.base64EncodedString(),
-    ].map(RemoteProjectLocation.shellQuoted).joined(separator: " ") + " >/dev/null 2>&1 || true"
+      + "for p,c in sorted(m.items())]; "
+      + "len(sys.argv)>2 and open(os.path.expanduser(sys.argv[2]),'w').write(sys.argv[3])"
+    var argv = ["python3", "-c", program, json.base64EncodedString()]
+    if let receipt { argv += [receipt.path, receipt.content] }
+    return argv.map(RemoteProjectLocation.shellQuoted).joined(separator: " ")
+      + " >/dev/null 2>&1 || true"
   }
 
   /// The remote `graphcode` CLI. It speaks `FramedMessageIO`'s framing and

--- a/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
@@ -95,16 +95,26 @@ public enum RemoteGraphAccess {
   /// content can't collide with a delimiter. Neutered with `|| true` because delivery
   /// must never block the launch it precedes — a session without its briefing is the
   /// old behaviour, which works.
+  ///
   /// `receipt` is a path and content written **after** every manifest entry has landed,
   /// as proof that the whole delivery succeeded.
   ///
   /// It cannot simply be another manifest entry. The comprehension is not transactional
   /// and iterates `sorted(m.items())`, where `.` (0x2E) sorts before `g` (0x67) — so a
   /// receipt at `~/.graphcode/bin/.shim-stamp` would be written *before*
-  /// `~/.graphcode/bin/graphcode`, and a Codespace near its disk quota (the 16-byte
-  /// write succeeds, the 14.6 KB one hits `ENOSPC`) would end up claiming a shim it
-  /// never received — permanently, because the matching stamp then skips every later
-  /// delivery. The trailing statement is skipped outright if anything above it raises.
+  /// `~/.graphcode/bin/graphcode`, and any host whose shim write fails would end up
+  /// claiming a CLI it never received. Permanently, too: the matching stamp then skips
+  /// every later delivery, so the host can never be upgraded again.
+  ///
+  /// The trigger is a shim that can't be overwritten under a directory that can —
+  /// a `graphcode` owned by another uid, a devcontainer feature's own copy, `chattr +i`.
+  /// *Not* a full disk, though that was the first guess: on a genuinely full volume both
+  /// writes fail and nothing is stranded, so it takes the freak case of enough free
+  /// blocks for a 12-byte stamp but not a 14.6 KB shim.
+  ///
+  /// Ordering alone is sufficient — no `with`/`flush` bookkeeping — because a payload
+  /// this size raises at `.write()` rather than at an implicit close, leaving no file
+  /// behind and aborting the comprehension before the trailing statement is reached.
   ///
   /// No `makedirs` for the receipt: it is only reached once the shim it vouches for has
   /// been written, and that write created the directory.

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -795,6 +795,10 @@ public enum ZmxSessionLauncher {
   static func deliveryFragment(_ delivery: String, ifSessionMissing check: String) -> String {
     guard !delivery.isEmpty else { return "" }
     let stamp = RemoteProjectLocation.shellQuoted(RemoteGraphAccess.cliShimStamp)
+    // Tilde, unquoted, so the remote shell expands it — the same one constant the
+    // installer expands with `expanduser`. The stamp is written *by* the delivery
+    // (`remoteDeliveryScript`), not after it, so a delivery that failed leaves no stamp
+    // and the next dial tries again.
     let stampFile = RemoteGraphAccess.deliveryStampPath
     // `!` binds to the pipeline, so this reads (session missing) OR (stamp differs). A
     // missing session has to re-deliver whatever the stamp says: the create branch below
@@ -802,8 +806,7 @@ public enum ZmxSessionLauncher {
     // of them rides in this same fragment.
     return "if ! \(check) >/dev/null 2>&1 "
       + "|| [ \"$(cat \(stampFile) 2>/dev/null)\" != \(stamp) ]; then "
-      + delivery
-      + "printf '%s' \(stamp) > \(stampFile) 2>/dev/null; fi; "
+      + delivery + "fi; "
   }
 
   /// What the ensure dial runs when the check found no session: resume the backend
@@ -856,7 +859,15 @@ public enum ZmxSessionLauncher {
   public static func remoteDeliveryScript(
     forNode node: LoopNode?, at location: RemoteProjectLocation, settings: GraphcodeSettings
   ) -> String? {
-    var files = [RemoteGraphAccess.cliInstallPath: RemoteGraphAccess.cliShimSource]
+    // The stamp rides in the manifest rather than being written by the shell after it.
+    // `installerScript` ends in `|| true` — it must never block the launch it precedes —
+    // so a separate `printf` would stamp the host even when nothing was installed, and a
+    // host with no `python3` would be marked current forever with the shim never landing.
+    // One python process writes all of these or none of them.
+    var files = [
+      RemoteGraphAccess.cliInstallPath: RemoteGraphAccess.cliShimSource,
+      RemoteGraphAccess.deliveryStampPath: RemoteGraphAccess.cliShimStamp,
+    ]
     if settings.briefsSessionsAboutTheGraph,
       let text = SessionBriefing.text(projectPath: location.projectPath)
     {

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -763,18 +763,47 @@ public enum ZmxSessionLauncher {
       .map { $0 + "; " } ?? ""
     let create = remoteCreateScript(
       forNode: node, freshRun: run, at: location, settings: settings)
-    // Everything the create needs on the host goes *behind* the check, not in front of
-    // it. This used to run per ensure, which was once at load and once per node created;
-    // the liveness sweep dials every minute, and re-sending ~20 KB of base64'd shim
-    // through a `python3 -c` (plus a second one for Copilot's trust seed) at that rate to
-    // refresh files for a session that is already running is pure cost. Create-only also
-    // matches what `PresenceHooks.write` already documents about the local hooks file: an
-    // upgraded graphcode reaches a loop at the loop's next session, not mid-run.
+    // The trust seed and the hooks file are genuinely create-only — a folder-trust
+    // dialog is answered per session start, and Claude Code reads `--settings` once at
+    // startup, so refreshing either mid-run does nothing for the session already
+    // running. This used to run per ensure, which was once at load and once per node
+    // created; the liveness sweep dials every minute, and a `python3` per loop per
+    // minute to rewrite files nothing will re-read is pure cost.
     let script =
       "cd \(RemoteProjectLocation.shellQuoted(location.remotePath)) && { "
-      + "\(check) >/dev/null 2>&1 || { " + trustSeed + hooksWrite + delivery
+      + deliveryFragment(delivery, ifSessionMissing: check)
+      + "\(check) >/dev/null 2>&1 || { " + trustSeed + hooksWrite
       + "\(create); }; }"
     return location.sshInvocation(remoteCommand: location.remoteLoginShellCommand(script))
+  }
+
+  /// The delivery, run when the session is missing **or** the host's shim is out of date.
+  ///
+  /// Delivery cannot follow the trust seed and the hooks file behind the existence check.
+  /// Those are read once at session start; the CLI shim is re-executed for as long as the
+  /// session lives, and it speaks a wire protocol to this daemon
+  /// (`RemoteGraphAccess.cliShimStamp` has the full reasoning). Skipping it for a live
+  /// session means a graphcode upgrade never reaches a remote host whose loops are still
+  /// running — and since those loops are unattended by definition, nothing else would
+  /// heal it either: `GhosttyTerminalView.remoteCommand` delivers unconditionally, but
+  /// only when a human opens the loop.
+  ///
+  /// Nor can it stay unconditional, which is what made it a `python3` and ~20 KB of
+  /// base64 per loop per minute once the sweep existed. The stamp splits the difference:
+  /// a healthy tick costs one extra `zmx get` and a `cat` on the same host, and the
+  /// delivery itself runs only when it has something new to say.
+  static func deliveryFragment(_ delivery: String, ifSessionMissing check: String) -> String {
+    guard !delivery.isEmpty else { return "" }
+    let stamp = RemoteProjectLocation.shellQuoted(RemoteGraphAccess.cliShimStamp)
+    let stampFile = RemoteGraphAccess.deliveryStampPath
+    // `!` binds to the pipeline, so this reads (session missing) OR (stamp differs). A
+    // missing session has to re-deliver whatever the stamp says: the create branch below
+    // launches an argv naming the briefing, wake digest and prompt files, and every one
+    // of them rides in this same fragment.
+    return "if ! \(check) >/dev/null 2>&1 "
+      + "|| [ \"$(cat \(stampFile) 2>/dev/null)\" != \(stamp) ]; then "
+      + delivery
+      + "printf '%s' \(stamp) > \(stampFile) 2>/dev/null; fi; "
   }
 
   /// What the ensure dial runs when the check found no session: resume the backend

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -587,7 +587,15 @@ public enum ZmxSessionLauncher {
   ///
   /// Used after a reboot: the zmx session is gone, but a persisted session ID lets the
   /// backend pick up where it left off. Falls back to `nil` when resume isn't possible
-  /// (no persisted ID, unsupported backend, or the executable isn't found).
+  /// (unsupported backend, or the executable isn't found).
+  ///
+  /// Remote projects go through here too, and the three things that differ from a local
+  /// resume are the three `arguments(forNode:)` already branches on: no hooks *file* from
+  /// this machine (the ensure dial writes one on the host and names it through
+  /// `scriptSuffix`), no local `zmx` path to report to, and workspace paths as the remote
+  /// host sees them. The `sessionID` a remote caller passes is
+  /// `remoteResumeIDPlaceholder` rather than a literal — the ID lives in a file on the
+  /// other machine, so only a shell there can read it (`remoteEnsureInvocation`).
   static func resumeArguments(
     forNode node: LoopNode, sessionID: String, projectPath: String? = nil,
     settings: GraphcodeSettings = GraphcodeSettingsStore.load()
@@ -595,10 +603,13 @@ public enum ZmxSessionLauncher {
     guard node.backend == .claudeCode || node.backend == .copilotCLI else { return nil }
     guard let executable = node.backend.executableName else { return nil }
     let remote = projectPath.flatMap { RemoteProjectLocation.parse(projectPath: $0) }
-    guard remote == nil else { return nil }
     let tier = node.effectiveModelTier(autoSelecting: settings.autoSelectsModel)
-    let hooksFile = PresenceHooks.write(forBackend: node.backend)
-    let reportingPath = ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil
+    let hooksFile = remote == nil ? PresenceHooks.write(forBackend: node.backend) : nil
+    let reportingPath =
+      remote == nil && ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil
+    let remoteHooksSuffix =
+      remote != nil && node.backend == .claudeCode
+      ? " --settings \"\(PresenceHooks.remotePathExpression)\"" : ""
     // Copilot's `--name` and `--resume` are mutually exclusive: one creates a new
     // session, the other restores an existing one. A resume session drops `--name`
     // (by passing nil for sessionName) and uses `--resume` alone; the session's
@@ -617,8 +628,19 @@ public enum ZmxSessionLauncher {
     return [
       "run", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName, "-d",
     ]
-      + Self.loginShellInvocation(of: executable, arguments: resumeArgs)
+      + Self.loginShellInvocation(
+        of: executable, arguments: resumeArgs, scriptSuffix: remoteHooksSuffix)
   }
+
+  /// Stands in for a remote session ID that this machine cannot know: the ID was written
+  /// by a hook on the remote host and is read back there, so what travels in the argv is
+  /// a shell variable reference, not a value. `remoteQuotedCommand` is the one place that
+  /// renders it — every other argument is quoted into a literal, and this one must not be.
+  static let remoteResumeIDPlaceholder = "__graphcode_remote_resume_id__"
+
+  /// The shell variable `remoteEnsureInvocation` assigns the captured ID to, and that
+  /// `remoteResumeIDPlaceholder` expands into.
+  static let remoteResumeIDVariable = "GRAPHCODE_RESUME_ID"
 
   /// The directories a loop's work legitimately spans: the project, and its worktree when
   /// it has one. A backend that verifies paths (Copilot) is told about both, because a
@@ -739,11 +761,41 @@ public enum ZmxSessionLauncher {
     let delivery =
       remoteDeliveryScript(forNode: node, at: location, settings: settings)
       .map { $0 + "; " } ?? ""
+    let create = remoteCreateScript(
+      forNode: node, freshRun: run, at: location, settings: settings)
     let script =
       "cd \(RemoteProjectLocation.shellQuoted(location.remotePath)) && { "
       + trustSeed + hooksWrite + delivery
-      + "\(check) >/dev/null 2>&1 || \(run); }"
+      + "\(check) >/dev/null 2>&1 || { \(create); }; }"
     return location.sshInvocation(remoteCommand: location.remoteLoginShellCommand(script))
+  }
+
+  /// What the ensure dial runs when the check found no session: resume the backend
+  /// session the last one left behind, or start fresh when there is nothing to resume.
+  ///
+  /// The choice is made *on the remote host*, in the shell that is already there, because
+  /// that is the only side that can answer it. The ID was written by the `SessionStart`
+  /// hook into the remote `~/.graphcode/sessions` (`PresenceHooks.captureSessionID`), and
+  /// `SessionIDStore` — the local path's source — reads this Mac's disk, where a remote
+  /// loop's ID has never existed. Deciding here also keeps the whole ensure one ssh
+  /// round-trip, which is the property `remoteEnsureInvocation` exists to protect.
+  ///
+  /// An empty or missing file falls through to the fresh launch, which is the right
+  /// answer for a first launch and for a Codespace *rebuild*: everything outside
+  /// `/workspaces` is gone, so the transcript `--resume` would name is gone with it.
+  static func remoteCreateScript(
+    forNode node: LoopNode, freshRun: String, at location: RemoteProjectLocation,
+    settings: GraphcodeSettings
+  ) -> String {
+    guard
+      let resumeArgv = resumeArguments(
+        forNode: node, sessionID: remoteResumeIDPlaceholder,
+        projectPath: location.projectPath, settings: settings)
+    else { return freshRun }
+    let resume = remoteQuotedCommand(["zmx"] + resumeArgv)
+    let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: node.id)
+    return "\(remoteResumeIDVariable)=$(cat \(idFile) 2>/dev/null); "
+      + "if [ -n \"$\(remoteResumeIDVariable)\" ]; then \(resume); else \(freshRun); fi"
   }
 
   /// The files a remote session needs on its own disk, as one installer fragment
@@ -791,7 +843,10 @@ public enum ZmxSessionLauncher {
   /// happens to start with a tilde is never rewritten.
   static func remoteQuotedCommand(_ argv: [String]) -> String {
     argv.map { argument in
-      argument.hasPrefix("~/.graphcode/")
+      if argument == remoteResumeIDPlaceholder {
+        return "\"$\(remoteResumeIDVariable)\""
+      }
+      return argument.hasPrefix("~/.graphcode/")
         ? "~/" + RemoteProjectLocation.shellQuoted(String(argument.dropFirst(2)))
         : RemoteProjectLocation.shellQuoted(argument)
     }.joined(separator: " ")

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -796,10 +796,10 @@ public enum ZmxSessionLauncher {
     guard !delivery.isEmpty else { return "" }
     let stamp = RemoteProjectLocation.shellQuoted(RemoteGraphAccess.cliShimStamp)
     // Tilde, unquoted, so the remote shell expands it — the same one constant the
-    // installer expands with `expanduser`. The stamp is written *by* the delivery
-    // (`remoteDeliveryScript`), not after it, so a delivery that failed leaves no stamp
-    // and the next dial tries again.
-    let stampFile = RemoteGraphAccess.deliveryStampPath
+    // installer expands with `expanduser`. The stamp is the delivery's own receipt,
+    // written last and only on success, so a delivery that failed anywhere leaves no
+    // stamp and the next dial tries again.
+    let stampFile = RemoteGraphAccess.shimStampPath
     // `!` binds to the pipeline, so this reads (session missing) OR (stamp differs). A
     // missing session has to re-deliver whatever the stamp says: the create branch below
     // launches an argv naming the briefing, wake digest and prompt files, and every one
@@ -859,15 +859,7 @@ public enum ZmxSessionLauncher {
   public static func remoteDeliveryScript(
     forNode node: LoopNode?, at location: RemoteProjectLocation, settings: GraphcodeSettings
   ) -> String? {
-    // The stamp rides in the manifest rather than being written by the shell after it.
-    // `installerScript` ends in `|| true` — it must never block the launch it precedes —
-    // so a separate `printf` would stamp the host even when nothing was installed, and a
-    // host with no `python3` would be marked current forever with the shim never landing.
-    // One python process writes all of these or none of them.
-    var files = [
-      RemoteGraphAccess.cliInstallPath: RemoteGraphAccess.cliShimSource,
-      RemoteGraphAccess.deliveryStampPath: RemoteGraphAccess.cliShimStamp,
-    ]
+    var files = [RemoteGraphAccess.cliInstallPath: RemoteGraphAccess.cliShimSource]
     if settings.briefsSessionsAboutTheGraph,
       let text = SessionBriefing.text(projectPath: location.projectPath)
     {
@@ -892,7 +884,12 @@ public enum ZmxSessionLauncher {
           promptText
       }
     }
-    return RemoteGraphAccess.installerScript(files: files)
+    // The shim's receipt, written only once every file above has landed — see
+    // `installerScript`. It is what lets a later ensure skip a delivery it doesn't need
+    // without ever claiming a shim the host never received.
+    return RemoteGraphAccess.installerScript(
+      files: files,
+      receipt: (path: RemoteGraphAccess.shimStampPath, content: RemoteGraphAccess.cliShimStamp))
   }
 
   /// `quotedCommand`, except that arguments naming graphcode's own remote files —
@@ -1090,7 +1087,7 @@ public enum ZmxSessionLauncher {
   private static func startRemote(_ node: LoopNode, at location: RemoteProjectLocation) async {
     // A dial already in flight for this node is doing this job; a second one racing it
     // is how two `zmx run`s land on one session (`RemoteEnsureGate`).
-    guard await RemoteEnsureGate.shared.begin(node.id) else { return }
+    guard let lease = await RemoteEnsureGate.shared.begin(node.id) else { return }
     // The forwarded socket is what makes the delivered CLI's dial land on this Mac's
     // daemon — without it the shim's commands have nowhere to go. Kept alive per host,
     // not per launch; see `RemoteSocketForwarder`.
@@ -1102,7 +1099,7 @@ public enum ZmxSessionLauncher {
     if let ensure = remoteEnsureInvocation(forNode: node, at: location) {
       _ = await runRemoteRetrying(ensure)
     }
-    await RemoteEnsureGate.shared.end(node.id)
+    await RemoteEnsureGate.shared.end(node.id, token: lease)
   }
 
   static func start(_ node: LoopNode, projectPath: String? = nil) async {

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -763,10 +763,17 @@ public enum ZmxSessionLauncher {
       .map { $0 + "; " } ?? ""
     let create = remoteCreateScript(
       forNode: node, freshRun: run, at: location, settings: settings)
+    // Everything the create needs on the host goes *behind* the check, not in front of
+    // it. This used to run per ensure, which was once at load and once per node created;
+    // the liveness sweep dials every minute, and re-sending ~20 KB of base64'd shim
+    // through a `python3 -c` (plus a second one for Copilot's trust seed) at that rate to
+    // refresh files for a session that is already running is pure cost. Create-only also
+    // matches what `PresenceHooks.write` already documents about the local hooks file: an
+    // upgraded graphcode reaches a loop at the loop's next session, not mid-run.
     let script =
       "cd \(RemoteProjectLocation.shellQuoted(location.remotePath)) && { "
-      + trustSeed + hooksWrite + delivery
-      + "\(check) >/dev/null 2>&1 || { \(create); }; }"
+      + "\(check) >/dev/null 2>&1 || { " + trustSeed + hooksWrite + delivery
+      + "\(create); }; }"
     return location.sshInvocation(remoteCommand: location.remoteLoginShellCommand(script))
   }
 
@@ -783,6 +790,19 @@ public enum ZmxSessionLauncher {
   /// An empty or missing file falls through to the fresh launch, which is the right
   /// answer for a first launch and for a Codespace *rebuild*: everything outside
   /// `/workspaces` is gone, so the transcript `--resume` would name is gone with it.
+  ///
+  /// **The ID is consumed, not just read.** An ID whose transcript no longer exists —
+  /// Claude Code's own retention expired it, or `~/.claude` was wiped while
+  /// `~/.graphcode` survived — makes `claude --resume` exit immediately, and the session
+  /// dies with it. Nothing would clear the file: `kill` removes the local one
+  /// (`SessionIDStore.remove`) but the remote path returns before reaching it, and
+  /// `zmx kill` doesn't touch the host's copy. Left in place, the liveness sweep would
+  /// retry the same dead ID every minute forever and the fresh-launch branch would
+  /// become unreachable. Testing the exit status instead does not work: `zmx run -d`
+  /// returns 0 the moment the detached session exists, long before the agent inside it
+  /// fails. So the file is removed *before* the attempt — a resume that lands has its
+  /// `SessionStart` hook write it straight back, and one that doesn't costs a single
+  /// wasted launch before the next sweep starts fresh.
   static func remoteCreateScript(
     forNode node: LoopNode, freshRun: String, at location: RemoteProjectLocation,
     settings: GraphcodeSettings
@@ -795,7 +815,8 @@ public enum ZmxSessionLauncher {
     let resume = remoteQuotedCommand(["zmx"] + resumeArgv)
     let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: node.id)
     return "\(remoteResumeIDVariable)=$(cat \(idFile) 2>/dev/null); "
-      + "if [ -n \"$\(remoteResumeIDVariable)\" ]; then \(resume); else \(freshRun); fi"
+      + "if [ -n \"$\(remoteResumeIDVariable)\" ]; then rm -f \(idFile); \(resume); "
+      + "else \(freshRun); fi"
   }
 
   /// The files a remote session needs on its own disk, as one installer fragment
@@ -1027,16 +1048,21 @@ public enum ZmxSessionLauncher {
   }
 
   private static func startRemote(_ node: LoopNode, at location: RemoteProjectLocation) async {
+    // A dial already in flight for this node is doing this job; a second one racing it
+    // is how two `zmx run`s land on one session (`RemoteEnsureGate`).
+    guard await RemoteEnsureGate.shared.begin(node.id) else { return }
     // The forwarded socket is what makes the delivered CLI's dial land on this Mac's
     // daemon — without it the shim's commands have nowhere to go. Kept alive per host,
     // not per launch; see `RemoteSocketForwarder`.
     await RemoteSocketForwarder.shared.ensureForwarding(to: location)
-    guard let ensure = remoteEnsureInvocation(forNode: node, at: location) else { return }
     // Create only, in one round-trip — see `remoteEnsureInvocation` for why the check
     // and the run must share a shell. A failure after the retries is the same posture
     // as the local path: no UI here, the node's state stays honest, opening the loop
     // retries.
-    _ = await runRemoteRetrying(ensure)
+    if let ensure = remoteEnsureInvocation(forNode: node, at: location) {
+      _ = await runRemoteRetrying(ensure)
+    }
+    await RemoteEnsureGate.shared.end(node.id)
   }
 
   static func start(_ node: LoopNode, projectPath: String? = nil) async {

--- a/Project.swift
+++ b/Project.swift
@@ -54,8 +54,8 @@ let project = Project(
                 // (#33). Before that the suffix lived on the tag only, so betas 48/49
                 // of the 0.1.15 line read "0.1.15" and are told by the build number
                 // apart.
-                "CFBundleShortVersionString": "0.1.29",
-                "CFBundleVersion": "98",
+                "CFBundleShortVersionString": "0.1.30-beta1",
+                "CFBundleVersion": "99",
             ]),
             resources: [
                 "graphcode/Resources/**"

--- a/graphcode/Tests/RemoteSessionLaunchTests.swift
+++ b/graphcode/Tests/RemoteSessionLaunchTests.swift
@@ -215,16 +215,14 @@ struct RemoteSessionLaunchTests {
     #expect(paths.contains { $0.hasPrefix("~/.graphcode/briefings/") })
 
     // And with briefing switched off, the shim still ships — the CLI is not a
-    // briefing feature, it's what `node send`'s report-back route relies on. The
-    // delivery stamp ships with it and only with it: written by the same python process
-    // so a delivery that failed leaves no claim that it succeeded.
+    // briefing feature, it's what `node send`'s report-back route relies on. The shim
+    // stamp is deliberately *not* in the manifest: it is the delivery's receipt, written
+    // after every entry has landed rather than sorted in among them.
     let unbriefed = try #require(
       ZmxSessionLauncher.remoteDeliveryScript(
         forNode: nil, at: location,
         settings: GraphcodeSettings(briefsSessionsAboutTheGraph: false)))
-    #expect(
-      deliveredPaths(in: unbriefed).sorted()
-        == ["~/.graphcode/bin/.delivery-stamp", "~/.graphcode/bin/graphcode"])
+    #expect(deliveredPaths(in: unbriefed) == ["~/.graphcode/bin/graphcode"])
   }
 
   /// Decodes the installer fragment's base64 JSON manifest back into the delivered

--- a/graphcode/Tests/RemoteSessionLaunchTests.swift
+++ b/graphcode/Tests/RemoteSessionLaunchTests.swift
@@ -215,12 +215,16 @@ struct RemoteSessionLaunchTests {
     #expect(paths.contains { $0.hasPrefix("~/.graphcode/briefings/") })
 
     // And with briefing switched off, the shim still ships — the CLI is not a
-    // briefing feature, it's what `node send`'s report-back route relies on.
+    // briefing feature, it's what `node send`'s report-back route relies on. The
+    // delivery stamp ships with it and only with it: written by the same python process
+    // so a delivery that failed leaves no claim that it succeeded.
     let unbriefed = try #require(
       ZmxSessionLauncher.remoteDeliveryScript(
         forNode: nil, at: location,
         settings: GraphcodeSettings(briefsSessionsAboutTheGraph: false)))
-    #expect(deliveredPaths(in: unbriefed) == ["~/.graphcode/bin/graphcode"])
+    #expect(
+      deliveredPaths(in: unbriefed).sorted()
+        == ["~/.graphcode/bin/.delivery-stamp", "~/.graphcode/bin/graphcode"])
   }
 
   /// Decodes the installer fragment's base64 JSON manifest back into the delivered

--- a/graphcode/Tests/RemoteSessionLaunchTests.swift
+++ b/graphcode/Tests/RemoteSessionLaunchTests.swift
@@ -62,10 +62,14 @@ struct RemoteSessionLaunchTests {
     // Never load-bearing: a failed seed must fall back to today's dialog, not block
     // the launch.
     #expect(remoteCommand.contains("|| true"))
-    // And the seed runs before the create-only pair.
-    let seed = try #require(remoteCommand.range(of: "trustedFolders"))
+    // And the seed runs before the launch it clears the way for — but *behind* the
+    // existence check, which is what keeps the liveness sweep's healthy tick a bare
+    // `zmx get` rather than a `python3` per minute against an already-trusted folder.
     let get = try #require(remoteCommand.range(of: "'get'"))
-    #expect(seed.lowerBound < get.lowerBound)
+    let seed = try #require(remoteCommand.range(of: "trustedFolders"))
+    let run = try #require(remoteCommand.range(of: "'run'"))
+    #expect(get.lowerBound < seed.lowerBound)
+    #expect(seed.lowerBound < run.lowerBound)
   }
 
   @Test
@@ -149,8 +153,10 @@ struct RemoteSessionLaunchTests {
 
   @Test
   func aRemoteEnsureDeliversTheCLIAndBriefingBeforeLaunching() throws {
-    // The delivery fragment must precede the create-only pair: a `zmx run` that fires
-    // has to find every path its argv names already on the host's disk.
+    // The delivery fragment must precede the launch: a `zmx run` that fires has to find
+    // every path its argv names already on the host's disk. It sits *behind* the
+    // existence check, so a session that is already running costs the sweep one `zmx
+    // get` rather than ~20 KB of base64'd shim through a `python3` every minute.
     let node = LoopNode(
       title: "Fix", loopType: .goalBased, goal: GoalSpec(summary: "tests pass"))
     let invocation = try #require(
@@ -163,9 +169,11 @@ struct RemoteSessionLaunchTests {
     // Never load-bearing: a failed delivery degrades to an unbriefed session, not a
     // blocked launch.
     #expect(remoteCommand.contains("|| true"))
-    let deliver = try #require(remoteCommand.range(of: "b64decode"))
     let get = try #require(remoteCommand.range(of: "'get'"))
-    #expect(deliver.lowerBound < get.lowerBound)
+    let deliver = try #require(remoteCommand.range(of: "b64decode"))
+    let run = try #require(remoteCommand.range(of: "'run'"))
+    #expect(get.lowerBound < deliver.lowerBound)
+    #expect(deliver.lowerBound < run.lowerBound)
   }
 
   @Test

--- a/graphcode/Tests/RemoteSessionResumeTests.swift
+++ b/graphcode/Tests/RemoteSessionResumeTests.swift
@@ -186,13 +186,42 @@ struct RemoteSessionResumeTests {
     let remoteCommand = try #require(invocation.last)
 
     #expect(remoteCommand.contains(RemoteGraphAccess.cliShimStamp))
-    #expect(remoteCommand.contains(".delivery-stamp"))
+    #expect(remoteCommand.contains("cat \(RemoteGraphAccess.deliveryStampPath)"))
     // Session missing *or* stamp differs — a fresh launch must re-deliver whatever the
     // stamp says, because the argv it is about to run names the briefing, wake digest
     // and prompt files that ride in this same fragment.
     let gate = try #require(remoteCommand.range(of: "if ! "))
     let deliver = try #require(remoteCommand.range(of: "b64decode"))
     #expect(gate.lowerBound < deliver.lowerBound)
+  }
+
+  @Test
+  func aFailedDeliveryLeavesNoStampBehind() throws {
+    // `installerScript` ends in `|| true` — it must never block the launch it precedes —
+    // so stamping in the shell after it would mark a host current even when nothing was
+    // installed. A host with no `python3` would then never receive the shim again, which
+    // is worse than the unconditional delivery the stamp replaced. The stamp rides in
+    // the manifest instead: one python process writes shim and stamp, or neither.
+    let script = try #require(
+      ZmxSessionLauncher.remoteDeliveryScript(
+        forNode: nil,
+        at: location,
+        settings: GraphcodeSettings()))
+
+    // Nothing writes the stamp outside the installer.
+    #expect(!script.contains("printf"))
+
+    // The manifest is the one token that base64-decodes to a JSON object.
+    let files = try #require(
+      script.split(whereSeparator: { $0 == " " || $0 == "'" })
+        .compactMap { Data(base64Encoded: String($0)) }
+        .compactMap { try? JSONSerialization.jsonObject(with: $0) as? [String: String] }
+        .first)
+    #expect(files[RemoteGraphAccess.cliInstallPath] != nil)
+    let stamp = try #require(files[RemoteGraphAccess.deliveryStampPath])
+    #expect(
+      String(data: try #require(Data(base64Encoded: stamp)), encoding: .utf8)
+        == RemoteGraphAccess.cliShimStamp)
   }
 
   @Test

--- a/graphcode/Tests/RemoteSessionResumeTests.swift
+++ b/graphcode/Tests/RemoteSessionResumeTests.swift
@@ -1,0 +1,223 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// A remote host rebooting — a Codespace idle-stopping and starting again — and what
+/// happens to the loops running on it.
+///
+/// Local loops were covered from the start: the machine coming back restarts
+/// `graphcoded`, which loads the graph, calls `ensureUnattendedSessions`, and resumes
+/// each backend session from the ID a `SessionStart` hook persisted. Every link in that
+/// chain was local-only. The remote host reboots without this daemon restarting, so
+/// nothing re-ensured; `resumeArguments` refused remote outright; and the hook installed
+/// on the remote named *this Mac's* `/Users/<me>/.graphcode`, a path a Codespace cannot
+/// even create. Loops sat dead until the app was relaunched, and then started over from
+/// their opening prompt.
+@Suite
+struct RemoteSessionResumeTests {
+  private let location = RemoteProjectLocation(
+    user: "dev", host: "codespace", port: 2222, remotePath: "/workspaces/widget")
+
+  private func goalNode(_ backend: CLISessionBackendKind = .claudeCode) -> LoopNode {
+    LoopNode(
+      title: "Fix", loopType: .goalBased, goal: GoalSpec(summary: "tests pass"),
+      backend: backend, state: .running)
+  }
+
+  /// The `SessionStart` capture command, dug out of the settings JSON.
+  private func captureCommand(sessionsDirectory: String? = nil) throws -> String {
+    let json = try #require(
+      PresenceHooks.json(
+        forBackend: .claudeCode, zmxPath: "/opt/zmx", sessionsDirectory: sessionsDirectory))
+    let parsed =
+      try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any] ?? [:]
+    let hooks = try #require(parsed["hooks"] as? [String: Any])
+    let matchers = try #require(hooks["SessionStart"] as? [[String: Any]])
+    let entries = try #require(matchers.first?["hooks"] as? [[String: Any]])
+    let commands = entries.compactMap { $0["command"] as? String }
+    return try #require(commands.first { $0.contains("CLAUDE_CODE_SESSION_ID") })
+  }
+
+  // MARK: - Capturing the ID on the host that will read it
+
+  @Test
+  func aRemoteHookWritesTheSessionIDIntoTheRemoteHomeDirectory() throws {
+    let command = try captureCommand(sessionsDirectory: PresenceHooks.remoteSessionsExpression)
+
+    // A `$HOME` expression, not a path: only a shell on that machine knows its home
+    // directory. The hook used to carry this Mac's absolute path, so on a Codespace it
+    // tried to `mkdir -p /Users/<me>/.graphcode/sessions` as a non-root user and wrote
+    // nothing at all — which is why no remote loop ever had an ID to resume from.
+    #expect(command.contains("mkdir -p \"$HOME/.graphcode/sessions\""))
+    #expect(command.contains("\"$HOME/.graphcode/sessions\"/\"$node_id\".id"))
+    #expect(!command.contains(SupportDirectory.url.path))
+  }
+
+  @Test
+  func theLocalHookStillWritesWhereTheLocalStoreReads() throws {
+    // The regression guard on the other side of the same change: `SessionIDStore.load`
+    // reads an absolute path on this disk, so the local hook must keep naming it.
+    let command = try captureCommand()
+    let sessions = SupportDirectory.url.appendingPathComponent("sessions", isDirectory: true)
+
+    #expect(command.contains(sessions.path))
+    #expect(!command.contains("$HOME"))
+  }
+
+  @Test
+  func theRemoteFragmentInstallsTheRemoteFlavourOfTheHooks() throws {
+    let fragment = try #require(PresenceHooks.remoteWriteFragment())
+    // `JSONEncoder` escapes forward slashes, and the fragment carries the settings file
+    // as raw JSON — so read the paths back the way the hook's own JSON parser will.
+    let unescaped = fragment.replacingOccurrences(of: "\\/", with: "/")
+
+    #expect(fragment.contains(PresenceHooks.remotePathExpression))
+    #expect(unescaped.contains("$HOME/.graphcode/sessions"))
+    #expect(!unescaped.contains(SupportDirectory.url.path))
+    // Still never load-bearing: a host that can't take the write gets the heuristic
+    // presence, not a failed launch.
+    #expect(fragment.contains("|| true"))
+  }
+
+  // MARK: - Reading it back, on the host
+
+  @Test
+  func aRemoteEnsureResumesFromTheIDTheRemoteHookLeftBehind() throws {
+    let node = goalNode()
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location))
+    let remoteCommand = try #require(invocation.last)
+
+    // The ID is read on the host, because that is the only side that has it:
+    // `SessionIDStore` reads this Mac's disk, where a remote loop's ID has never been
+    // written.
+    #expect(
+      remoteCommand.contains("$HOME/.graphcode/sessions/\(node.id.uuidString).id"))
+    #expect(remoteCommand.contains("'--resume'"))
+    // As a variable reference, not a literal — this machine cannot know the value.
+    #expect(remoteCommand.contains("\"$GRAPHCODE_RESUME_ID\""))
+    #expect(!remoteCommand.contains(ZmxSessionLauncher.remoteResumeIDPlaceholder))
+  }
+
+  @Test
+  func anAbsentIDFallsBackToTheOpeningPrompt() throws {
+    // A first launch, and a Codespace *rebuild*: everything outside /workspaces is gone,
+    // so the transcript `--resume` would name went with the ID file. Starting fresh is
+    // the right answer for both.
+    let node = goalNode()
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location))
+    let remoteCommand = try #require(invocation.last)
+
+    #expect(remoteCommand.contains("; else "))
+    // The opening prompt is still there, on the branch taken when the `cat` came back
+    // empty — and it comes after the resume, which is the branch order the `if` states.
+    let resume = try #require(remoteCommand.range(of: "--resume"))
+    let goal = try #require(remoteCommand.range(of: "tests pass"))
+    #expect(resume.lowerBound < goal.lowerBound)
+  }
+
+  @Test
+  func theExistenceCheckStillGuardsBothBranches() throws {
+    // The create-only property the one-shell ensure exists for: a live session must not
+    // be relaunched *or* resumed. Both are behind the same `zmx get`.
+    let node = goalNode()
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location))
+    let remoteCommand = try #require(invocation.last)
+
+    let get = try #require(remoteCommand.range(of: "'get'"))
+    let resume = try #require(remoteCommand.range(of: "--resume"))
+    let run = try #require(remoteCommand.range(of: "'run'"))
+    #expect(get.lowerBound < resume.lowerBound)
+    #expect(get.lowerBound < run.lowerBound)
+    #expect(remoteCommand.contains("||"))
+  }
+
+  @Test
+  func aRemoteResumeNamesTheRemoteHooksAndNoLocalPaths() throws {
+    let node = goalNode()
+    let argv = try #require(
+      ZmxSessionLauncher.resumeArguments(
+        forNode: node, sessionID: ZmxSessionLauncher.remoteResumeIDPlaceholder,
+        projectPath: location.projectPath))
+
+    // The same three things `arguments(forNode:)` branches on for remote: hooks named as
+    // a `$HOME` expression the remote shell expands, no local zmx to report to, and no
+    // path from this machine anywhere in the argv.
+    #expect(argv.contains { $0.contains("--settings \"$HOME/.graphcode/hooks/claude-code.json\"") })
+    #expect(!argv.contains { $0.contains(SupportDirectory.url.path) })
+  }
+
+  // MARK: - Local resume, unchanged
+
+  @Test
+  func aLocalResumeStillCarriesItsLiteralIDAndLocalHooks() throws {
+    let node = goalNode()
+    let argv = try #require(
+      ZmxSessionLauncher.resumeArguments(
+        forNode: node, sessionID: "abc-123", projectPath: "/Users/dev/widget"))
+
+    #expect(argv.contains("--resume"))
+    #expect(argv.contains("abc-123"))
+    // No remote hooks suffix leaked onto the local path — the `$HOME` there would be
+    // this machine's, and the file it names is written by absolute path.
+    #expect(!argv.contains { $0.contains("$HOME") })
+  }
+
+  @Test
+  func aCodexNodeHasNoResumeToOffer() {
+    // Codex has no `--resume` graphcode has spiked, so the remote ensure keeps the
+    // single fresh-launch branch rather than inventing a flag.
+    #expect(
+      ZmxSessionLauncher.resumeArguments(
+        forNode: goalNode(.codex), sessionID: "abc-123", projectPath: location.projectPath)
+        == nil)
+  }
+
+  // MARK: - Noticing the reboot at all
+
+  @Test
+  func theLivenessSweepRestartsUnattendedLoopsWithoutRearmingPollers() async {
+    // The sweep is what makes any of the above run: a remote host reboots while this
+    // daemon keeps going, so `ensureUnattendedSessions`'s one call site — loading a
+    // persisted graph — never fires again.
+    let started = LockIsolated<[LoopNode]>([])
+    let store = GraphStore(onEnsureSession: { node, _ in started.withValue { $0.append(node) } })
+    await store.handle(
+      .createNode(NodeDraft(title: "Poll", loopType: .timeBased, triggerPrompt: "/loop 1h Check")))
+    await store.handle(
+      .createNode(
+        NodeDraft(title: "Green", loopType: .goalBased, goal: GoalSpec(summary: "CI passes"))))
+    await store.handle(
+      .createNode(
+        NodeDraft(title: "Read", loopType: .turnBased, checkDescription: "Sound?")))
+    started.withValue { $0.removeAll() }
+
+    await store.ensureUnattendedSessionsAlive()
+
+    #expect(started.value.count == 2)
+    #expect(Set(started.value.map(\.loopType)) == [.timeBased, .goalBased])
+  }
+
+  @Test
+  func theLivenessSweepLeavesAStoppedLoopStopped() async {
+    // The one place the sweep is deliberately stricter than the load-time ensure, which
+    // restarts a `.stopped` time-based node. Defensible once at boot; every minute it
+    // would mean a human who stopped a remote loop watches it come back.
+    let started = LockIsolated<[LoopNode]>([])
+    let node = LoopNode(
+      title: "Poll", loopType: .timeBased, triggerPrompt: "/loop 1h Check", state: .stopped)
+    let store = GraphStore(
+      graph: LoopGraph(
+        scope: LoopGraphScope(projectPath: location.projectPath, name: "widget"),
+        nodes: [node]),
+      onEnsureSession: { node, _ in started.withValue { $0.append(node) } })
+
+    await store.ensureUnattendedSessionsAlive()
+
+    #expect(started.value.isEmpty)
+  }
+}

--- a/graphcode/Tests/RemoteSessionResumeTests.swift
+++ b/graphcode/Tests/RemoteSessionResumeTests.swift
@@ -186,7 +186,7 @@ struct RemoteSessionResumeTests {
     let remoteCommand = try #require(invocation.last)
 
     #expect(remoteCommand.contains(RemoteGraphAccess.cliShimStamp))
-    #expect(remoteCommand.contains("cat \(RemoteGraphAccess.deliveryStampPath)"))
+    #expect(remoteCommand.contains("cat \(RemoteGraphAccess.shimStampPath)"))
     // Session missing *or* stamp differs — a fresh launch must re-deliver whatever the
     // stamp says, because the argv it is about to run names the briefing, wake digest
     // and prompt files that ride in this same fragment.
@@ -197,31 +197,38 @@ struct RemoteSessionResumeTests {
 
   @Test
   func aFailedDeliveryLeavesNoStampBehind() throws {
-    // `installerScript` ends in `|| true` — it must never block the launch it precedes —
-    // so stamping in the shell after it would mark a host current even when nothing was
-    // installed. A host with no `python3` would then never receive the shim again, which
-    // is worse than the unconditional delivery the stamp replaced. The stamp rides in
-    // the manifest instead: one python process writes shim and stamp, or neither.
+    // Two failure modes, one rule: the stamp is a receipt, so it must be written last
+    // and only on success.
+    //
+    // Stamping from the shell after the installer doesn't work — `installerScript` ends
+    // in `|| true`, so a host with no `python3` would be marked current with nothing
+    // installed. Nor does putting it in the manifest: that comprehension is not
+    // transactional and iterates `sorted(m.items())`, where `.` sorts before `g`, so
+    // `.shim-stamp` would land *before* `graphcode` and a disk-full host would claim a
+    // shim it never received. Both leave the host permanently un-upgradeable, because
+    // the matching stamp then skips every later delivery.
     let script = try #require(
       ZmxSessionLauncher.remoteDeliveryScript(
-        forNode: nil,
-        at: location,
-        settings: GraphcodeSettings()))
+        forNode: nil, at: location, settings: GraphcodeSettings()))
 
-    // Nothing writes the stamp outside the installer.
     #expect(!script.contains("printf"))
 
-    // The manifest is the one token that base64-decodes to a JSON object.
+    // Not a manifest entry — the manifest is the one token that base64-decodes to JSON.
     let files = try #require(
       script.split(whereSeparator: { $0 == " " || $0 == "'" })
         .compactMap { Data(base64Encoded: String($0)) }
         .compactMap { try? JSONSerialization.jsonObject(with: $0) as? [String: String] }
         .first)
     #expect(files[RemoteGraphAccess.cliInstallPath] != nil)
-    let stamp = try #require(files[RemoteGraphAccess.deliveryStampPath])
-    #expect(
-      String(data: try #require(Data(base64Encoded: stamp)), encoding: .utf8)
-        == RemoteGraphAccess.cliShimStamp)
+    #expect(files[RemoteGraphAccess.shimStampPath] == nil)
+
+    // Written by a statement that follows the comprehension, so a raise anywhere inside
+    // it skips the receipt entirely.
+    let write = try #require(script.range(of: "open(os.path.expanduser(sys.argv[2])"))
+    let comprehension = try #require(script.range(of: "for p,c in sorted(m.items())]"))
+    #expect(comprehension.upperBound < write.lowerBound)
+    #expect(script.contains(RemoteGraphAccess.shimStampPath))
+    #expect(script.contains(RemoteGraphAccess.cliShimStamp))
   }
 
   @Test
@@ -293,18 +300,18 @@ struct RemoteSessionResumeTests {
   // MARK: - One ensure per node
 
   @Test
-  func aSecondEnsureForTheSameNodeIsRefusedWhileOneIsInFlight() async {
+  func aSecondEnsureForTheSameNodeIsRefusedWhileOneIsInFlight() async throws {
     // Two dials whose checks both miss both run, and the second types the whole launch
     // command into the agent the first one started.
     let gate = RemoteEnsureGate()
     let node = UUID()
 
-    #expect(await gate.begin(node))
-    #expect(await gate.begin(node) == false)
-    #expect(await gate.begin(UUID()))
+    let lease = try #require(await gate.begin(node))
+    #expect(await gate.begin(node) == nil)
+    #expect(await gate.begin(UUID()) != nil)
 
-    await gate.end(node)
-    #expect(await gate.begin(node))
+    await gate.end(node, token: lease)
+    #expect(await gate.begin(node) != nil)
   }
 
   @Test
@@ -319,11 +326,35 @@ struct RemoteSessionResumeTests {
     let node = UUID()
     let start = Date()
 
-    #expect(await gate.begin(node, now: start))
-    #expect(await gate.begin(node, now: start.addingTimeInterval(60)) == false)
+    #expect(await gate.begin(node, now: start) != nil)
+    #expect(await gate.begin(node, now: start.addingTimeInterval(60)) == nil)
     #expect(
       await gate.begin(
-        node, now: start.addingTimeInterval(RemoteEnsureGate.leaseDuration + 1)))
+        node, now: start.addingTimeInterval(RemoteEnsureGate.leaseDuration + 1)) != nil)
+  }
+
+  @Test
+  func aRecoveredWedgeCannotReleaseSomeoneElsesLease() async throws {
+    // The race an unconditional `removeValue` loses: dial A wedges and its lease
+    // expires, dial B takes a fresh one, then A's ssh finally returns. If A's `end`
+    // cleared B's lease, the next sweep tick would start a third dial alongside B — and
+    // with the host having just come back, both would miss on `zmx get` and both would
+    // `zmx run`, which is the composer-bar leak the gate exists to prevent.
+    let gate = RemoteEnsureGate()
+    let node = UUID()
+    let start = Date()
+
+    let wedged = try #require(await gate.begin(node, now: start))
+    let expired = start.addingTimeInterval(RemoteEnsureGate.leaseDuration + 1)
+    let fresh = try #require(await gate.begin(node, now: expired))
+
+    // A returns late and tries to clean up after itself.
+    await gate.end(node, token: wedged)
+
+    // B still holds the gate.
+    #expect(await gate.begin(node, now: expired.addingTimeInterval(60)) == nil)
+    await gate.end(node, token: fresh)
+    #expect(await gate.begin(node, now: expired.addingTimeInterval(61)) != nil)
   }
 
   // MARK: - Noticing the reboot at all

--- a/graphcode/Tests/RemoteSessionResumeTests.swift
+++ b/graphcode/Tests/RemoteSessionResumeTests.swift
@@ -94,7 +94,10 @@ struct RemoteSessionResumeTests {
     // `SessionIDStore` reads this Mac's disk, where a remote loop's ID has never been
     // written.
     #expect(
-      remoteCommand.contains("$HOME/.graphcode/sessions/\(node.id.uuidString).id"))
+      remoteCommand.contains(
+        "cat \(PresenceHooks.remoteSessionIDExpression(forNodeID: node.id))"))
+    #expect(remoteCommand.contains("$HOME/.graphcode/sessions"))
+    #expect(remoteCommand.contains(node.id.uuidString))
     #expect(remoteCommand.contains("'--resume'"))
     // As a variable reference, not a literal — this machine cannot know the value.
     #expect(remoteCommand.contains("\"$GRAPHCODE_RESUME_ID\""))
@@ -117,6 +120,52 @@ struct RemoteSessionResumeTests {
     let resume = try #require(remoteCommand.range(of: "--resume"))
     let goal = try #require(remoteCommand.range(of: "tests pass"))
     #expect(resume.lowerBound < goal.lowerBound)
+  }
+
+  @Test
+  func aResumeConsumesTheIDSoADeadOneCannotTrapTheLoop() throws {
+    // An ID whose transcript has expired makes `claude --resume` exit at once, and
+    // nothing clears the remote file: `kill` removes only the local one, and the remote
+    // path returns before reaching it. Left in place, the sweep would retry the same
+    // dead ID every minute and never reach the fresh branch again. Testing the exit
+    // status cannot help — `zmx run -d` returns 0 as soon as the detached session
+    // exists, long before the agent inside it fails — so the file is removed up front.
+    let node = goalNode()
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location))
+    let remoteCommand = try #require(invocation.last)
+
+    let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: node.id)
+    #expect(remoteCommand.contains("rm -f \(idFile)"))
+    let removal = try #require(remoteCommand.range(of: "rm -f"))
+    let resume = try #require(remoteCommand.range(of: "--resume"))
+    #expect(removal.lowerBound < resume.lowerBound)
+  }
+
+  @Test
+  func theReaderAndTheWriterNameTheSameDirectory() {
+    // Divergence here would not fail loudly: every remote resume would fall silently
+    // through to the opening prompt, which is the bug this path exists to end.
+    #expect(
+      PresenceHooks.remoteSessionIDExpression(forNodeID: UUID())
+        .hasPrefix(PresenceHooks.remoteSessionsExpression))
+  }
+
+  @Test
+  func aHealthySweepTickCostsOnlyTheExistenceCheck() throws {
+    // The hooks write and the file delivery sit behind the check, so a minute-by-minute
+    // sweep against a live session doesn't re-send ~20 KB of base64'd shim through a
+    // `python3` for a session that is already running.
+    let node = goalNode()
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location))
+    let remoteCommand = try #require(invocation.last)
+
+    let get = try #require(remoteCommand.range(of: "'get'"))
+    let hooks = try #require(remoteCommand.range(of: ".graphcode/hooks"))
+    let deliver = try #require(remoteCommand.range(of: "b64decode"))
+    #expect(get.lowerBound < hooks.lowerBound)
+    #expect(get.lowerBound < deliver.lowerBound)
   }
 
   @Test

--- a/graphcode/Tests/RemoteSessionResumeTests.swift
+++ b/graphcode/Tests/RemoteSessionResumeTests.swift
@@ -204,9 +204,10 @@ struct RemoteSessionResumeTests {
     // in `|| true`, so a host with no `python3` would be marked current with nothing
     // installed. Nor does putting it in the manifest: that comprehension is not
     // transactional and iterates `sorted(m.items())`, where `.` sorts before `g`, so
-    // `.shim-stamp` would land *before* `graphcode` and a disk-full host would claim a
-    // shim it never received. Both leave the host permanently un-upgradeable, because
-    // the matching stamp then skips every later delivery.
+    // `.shim-stamp` would land *before* `graphcode` and a host whose shim write fails
+    // (one owned by another uid, under a directory that is writable) would claim a CLI
+    // it never received. Both leave the host permanently un-upgradeable, because the
+    // matching stamp then skips every later delivery.
     let script = try #require(
       ZmxSessionLauncher.remoteDeliveryScript(
         forNode: nil, at: location, settings: GraphcodeSettings()))

--- a/graphcode/Tests/RemoteSessionResumeTests.swift
+++ b/graphcode/Tests/RemoteSessionResumeTests.swift
@@ -152,20 +152,55 @@ struct RemoteSessionResumeTests {
   }
 
   @Test
-  func aHealthySweepTickCostsOnlyTheExistenceCheck() throws {
-    // The hooks write and the file delivery sit behind the check, so a minute-by-minute
-    // sweep against a live session doesn't re-send ~20 KB of base64'd shim through a
-    // `python3` for a session that is already running.
+  func theHooksWriteRunsOnlyWhenASessionIsBeingCreated() throws {
+    // Claude Code reads `--settings` once at startup, so rewriting the hooks file for a
+    // session that is already running does nothing — and at one dial a minute it is a
+    // `python3` and a `printf` per loop for a file nothing will re-read.
     let node = goalNode()
     let invocation = try #require(
       ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location))
     let remoteCommand = try #require(invocation.last)
 
-    let get = try #require(remoteCommand.range(of: "'get'"))
-    let hooks = try #require(remoteCommand.range(of: ".graphcode/hooks"))
+    // Anchored on the write itself, not on the path: `.graphcode/hooks` also appears in
+    // the launch argv as `--settings "$HOME/.graphcode/hooks/claude-code.json"`, so this
+    // assertion would pass with the write deleted entirely.
+    let write = try #require(remoteCommand.range(of: "mkdir -p \"$HOME/.graphcode/hooks\""))
+    // And inside the create branch, not merely after the check — textual order alone
+    // would be satisfied by a fragment sitting outside the group.
+    let branch = try #require(remoteCommand.range(of: ">/dev/null 2>&1 || { "))
+    let run = try #require(remoteCommand.range(of: "'run'"))
+    #expect(branch.lowerBound < write.lowerBound)
+    #expect(write.lowerBound < run.lowerBound)
+  }
+
+  @Test
+  func theShimIsRedeliveredWhenTheHostsCopyIsStaleEvenIfTheSessionIsLive() throws {
+    // The one delivered file that cannot follow the hooks behind the check: the agent
+    // re-executes the shim for as long as the session lives, and it speaks a wire
+    // protocol to this daemon. A graphcode upgrade that never reaches a host whose loops
+    // are still running breaks `graphcode node send`/`memo`/`resolve` for all of them —
+    // and an unattended loop has no human to open it and heal the delivery.
+    let node = goalNode()
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location))
+    let remoteCommand = try #require(invocation.last)
+
+    #expect(remoteCommand.contains(RemoteGraphAccess.cliShimStamp))
+    #expect(remoteCommand.contains(".delivery-stamp"))
+    // Session missing *or* stamp differs — a fresh launch must re-deliver whatever the
+    // stamp says, because the argv it is about to run names the briefing, wake digest
+    // and prompt files that ride in this same fragment.
+    let gate = try #require(remoteCommand.range(of: "if ! "))
     let deliver = try #require(remoteCommand.range(of: "b64decode"))
-    #expect(get.lowerBound < hooks.lowerBound)
-    #expect(get.lowerBound < deliver.lowerBound)
+    #expect(gate.lowerBound < deliver.lowerBound)
+  }
+
+  @Test
+  func theShimStampIsStableAcrossProcesses() {
+    // Swift's own `hashValue` is seeded per process, which would report the shim as
+    // changed on every daemon restart and re-deliver it forever.
+    #expect(RemoteGraphAccess.cliShimStamp == RemoteGraphAccess.cliShimStamp)
+    #expect(!RemoteGraphAccess.cliShimStamp.isEmpty)
   }
 
   @Test
@@ -224,6 +259,42 @@ struct RemoteSessionResumeTests {
       ZmxSessionLauncher.resumeArguments(
         forNode: goalNode(.codex), sessionID: "abc-123", projectPath: location.projectPath)
         == nil)
+  }
+
+  // MARK: - One ensure per node
+
+  @Test
+  func aSecondEnsureForTheSameNodeIsRefusedWhileOneIsInFlight() async {
+    // Two dials whose checks both miss both run, and the second types the whole launch
+    // command into the agent the first one started.
+    let gate = RemoteEnsureGate()
+    let node = UUID()
+
+    #expect(await gate.begin(node))
+    #expect(await gate.begin(node) == false)
+    #expect(await gate.begin(UUID()))
+
+    await gate.end(node)
+    #expect(await gate.begin(node))
+  }
+
+  @Test
+  func aWedgedDialCannotSilenceItsNodeForever() async {
+    // The reason this is a lease and not a `Set`. `runRemoteRetrying` →
+    // `PTYProcessSession.waitCollectingOutput` ends only when the child's
+    // `terminationHandler` finishes the stream, and there is no timeout in the chain —
+    // ssh blocked on a wedged `ControlMaster` socket never returns, so `end` is never
+    // reached. A flag would leave that node refused for the daemon's lifetime, which is
+    // a worse failure than the double-launch it prevents.
+    let gate = RemoteEnsureGate()
+    let node = UUID()
+    let start = Date()
+
+    #expect(await gate.begin(node, now: start))
+    #expect(await gate.begin(node, now: start.addingTimeInterval(60)) == false)
+    #expect(
+      await gate.begin(
+        node, now: start.addingTimeInterval(RemoteEnsureGate.leaseDuration + 1)))
   }
 
   // MARK: - Noticing the reboot at all


### PR DESCRIPTION
## The issue

When a **remote** machine restarts — a Codespace idle-stopping and starting again — its loops die and nothing brings them back. Relaunching the app eventually restarts them **from their opening prompt**, redoing work. This is exactly what `SessionIDStore`'s own doc comment says it exists to prevent.

A *local* reboot was handled end to end: the machine comes back → `graphcoded` restarts → loading the persisted graph calls `ensureUnattendedSessions` → each loop resumes from the session ID a `SessionStart` hook wrote. Every link in that chain turned out to be local-only.

## Four breaks, all remote-only

| # | Break | Was |
|---|---|---|
| 1 | **Nothing re-ensured.** `ensureUnattendedSessions` runs once per daemon lifetime, at project load. A remote host reboots without this daemon restarting, so it never fired again. | `ProjectRegistry.swift:275` |
| 2 | **`start()` short-circuited before the resume logic.** The remote early-return happens before `SessionIDStore` is consulted, so the remote branch was always the from-scratch launch. | `ZmxSessionLauncher.swift:988-991` |
| 3 | **`resumeArguments` refused remote outright** — `guard remote == nil else { return nil }`, present since the feature landed in `faca382`. | `ZmxSessionLauncher.swift:597-598` |
| 4 | **The session ID was never captured on the host anyway.** `remoteWriteFragment` reused the local hooks JSON, which bakes in *this Mac's* `/Users/<me>/.graphcode`. On a Codespace that `mkdir -p` fails as a non-root user, so nothing was ever written. | `PresenceHooks.swift:92` |

## The fix

**A — decide resume-or-fresh in the remote shell.** `resumeArguments` now takes the same three branches `arguments(forNode:)` already takes for remote: no local hooks file, no local `zmx` to report to, `--settings` pointed at the host's own copy. `remoteEnsureInvocation` gained a `remoteCreateScript` fallback inside the *existing* single round-trip:

```sh
zmx get <name> >/dev/null 2>&1 || {
  GRAPHCODE_RESUME_ID=$(cat "$HOME/.graphcode/sessions/<uuid>.id" 2>/dev/null)
  if [ -n "$GRAPHCODE_RESUME_ID" ]; then <zmx run … --resume "$GRAPHCODE_RESUME_ID">
  else <zmx run … with the opening prompt>; fi
}
```

The choice has to be made there: `SessionIDStore.load` reads this Mac's disk, where a remote loop's ID has never existed. A sentinel argv element (`remoteResumeIDPlaceholder`) carries the ID through argv assembly, and `remoteQuotedCommand` is the one place that renders it unquoted — every other argument stays a shell-quoted literal.

**B — capture the ID where it will be read.** `captureSessionID` now takes the sessions directory as shell *text* rather than a path, so the remote hook names `"$HOME/.graphcode/sessions"` — the same reason `remotePathExpression` was already an expression. Local callers pass the absolute path and are byte-identical to before.

**C — notice the reboot at all.** A new 60s `ProjectRegistry` liveness sweep calls `GraphStore.ensureUnattendedSessionsAlive()` for remote-project stores only. Unlike the presence poll it runs with **no client attached**, because a loop being alive matters when nobody is watching and a reading does not. Two deliberate differences from the load-time ensure, both because this repeats:

- **No goal-poller re-arming** — `armGoalPoller` replaces the existing poller, so re-arming every sweep would restart its interval and a goal polled less often than the sweep would never fire.
- **Resolved nodes skipped whatever their loop type** — the load-time version restarts a `.stopped` time-based node, defensible once at boot and wrong every minute. A loop a human stopped stays stopped.

Without C, A and B only help when the *Mac's* daemon restarts.

## Codespaces caveat

`--resume` needs the transcript in `~/.claude/projects/`. A **stop/start** preserves the container filesystem, so resume works. A **rebuild** wipes everything outside `/workspaces` — the `-n` test then falls through to a fresh launch, which is the correct fallback rather than a hang.

## Local loops

Every touched path branches on `RemoteProjectLocation.parse(...) != nil` and takes its previous shape when that is `nil`:

- `resumeArguments` with `remote == nil` computes the same `hooksFile`, `reportingPath`, and an empty `scriptSuffix` — identical argv.
- `PresenceHooks.json(forBackend:zmxPath:)` without the new parameter emits the same string; `localSessionsExpression` resolves to the same `SessionIDStore` directory.
- The placeholder carve-out in `remoteQuotedCommand` can only match a sentinel no real value can be.
- The sweep filters on remote project paths, so local stores and the `graphcode://global` graph are never touched.

## Tests

New `RemoteSessionResumeTests` (11 cases): the remote hook writing into the remote `$HOME`, the ensure dial reading it back, `--resume` riding as a variable reference, the fresh-launch fallback, the existence check still guarding both branches, the sweep restarting unattended loops without re-arming pollers, the sweep leaving a stopped loop stopped — plus regression guards that the local hook still names the local store and a local resume still carries its literal ID with no `$HOME` in the argv.

Full suite: **723 passing**, exit 0. `swiftlint` and `swift format lint` show no new violations (the remaining ones pre-exist on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
