### PR TITLE
Show a remote repository's server parameters from its context menu

### DIFF
--- a/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
@@ -119,6 +119,7 @@ extension AppSidebarView {
     Button("Move Down") { store.send(.projectMoveDownTapped(project.id)) }
     Divider()
     FolderHygieneMenuItems(store: store, projectPath: project.id)
+    RemoteServerMenuItems(store: store, projectPath: project.id)
     Divider()
     Button("Close") { store.send(.projectCloseTapped(project.id)) }
     Button("Remove from GraphCode") { store.send(.projectRemoveTapped(project.id)) }

--- a/graphcode/Sources/Features/App/AppSidebarView.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView.swift
@@ -119,14 +119,6 @@ struct AppSidebarView: View {
       ) {
         CloneRepositoryFormView(store: store.scope(state: \.welcome, action: \.welcome))
       }
-      .sheet(
-        isPresented: Binding(
-          get: { store.welcome.remoteDraft != nil },
-          set: { if !$0 { store.send(.welcome(.remoteCancelled)) } }
-        )
-      ) {
-        RemoteRepositoryFormView(store: store.scope(state: \.welcome, action: \.welcome))
-      }
       .confirmationDialog(
         "Delete this project's loops?",
         isPresented: Binding(

--- a/graphcode/Sources/Features/App/AppView.swift
+++ b/graphcode/Sources/Features/App/AppView.swift
@@ -51,6 +51,17 @@ struct AppView: View {
     ) {
       OnboardingView { store.send(.onboardingDismissed) }
     }
+    // On the split view rather than on the sidebar that opens it: the same sheet also
+    // shows an existing remote's parameters, and that menu is reachable from the
+    // overview's lane captions with the sidebar column collapsed.
+    .sheet(
+      isPresented: Binding(
+        get: { store.welcome.remoteDraft != nil },
+        set: { if !$0 { store.send(.welcome(.remoteCancelled)) } }
+      )
+    ) {
+      RemoteRepositoryFormView(store: store.scope(state: \.welcome, action: \.welcome))
+    }
     // The window's own backdrop, and the glass every `Theme` scrim is layered over —
     // this is what makes the whole window translucent rather than only the sidebar.
     // A material here (rather than a color) is what lets the window sample the desktop

--- a/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
@@ -96,6 +96,7 @@ extension GraphOverviewView {
       .contextMenu {
         if !folder.isGlobal {
           FolderHygieneMenuItems(store: store, projectPath: folder.path)
+          RemoteServerMenuItems(store: store, projectPath: folder.path)
           Divider()
           Button("Close Folder") { store.send(.projectCloseTapped(folder.path)) }
         }

--- a/graphcode/Sources/Features/Welcome/RemoteRepositoryFormView.swift
+++ b/graphcode/Sources/Features/Welcome/RemoteRepositoryFormView.swift
@@ -6,35 +6,51 @@ import SwiftUI
 /// Everything is validated before the project is added (reachability, the path being a
 /// repo, zmx being installed there), because each of those failures would otherwise
 /// surface later as a loop that silently does nothing.
+///
+/// The same sheet doubles as the read-only view of an already-added remote's parameters
+/// (`RemoteDraft.isInspecting`), so the connection is described in one place and can't
+/// drift between the two.
 struct RemoteRepositoryFormView: View {
   @Bindable var store: StoreOf<WelcomeFeature>
 
+  private var isInspecting: Bool { store.remoteDraft?.isInspecting == true }
+
   var body: some View {
     VStack(spacing: 12) {
-      Text("Add Remote Repository").font(.headline)
+      Text(isInspecting ? "Server Parameters" : "Add Remote Repository").font(.headline)
 
       Form {
-        TextField("Server", text: field(\.server), prompt: Text("build-box.local"))
+        if isInspecting {
+          LabeledContent("Server") { value(\.server) }
+          LabeledContent("User") { value(\.user) }
+          LabeledContent("Port") { value(\.port) }
+          LabeledContent("Path") { value(\.remotePath) }
+        } else {
+          TextField("Server", text: field(\.server), prompt: Text("build-box.local"))
+            .autocorrectionDisabled()
+            .font(.system(.body, design: .monospaced))
+          TextField("User", text: field(\.user), prompt: Text("your login on the server"))
+            .autocorrectionDisabled()
+            .font(.system(.body, design: .monospaced))
+          TextField("Port", text: field(\.port), prompt: Text("22"))
+            .font(.system(.body, design: .monospaced))
+          TextField(
+            "Path", text: field(\.remotePath),
+            prompt: Text("/home/you/projects/repo — absolute")
+          )
           .autocorrectionDisabled()
           .font(.system(.body, design: .monospaced))
-        TextField("User", text: field(\.user), prompt: Text("your login on the server"))
-          .autocorrectionDisabled()
-          .font(.system(.body, design: .monospaced))
-        TextField("Port", text: field(\.port), prompt: Text("22"))
-          .font(.system(.body, design: .monospaced))
-        TextField(
-          "Path", text: field(\.remotePath),
-          prompt: Text("/home/you/projects/repo — absolute")
-        )
-        .autocorrectionDisabled()
-        .font(.system(.body, design: .monospaced))
+        }
       }
       .formStyle(.columns)
       .fixedSize(horizontal: false, vertical: true)
 
       Text(
-        "Needs key-based SSH (no password prompts), and zmx installed on the server. "
-          + "Loops run on the server; this Mac steers them."
+        isInspecting
+          ? "Loops for this project run on the server; this Mac steers them. To point at a "
+            + "different server or path, add it as another remote repository."
+          : "Needs key-based SSH (no password prompts), and zmx installed on the server. "
+            + "Loops run on the server; this Mac steers them."
       )
       .font(.caption2)
       .foregroundStyle(.secondary)
@@ -49,18 +65,37 @@ struct RemoteRepositoryFormView: View {
       }
 
       HStack {
-        Button("Cancel") { store.send(.remoteCancelled) }
-        Spacer()
-        if store.remoteDraft?.isValidating == true {
-          ProgressView().controlSize(.small).padding(.trailing, 4)
+        if isInspecting {
+          Spacer()
+          Button("Done") { store.send(.remoteCancelled) }
+            .keyboardShortcut(.defaultAction)
+        } else {
+          Button("Cancel") { store.send(.remoteCancelled) }
+          Spacer()
+          if store.remoteDraft?.isValidating == true {
+            ProgressView().controlSize(.small).padding(.trailing, 4)
+          }
+          Button("Add") { store.send(.remoteSubmitted) }
+            .keyboardShortcut(.defaultAction)
+            .disabled(store.remoteDraft?.canSubmit != true)
         }
-        Button("Add") { store.send(.remoteSubmitted) }
-          .keyboardShortcut(.defaultAction)
-          .disabled(store.remoteDraft?.canSubmit != true)
       }
     }
     .padding(24)
     .frame(width: 460)
+  }
+
+  /// Selectable rather than a disabled `TextField`: the reason to open this sheet is to
+  /// read a value off it, and often to copy it.
+  private func value(
+    _ keyPath: KeyPath<WelcomeFeature.RemoteDraft, String>
+  ) -> some View {
+    let text = store.remoteDraft?[keyPath: keyPath] ?? ""
+    return Text(text.isEmpty ? "—" : text)
+      .font(.system(.body, design: .monospaced))
+      .foregroundStyle(text.isEmpty ? HierarchicalShapeStyle.secondary : .primary)
+      .textSelection(.enabled)
+      .frame(maxWidth: .infinity, alignment: .leading)
   }
 
   private func field(

--- a/graphcode/Sources/Features/Welcome/RemoteServerMenuItems.swift
+++ b/graphcode/Sources/Features/Welcome/RemoteServerMenuItems.swift
@@ -1,0 +1,23 @@
+import ComposableArchitecture
+import GraphcodeKit
+import SwiftUI
+
+/// The verbs a remote folder has and a local one doesn't, shared between the sidebar
+/// row's menu and the overview lane caption's — the band *is* the folder, so the two
+/// must not disagree about what you can do to it.
+///
+/// A remote project's connection is only ever visible as the `ssh://` path behind its
+/// display name, which reads as "repo @ host" and hides the user, port, and remote path
+/// entirely. This is where those are answerable without going to a terminal.
+struct RemoteServerMenuItems: View {
+  let store: StoreOf<AppFeature>
+  let projectPath: String
+
+  var body: some View {
+    if RemoteProjectLocation.parse(projectPath: projectPath) != nil {
+      Button("Server Parameters…") {
+        store.send(.welcome(.remoteParametersRequested(projectPath: projectPath)))
+      }
+    }
+  }
+}

--- a/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
+++ b/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
@@ -79,6 +79,24 @@ struct WelcomeFeature {
     var remotePath = ""
     var isValidating = false
     var failureMessage: String?
+    /// Set when the sheet is showing an already-added project's connection instead of
+    /// collecting a new one. Read-only in that mode: a remote project's identity *is*
+    /// its `ssh://` path, so changing a field here would name a different project rather
+    /// than edit this one.
+    var inspectedProjectPath: String?
+
+    var isInspecting: Bool { inspectedProjectPath != nil }
+
+    static func inspecting(
+      _ location: RemoteProjectLocation, projectPath: String
+    ) -> RemoteDraft {
+      RemoteDraft(
+        server: location.host,
+        port: location.port.map(String.init) ?? "22",
+        user: location.user ?? "",
+        remotePath: location.remotePath,
+        inspectedProjectPath: projectPath)
+    }
 
     /// The location the fields currently describe, or `nil` while they don't describe
     /// one — the Add button's enablement. The path must be absolute: `~` means nothing
@@ -97,7 +115,7 @@ struct WelcomeFeature {
         user: userName, host: host, port: portNumber, remotePath: path)
     }
 
-    var canSubmit: Bool { location != nil && !isValidating }
+    var canSubmit: Bool { location != nil && !isValidating && !isInspecting }
   }
 
   @ObservableState
@@ -128,6 +146,7 @@ struct WelcomeFeature {
     case cloneFinished(path: String)
     case cloneFailed(String)
     case addRemoteRepositoryButtonTapped
+    case remoteParametersRequested(projectPath: String)
     case remoteSubmitted
     case remoteCancelled
     case remoteValidated(projectPath: String)
@@ -268,6 +287,12 @@ struct WelcomeFeature {
 
       case .addRemoteRepositoryButtonTapped:
         state.remoteDraft = RemoteDraft()
+        return .none
+
+      case .remoteParametersRequested(let projectPath):
+        guard let location = RemoteProjectLocation.parse(projectPath: projectPath)
+        else { return .none }
+        state.remoteDraft = .inspecting(location, projectPath: projectPath)
         return .none
 
       case .remoteSubmitted:

--- a/graphcode/Tests/RemoteRepositoryTests.swift
+++ b/graphcode/Tests/RemoteRepositoryTests.swift
@@ -280,6 +280,64 @@ struct RemoteRepositoryTests {
     #expect(store.state.remoteDraft?.isValidating == false)
     #expect(store.state.remoteDraft?.failureMessage?.contains("zmx") == true)
   }
+
+  // MARK: - Server parameters
+
+  @Test
+  @MainActor
+  func serverParametersFillTheSheetFromTheProjectPath() async {
+    let store = TestStore(initialState: WelcomeFeature.State()) {
+      WelcomeFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .remoteParametersRequested(projectPath: "ssh://dev@build-box:2222/home/dev/widget"))
+
+    let draft = store.state.remoteDraft
+    #expect(draft?.server == "build-box")
+    #expect(draft?.user == "dev")
+    #expect(draft?.port == "2222")
+    #expect(draft?.remotePath == "/home/dev/widget")
+    // Read-only: the ssh:// path *is* the project's identity, so submitting an edited
+    // dial would open a second project rather than change this one.
+    #expect(draft?.isInspecting == true)
+    #expect(draft?.canSubmit == false)
+  }
+
+  @Test
+  @MainActor
+  func aLocalFolderHasNoServerParametersToShow() async {
+    let store = TestStore(initialState: WelcomeFeature.State()) {
+      WelcomeFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.remoteParametersRequested(projectPath: "/Users/dev/widget"))
+
+    #expect(store.state.remoteDraft == nil)
+  }
+
+  @Test
+  @MainActor
+  func inspectingRefusesToSubmit() async {
+    let store = TestStore(initialState: WelcomeFeature.State()) {
+      WelcomeFeature()
+    } withDependencies: {
+      $0.remoteRepositoryClient.validate = { _ in nil }
+      $0.orchestratorClient.send = { _ in
+        Issue.record("inspecting a remote must not re-open it")
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .remoteParametersRequested(projectPath: "ssh://dev@build-box:22/home/dev/widget"))
+    await store.send(.remoteSubmitted)
+    await store.finish()
+
+    #expect(store.state.remoteDraft?.isValidating == false)
+  }
 }
 
 private actor OpenedRemoteProjectsBox {


### PR DESCRIPTION
## What

Right-clicking a remote repository now offers **Server Parameters…**, which opens the same sheet as *Add Remote Repository* — pre-filled with that project's connection, and read-only.

| | |
|---|---|
| 🖱️ Where | Sidebar project row, and the overview lane caption (same menu, same folder) |
| 👁️ Mode | Read-only, values selectable for copying |
| 🔘 Buttons | Single **Done** |

## Why

A remote project's connection is only ever visible as the `ssh://` path behind its `repo @ host` display name, which hides the user, port, and remote path entirely. Answering "which box is this on, as whom, at what path?" meant going to a terminal.

## Why read-only

A remote project's identity *is* its `ssh://` path. `remoteValidated` unconditionally opens `location.projectPath`, so submitting an edited dial would open a **second** project and leave the original in the sidebar — that's a move, not an edit. `canSubmit` is false while inspecting, so `.remoteSubmitted` is a no-op even if something else sends it.

## Notes

- `RemoteServerMenuItems` mirrors the existing `FolderHygieneMenuItems` shape, so the sidebar row and the overview lane caption can't drift apart on what a folder offers.
- The sheet moves from `AppSidebarView` to the split view in `AppView`: the lane-caption menu is reachable with the sidebar column collapsed, and a sheet on a hidden column doesn't present. Behavior-preserving for the Add flow — same store, same condition.

## Verification

| Check | Result |
|---|---|
| `xcodebuild build` | ✅ |
| `xcodebuild test` | ✅ Test Succeeded |
| `make check` (swiftlint + swift-format) | ✅ exit 0 |
| New tests | ✅ 3 added to `RemoteRepositoryTests` — prefill from path, local folder is a no-op, inspecting refuses to submit |

Not visually verified in the running app — this environment has no screen-capture permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)