### PR TITLE
Name the remote sheet's read-only mode "Connection Info"

### DIFF
--- a/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
@@ -119,7 +119,7 @@ extension AppSidebarView {
     Button("Move Down") { store.send(.projectMoveDownTapped(project.id)) }
     Divider()
     FolderHygieneMenuItems(store: store, projectPath: project.id)
-    RemoteServerMenuItems(store: store, projectPath: project.id)
+    RemoteConnectionMenuItems(store: store, projectPath: project.id)
     Divider()
     Button("Close") { store.send(.projectCloseTapped(project.id)) }
     Button("Remove from GraphCode") { store.send(.projectRemoveTapped(project.id)) }

--- a/graphcode/Sources/Features/App/AppView.swift
+++ b/graphcode/Sources/Features/App/AppView.swift
@@ -52,7 +52,7 @@ struct AppView: View {
       OnboardingView { store.send(.onboardingDismissed) }
     }
     // On the split view rather than on the sidebar that opens it: the same sheet also
-    // shows an existing remote's parameters, and that menu is reachable from the
+    // shows an existing remote's connection, and that menu is reachable from the
     // overview's lane captions with the sidebar column collapsed.
     .sheet(
       isPresented: Binding(

--- a/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
@@ -96,7 +96,7 @@ extension GraphOverviewView {
       .contextMenu {
         if !folder.isGlobal {
           FolderHygieneMenuItems(store: store, projectPath: folder.path)
-          RemoteServerMenuItems(store: store, projectPath: folder.path)
+          RemoteConnectionMenuItems(store: store, projectPath: folder.path)
           Divider()
           Button("Close Folder") { store.send(.projectCloseTapped(folder.path)) }
         }

--- a/graphcode/Sources/Features/Welcome/RemoteConnectionMenuItems.swift
+++ b/graphcode/Sources/Features/Welcome/RemoteConnectionMenuItems.swift
@@ -9,14 +9,16 @@ import SwiftUI
 /// A remote project's connection is only ever visible as the `ssh://` path behind its
 /// display name, which reads as "repo @ host" and hides the user, port, and remote path
 /// entirely. This is where those are answerable without going to a terminal.
-struct RemoteServerMenuItems: View {
+struct RemoteConnectionMenuItems: View {
   let store: StoreOf<AppFeature>
   let projectPath: String
 
   var body: some View {
+    // No ellipsis, unlike the `Project Settings…` above it: nothing is asked of you
+    // here, and that pairing is what says which of the two is read-only.
     if RemoteProjectLocation.parse(projectPath: projectPath) != nil {
-      Button("Server Parameters…") {
-        store.send(.welcome(.remoteParametersRequested(projectPath: projectPath)))
+      Button("Connection Info") {
+        store.send(.welcome(.remoteConnectionRequested(projectPath: projectPath)))
       }
     }
   }

--- a/graphcode/Sources/Features/Welcome/RemoteRepositoryFormView.swift
+++ b/graphcode/Sources/Features/Welcome/RemoteRepositoryFormView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// repo, zmx being installed there), because each of those failures would otherwise
 /// surface later as a loop that silently does nothing.
 ///
-/// The same sheet doubles as the read-only view of an already-added remote's parameters
+/// The same sheet doubles as the read-only view of an already-added remote's connection
 /// (`RemoteDraft.isInspecting`), so the connection is described in one place and can't
 /// drift between the two.
 struct RemoteRepositoryFormView: View {
@@ -17,7 +17,7 @@ struct RemoteRepositoryFormView: View {
 
   var body: some View {
     VStack(spacing: 12) {
-      Text(isInspecting ? "Server Parameters" : "Add Remote Repository").font(.headline)
+      Text(isInspecting ? "Remote Connection" : "Add Remote Repository").font(.headline)
 
       Form {
         if isInspecting {

--- a/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
+++ b/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
@@ -146,7 +146,7 @@ struct WelcomeFeature {
     case cloneFinished(path: String)
     case cloneFailed(String)
     case addRemoteRepositoryButtonTapped
-    case remoteParametersRequested(projectPath: String)
+    case remoteConnectionRequested(projectPath: String)
     case remoteSubmitted
     case remoteCancelled
     case remoteValidated(projectPath: String)
@@ -289,7 +289,7 @@ struct WelcomeFeature {
         state.remoteDraft = RemoteDraft()
         return .none
 
-      case .remoteParametersRequested(let projectPath):
+      case .remoteConnectionRequested(let projectPath):
         guard let location = RemoteProjectLocation.parse(projectPath: projectPath)
         else { return .none }
         state.remoteDraft = .inspecting(location, projectPath: projectPath)

--- a/graphcode/Tests/RemoteRepositoryTests.swift
+++ b/graphcode/Tests/RemoteRepositoryTests.swift
@@ -281,18 +281,18 @@ struct RemoteRepositoryTests {
     #expect(store.state.remoteDraft?.failureMessage?.contains("zmx") == true)
   }
 
-  // MARK: - Server parameters
+  // MARK: - Connection info
 
   @Test
   @MainActor
-  func serverParametersFillTheSheetFromTheProjectPath() async {
+  func connectionInfoFillsTheSheetFromTheProjectPath() async {
     let store = TestStore(initialState: WelcomeFeature.State()) {
       WelcomeFeature()
     }
     store.exhaustivity = .off
 
     await store.send(
-      .remoteParametersRequested(projectPath: "ssh://dev@build-box:2222/home/dev/widget"))
+      .remoteConnectionRequested(projectPath: "ssh://dev@build-box:2222/home/dev/widget"))
 
     let draft = store.state.remoteDraft
     #expect(draft?.server == "build-box")
@@ -307,13 +307,13 @@ struct RemoteRepositoryTests {
 
   @Test
   @MainActor
-  func aLocalFolderHasNoServerParametersToShow() async {
+  func aLocalFolderHasNoConnectionInfoToShow() async {
     let store = TestStore(initialState: WelcomeFeature.State()) {
       WelcomeFeature()
     }
     store.exhaustivity = .off
 
-    await store.send(.remoteParametersRequested(projectPath: "/Users/dev/widget"))
+    await store.send(.remoteConnectionRequested(projectPath: "/Users/dev/widget"))
 
     #expect(store.state.remoteDraft == nil)
   }
@@ -332,7 +332,7 @@ struct RemoteRepositoryTests {
     store.exhaustivity = .off
 
     await store.send(
-      .remoteParametersRequested(projectPath: "ssh://dev@build-box:22/home/dev/widget"))
+      .remoteConnectionRequested(projectPath: "ssh://dev@build-box:22/home/dev/widget"))
     await store.send(.remoteSubmitted)
     await store.finish()
 


### PR DESCRIPTION
Follow-up to #73, renaming the string it introduced before it reaches a stable release.

## Why

| Problem with "Server Parameters…" | Fix |
|---|---|
| "Parameters" is config-file/API jargon; macOS says "Info" (Finder's Get Info) | **Connection Info** |
| "Server" names only one of the four values shown — login, port, and remote path are not server properties | "Connection" spans all four |
| Nothing distinguished it from the editable `Project Settings…` beside it | Settings = you change things, Info = you read things |

## The ellipsis

Dropped, deliberately. An ellipsis means the command needs further input before it can complete — which is why *Get Info* has none, and why `Delete Loops…` and `Project Settings…` keep theirs. A sheet whose only button is **Done** asks nothing. Sitting next to `Project Settings…`, the absence of the ellipsis is now itself the signal that this one is read-only.

## Scope

| Old | New |
|---|---|
| `"Server Parameters…"` (menu) | `"Connection Info"` |
| `"Server Parameters"` (sheet headline) | `"Remote Connection"` |
| `RemoteServerMenuItems` | `RemoteConnectionMenuItems` |
| `.remoteParametersRequested` | `.remoteConnectionRequested` |

No behavior change — the sheet, its gating, and the read-only rule are untouched.

## Verification

| Check | Result |
|---|---|
| `xcodebuild test` | ✅ Test Succeeded |
| `make check` | ✅ exit 0 |
| Renamed tests run | ✅ `connectionInfoFillsTheSheetFromTheProjectPath`, `aLocalFolderHasNoConnectionInfoToShow`, `inspectingRefusesToSubmit` |
| Stale references | ✅ none — grep for the old names is empty |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
