### PR TITLE
Stop a remote's main repository being sized as a worktree

### DIFF
--- a/GraphcodeKit/Sources/Domain/RemoteProjectLocation.swift
+++ b/GraphcodeKit/Sources/Domain/RemoteProjectLocation.swift
@@ -51,6 +51,24 @@ public struct RemoteProjectLocation: Equatable, Sendable {
     "\(Self.scheme)://\(authority)\(remotePath)"
   }
 
+  /// An absolute remote path reduced to the one spelling git will print for it, so two
+  /// spellings of one directory can be compared as strings.
+  ///
+  /// Purely textual, and deliberately so: `URL.resolvingSymlinksInPath` — what the local
+  /// twin in `GitClient` uses — would resolve a *server's* path against this Mac's
+  /// filesystem. Symlinks on the far side can only be resolved by asking the far side.
+  public static func normalizedPath(_ path: String) -> String {
+    var segments: [String] = []
+    for segment in path.split(separator: "/", omittingEmptySubsequences: true) {
+      switch segment {
+      case ".": continue
+      case "..": if !segments.isEmpty { segments.removeLast() }
+      default: segments.append(String(segment))
+      }
+    }
+    return "/" + segments.joined(separator: "/")
+  }
+
   /// `user@host` / `user@host:port` — what `ssh` is pointed at (port rides separately
   /// as `-p`, but the authority string carries it for identity and display).
   public var authority: String {

--- a/graphcode/Sources/Clients/RemoteGitClient.swift
+++ b/graphcode/Sources/Clients/RemoteGitClient.swift
@@ -32,8 +32,9 @@ extension RemoteGitClient: DependencyKey {
       let quoted = RemoteProjectLocation.shellQuoted
       let listCommand = "git -C \(quoted(location.remotePath)) worktree list --porcelain"
       let output = try await runSSH(location, listCommand)
+      let repositoryPath = await canonicalRepositoryPath(location)
       let blocks = parseWorktreeBlocks(output)
-        .filter { $0.path != location.remotePath }
+        .filter { RemoteProjectLocation.normalizedPath($0.path) != repositoryPath }
       let defaultBranch = await discoverDefaultBranch(location)
       var inspections = [WorktreeInspection?](repeating: nil, count: blocks.count)
       await withTaskGroup(of: (Int, WorktreeInspection)?.self) { group in
@@ -209,6 +210,24 @@ private func parseWorktreeBlocks(_ output: String) -> [WorktreeBlock] {
 }
 
 // MARK: - Remote git facts
+
+/// The spelling git itself will print for this repository, asked of the host.
+///
+/// The list has to drop the main working tree, and that comparison is exact. A stored
+/// path can differ from git's own by a trailing slash or a symlinked parent, and when it
+/// does the main repository survives the filter and reaches the sweeper as a worktree —
+/// the one directory holding the whole object store, every nested worktree and every
+/// build output, so it lands as a phantom row the size of the entire repository.
+///
+/// Falls back to the stored path normalized, which still answers the trailing slash when
+/// the host cannot be reached.
+private func canonicalRepositoryPath(_ location: RemoteProjectLocation) async -> String {
+  let quoted = RemoteProjectLocation.shellQuoted
+  let toplevel = try? await runSSH(
+    location, "git -C \(quoted(location.remotePath)) rev-parse --show-toplevel")
+  let path = toplevel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  return RemoteProjectLocation.normalizedPath(path.isEmpty ? location.remotePath : path)
+}
 
 private func discoverDefaultBranch(_ location: RemoteProjectLocation) async -> String {
   let quoted = RemoteProjectLocation.shellQuoted

--- a/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
+++ b/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
@@ -102,6 +102,10 @@ struct WelcomeFeature {
     /// one — the Add button's enablement. The path must be absolute: `~` means nothing
     /// until a shell on the *remote* machine expands it, and storing it unexpanded
     /// would bake the ambiguity into the project's identity.
+    ///
+    /// The path is normalized before it becomes that identity. A trailing slash is the
+    /// natural way to type a directory and git never prints one back, which left the two
+    /// spellings to be compared as strings elsewhere.
     var location: RemoteProjectLocation? {
       let host = server.trimmingCharacters(in: .whitespaces)
       let path = remotePath.trimmingCharacters(in: .whitespaces)
@@ -112,7 +116,8 @@ struct WelcomeFeature {
         let portNumber = Int(portText), (1...65535).contains(portNumber)
       else { return nil }
       return RemoteProjectLocation(
-        user: userName, host: host, port: portNumber, remotePath: path)
+        user: userName, host: host, port: portNumber,
+        remotePath: RemoteProjectLocation.normalizedPath(path))
     }
 
     var canSubmit: Bool { location != nil && !isValidating && !isInspecting }

--- a/graphcode/Tests/RemoteRepositoryTests.swift
+++ b/graphcode/Tests/RemoteRepositoryTests.swift
@@ -281,6 +281,34 @@ struct RemoteRepositoryTests {
     #expect(store.state.remoteDraft?.failureMessage?.contains("zmx") == true)
   }
 
+  // MARK: - Path normalization
+
+  /// The comparison that drops the main working tree from a worktree list is exact, and
+  /// git prints one canonical spelling. A stored path that disagrees by a trailing slash
+  /// survived that filter, and the main repository — the object store, every nested
+  /// worktree, every build output — was then sized and offered as a reclaimable worktree.
+  @Test
+  func aRemotePathReducesToTheSpellingGitPrints() {
+    #expect(RemoteProjectLocation.normalizedPath("/home/dev/widget/") == "/home/dev/widget")
+    #expect(RemoteProjectLocation.normalizedPath("/home/dev/widget///") == "/home/dev/widget")
+    #expect(RemoteProjectLocation.normalizedPath("//home//dev//widget") == "/home/dev/widget")
+    #expect(RemoteProjectLocation.normalizedPath("/home/dev/./widget") == "/home/dev/widget")
+    #expect(RemoteProjectLocation.normalizedPath("/home/dev/loops/../widget") == "/home/dev/widget")
+    // Already canonical, and the degenerate case: both must survive untouched.
+    #expect(RemoteProjectLocation.normalizedPath("/home/dev/widget") == "/home/dev/widget")
+    #expect(RemoteProjectLocation.normalizedPath("/") == "/")
+  }
+
+  @Test
+  func aTrailingSlashNeverReachesTheProjectIdentity() {
+    var draft = WelcomeFeature.RemoteDraft()
+    draft.server = "build-box"
+    draft.user = "dev"
+    draft.remotePath = "/home/dev/widget/"
+    #expect(draft.location?.remotePath == "/home/dev/widget")
+    #expect(draft.location?.projectPath == "ssh://dev@build-box:22/home/dev/widget")
+  }
+
   // MARK: - Connection info
 
   @Test


### PR DESCRIPTION
Remote worktree lists could show a row the size of the entire repository — 24 GB beside 200 MB worktrees.

## Root cause

The sweeper drops the main working tree from `git worktree list --porcelain` by comparing paths. The two clients did it differently:

```swift
.filter { resolvedPath($0.path) != repoPath }     // GitClient:82    — both sides normalized
.filter { $0.path != location.remotePath }        // RemoteGitClient:36 — raw string compare
```

git prints exactly one canonical spelling of a path. When the stored path disagrees, the main repository survives the filter and arrives in the sweeper as a worktree — and it is the one directory holding the whole object store, every nested worktree, and every build output.

## Two triggers, both reproduced

| Trigger | Evidence |
|---|---|
| **Trailing slash** — `/home/dev/repo/` passed the add form, which only checked `hasPrefix("/")` | `git -C /path/ worktree list --porcelain` printed `/path`; raw compare fails |
| **Symlinked parent** — no user error required | Reached via a symlink, git printed the *real* path while the stored path was the symlink |

Measured on this repository for scale: main repo **13.22 GB**, one real worktree **3.62 MB**.

## Secondary: it was preselected

A clean, pushed main repo scores `landed && clean && pushed` → `.safeToRemove`, and `isRemovable` is true, so the sweeper checked it by default. Acting on it failed safely — `git worktree remove` returns `fatal: '…' is a main working tree` (exit 128, verified), and the branch delete is sequenced after it with `try` — but the sheet offered space it could never reclaim, and its total was inflated by the whole repository.

## The fix

Ask the host for its own canonical spelling rather than deriving one here:

```
git -C <remotePath> rev-parse --show-toplevel
```

Verified to return the identical canonical path through both a trailing slash and a symlink, and it matches `worktree list --porcelain` output exactly.

This **cannot** be computed locally: `resolvingSymlinksInPath()` — what the local twin uses — would resolve a *server's* path against this Mac's filesystem. Only the far side can resolve the far side's symlinks.

Three layers:

1. `RemoteProjectLocation.normalizedPath` — pure, textual (trailing slashes, `//`, `.`, `..`), no filesystem access, safe for a foreign path.
2. `canonicalRepositoryPath` — `rev-parse --show-toplevel`, falling back to the normalized stored path so the trailing-slash case is still answered when the host is unreachable.
3. The add form normalizes before the path becomes a project identity, so a trailing slash never gets stored again.

Existing remote projects keep their identity — no migration, the comparison is fixed at the point of use.

## Verification

| Check | Result |
|---|---|
| `xcodebuild test` | ✅ Test Succeeded |
| `make check` | ✅ exit 0 |
| New tests | ✅ `aRemotePathReducesToTheSpellingGitPrints`, `aTrailingSlashNeverReachesTheProjectIdentity` |
| Non-vacuous | ✅ both fail without the fix — `normalizedPath` is new, and `location` previously returned `/home/dev/widget/` |

Local folders were investigated first and are unaffected: `du -sk` × 1024 is correct, symlinks are not followed, and the formatter is shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
