### PR TITLE
docs: put cross-vendor orchestration in the pitch, not just the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://graphcode.app/">
-    <img src="docs/assets/banner.png" alt="GraphCode — graphs of live, steerable Claude Code sessions on macOS" width="100%">
+    <img src="docs/assets/banner.png" alt="GraphCode — graphs of live, steerable coding-agent sessions on macOS" width="100%">
   </a>
 </p>
 
@@ -22,6 +22,10 @@ connected, unattended, and still yours to attach to and correct mid-run. Each no
 graph is a unit of work running inside a real CLI coding-agent session; each edge is a
 hand-off, message, or spawn between them. The sessions are real terminals you can attach
 to, watch, and steer — not headless jobs that report back when they're done.
+
+The nodes don't have to be the same agent. Claude Code, Codex and Copilot CLI all host
+loops and all take input mid-session, so an edge can hand work from a Claude Code loop to
+a Codex one on the same graph — one graph, spanning vendors.
 
 **[Graph Engineering, simplified →](https://graphcode.app/)** — the full
 article: the mental model, then the machinery underneath it.

--- a/README.md
+++ b/README.md
@@ -183,11 +183,15 @@ Design docs live in `docs/` and are kept local (gitignored) for now.
 - **Apple Silicon only.** GhosttyKit is built for the native architecture; there is no
   x86_64 slice, so a universal build won't link.
 - **Claude Code is the most complete backend.** Copilot CLI and Codex loops launch, run,
-  fan out, resume after a reboot, and receive message edges like Claude ones. Copilot
-  presence is read from its event log (local and remote), so a Copilot loop waiting for
-  input shows as "NEEDS YOU"; usage stays Claude Code-only. The picker refuses pairings a
-  backend can't host (time-based needs the session to re-trigger itself; composites need
-  verified sub-agents).
+  resume after a reboot, and receive message edges like Claude ones, and all three report
+  the tool call a loop is currently inside. Two loop types are narrower: only Claude Code
+  hosts a composite, which needs sub-agents neither other CLI exposes, and Codex can't
+  host a time-based loop, since the cadence lives in the session and Codex has no
+  `/loop` of its own. Presence comes from lifecycle hooks for Claude Code, the event log
+  for Copilot, and the notify hook for Codex, so a loop waiting for input shows as
+  "NEEDS YOU" on all three. Usage stays Claude Code-only, and remote Copilot and Codex
+  loops report no activity, because the log it is read from sits on the far host. The
+  picker refuses pairings a backend can't host.
 - **A new folder stops at Claude's trust prompt.** An unattended loop started by the daemon
   in a folder Claude hasn't seen waits at *"Do you trust this folder?"* and shows as
   `running` while doing nothing. Attach once and answer it.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -35,7 +35,8 @@
             <span class="gc-wordmark">Graph<span class="gc-thin">Code</span></span>
           </div>
           <p class="gc-tagline">
-            Graphs of <strong>live, steerable Claude&nbsp;Code sessions</strong> on macOS.
+            Graphs of <strong>live, steerable coding-agent sessions</strong> on macOS —
+            Claude&nbsp;Code, Codex and Copilot&nbsp;CLI loops on one graph.
             Run ten at once — connected, unattended, still yours to attach to and correct mid-run.
           </p>
           <div class="gc-install">

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,15 @@
 ---
 title: Graph Engineering, Simplified — with GraphCode
-description: Graph engineering for coding agents on macOS — loops and their types, self-improving loops, and the machinery underneath.
+description: Graph engineering for coding agents on macOS — Claude Code, Codex and Copilot CLI loops on one graph: loop types, self-improving loops, and the machinery underneath.
 ---
 
 # Graph Engineering, simplified — with GraphCode
 
 You can run one Claude Code session in a terminal. GraphCode lets you run ten —
-connected, unattended, and still yours to attach to and correct mid-run. That's
-**graph engineering**: your agents' work arranged as a graph you design, instead of a
-pile of terminals you babysit.
+connected, unattended, and still yours to attach to and correct mid-run. And they don't
+all have to be Claude Code: Codex and Copilot CLI loops sit on the same graph, so an edge
+can hand work from one vendor's agent to another's. That's **graph engineering**: your
+agents' work arranged as a graph you design, instead of a pile of terminals you babysit.
 
 Requires **macOS 15+ on Apple Silicon**, with **Claude Code on your `PATH`** —
 GraphCode launches it, it doesn't bundle it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -339,11 +339,18 @@ always loads in today's.
 
 ### What runs today
 
-Claude Code is the most complete backend. Copilot CLI and Codex loops launch, run, fan
-out on their own provider, message, and keep memory like Claude ones. Copilot presence
-is read from its event log (local and remote), so a Copilot loop waiting for input
-shows as "NEEDS YOU"; usage stays Claude Code-only. The picker refuses pairings a
-backend can't host. Current rough edges live in the README's
+Claude Code is the most complete backend — the only one that can host a composite, and
+the only one whose presence comes from lifecycle hooks graphcode installs rather than
+from a log the CLI writes anyway. Copilot CLI and Codex loops launch, run, message, and
+keep memory like Claude ones; Copilot takes time-based loops too, because its session can
+re-trigger its own work, and Codex can't, so the picker refuses that pairing rather than
+letting a `/loop …` prompt run once and look like a broken schedule.
+
+All three report **what a loop is doing right now** — the tool call it is still inside,
+not merely that it is busy — each read from what that CLI already writes: Claude Code's
+hooks, Copilot's `events.jsonl`, Codex's rollout file. Remote Copilot and Codex loops are
+the exception, since those logs sit on the far host, so their cards show the goal instead.
+Usage stays Claude Code-only. Current rough edges live in the README's
 [Known limitations](https://github.com/scgopi/GraphCode#known-limitations).
 
 ---


### PR DESCRIPTION
## What

Three surfaces named a single vendor. Every one of them is above the fold:

| Surface | Before | After |
|---|---|---|
| `docs/_layouts/default.html` — hero tagline on **every page** of graphcode.app | "Graphs of live, steerable **Claude Code** sessions on macOS." | "Graphs of live, steerable **coding-agent** sessions on macOS — Claude Code, Codex and Copilot CLI loops on one graph." |
| `README.md` — opening block | no mention of other backends | one sentence: an edge can hand work from a Claude Code loop to a Codex one |
| `docs/index.md` — front-matter `description` (the search/link-card line) | "…for coding agents on macOS" | names the three backends |

## Why

Running ten agents in parallel is the claim every competitor in this category already
makes. A graph whose **edges cross vendors** is the one neither Anthropic nor GitHub can
answer with a point release — and it was in the code and absent from the pitch.

`graphcode.app` is currently the **#2 referrer** to this repo (187 views / 26 uniques,
14d), behind only `github.com`. That hero line is the highest-traffic sentence the
project owns.

## The claim is bounded by what the code actually does

From `GraphcodeKit/Sources/Domain/BackendCapabilities.swift`:

- All three rows are spiked (`isSpiked` is `true` for `claudeCode`, `copilotCLI`, `codex`).
- All three set `supportsMidSessionInput: true`, which is the capability gating the `to`
  side of a `.message` edge; `.handoff` and `.spawn` are strictly more permissive because
  they start a session rather than interrupt one.

Nothing here claims parity between backends — "Claude Code is the most complete backend"
stays exactly as written further down `index.md`.

## Not done here, flagged for a decision

The GitHub repo description still reads *"…and work that continues without you."* That
sentence describes something the CLI vendors now ship themselves (mobile push on
needs-input, Remote Control). It's a settings-page edit rather than a file in this diff —
worth changing to lead with the graph, but that's your call, not a silent push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)