### PR TITLE
Report what each loop is doing, not just that it is running

### DIFF
--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -290,8 +290,10 @@ public actor GraphStore {
       // channel, and a second command on its own timer would triple the subprocess count
       // for the sake of separating three `zmx get`s.
       await refreshUsage()
-      await refreshActivity()
+      // Presence first: `refreshActivity` only asks the sessions that are working, so
+      // asking it against last tick's readings would describe the wrong ones.
       await refreshPresence()
+      await refreshActivity()
     }
 
     // Guarded re-fires need an `until` predicate answered first, which means a
@@ -426,18 +428,32 @@ public actor GraphStore {
     }
   }
 
-  /// Asks each live session what it is doing. Same shape and same honesty as
+  /// Asks each *working* session what it is doing. Same shape and same honesty as
   /// `refreshUsage`: a session reporting nothing keeps `activity == nil`, and the card's
   /// live line falls back to what the loop was handed rather than to a stale line from
   /// twenty minutes ago.
   ///
   /// Unreported is written back too — that is what clears the label when a session ends,
   /// so a finished loop doesn't keep claiming to be editing a file.
-  private func refreshActivity() async {
-    guard let onReadActivity else { return }
+  ///
+  /// **Only sessions `refreshPresence` just found busy are asked.** A loop that has
+  /// answered, stopped or gone is not doing anything, so its last reported activity is a
+  /// sentence about the past whatever the label still holds — clearing it costs nothing
+  /// and probing for it would cost a subprocess per quiet loop per tick, which on a remote
+  /// project is an ssh round trip. The cost of the live line is therefore paid only by the
+  /// loops that have something to say.
+  @discardableResult
+  private func refreshActivity() async -> Bool {
+    guard let onReadActivity else { return false }
+    var changed = false
     for node in graph.nodes {
-      graph.nodes[id: node.id]?.activity = await onReadActivity(node, graph.project.path)
+      let working = !node.isResolved && node.presence?.presence == .busy
+      let reported = working ? await onReadActivity(node, graph.project.path) : nil
+      guard graph.nodes[id: node.id]?.activity != reported else { continue }
+      graph.nodes[id: node.id]?.activity = reported
+      changed = true
     }
+    return changed
   }
 
   /// Asks each session what it is doing, the third reading on the same channel and the
@@ -497,7 +513,13 @@ public actor GraphStore {
   /// write per tick, forever, of the one field that is deliberately never restored.
   public func pollPresence() async {
     guard !connections.isEmpty, onReadPresence != nil else { return }
-    guard await refreshPresence() else { return }
+    // Both, and in this order, because they are one answer to a human: the pill says a
+    // loop is working and the line under it says what at. Reading the second only when
+    // someone presses refresh left every card describing the tool call its session made
+    // whenever that happened to be.
+    var changed = await refreshPresence()
+    if await refreshActivity() { changed = true }
+    guard changed else { return }
     notifyClients()
   }
 

--- a/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
+++ b/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
@@ -28,6 +28,13 @@ public enum PresenceHooks {
     directory.appendingPathComponent("\(backend.rawValue).json")
   }
 
+  /// The `PreToolUse` reporter, kept as a file next to the settings that name it: it is a
+  /// dozen lines of `case` and `sed`, and `zmx` types a launch command into a tty capped
+  /// at `MAX_CANON` — the same reason the settings themselves travel by path.
+  public static var activityScriptFile: URL {
+    directory.appendingPathComponent("activity.sh")
+  }
+
   /// Which of a backend's lifecycle events mean what, in the backend's own event names.
   ///
   /// `nil` for a backend with no hook mechanism at all, which is the honest answer for
@@ -63,9 +70,83 @@ public enum PresenceHooks {
   /// `$ZMX_SESSION` guard covers the case where this file reaches a session graphcode
   /// didn't start: there is no session store to write into, and `zmx set` against a name
   /// that doesn't exist is an error a human would see on their own terminal.
-  static func report(_ presence: Presence, zmxPath: String) -> String {
-    "if [ -n \"$ZMX_SESSION\" ]; then \(singleQuoted(zmxPath)) set \"$ZMX_SESSION\" "
-      + "presence=\(presence.rawValue) >/dev/null 2>&1; fi; exit 0"
+  ///
+  /// `clearingActivity` drops the activity label in the same write, and every event
+  /// except `PreToolUse` asks for it. Only a tool call knows what a session is doing; the
+  /// moment it answers, stops, or ends, the last thing it was doing is a sentence about
+  /// the past, and a card still reading "editing LoopNode.swift" under an IDLE pill is
+  /// exactly the stale claim the presence work removed from the pill itself.
+  static func report(_ presence: Presence, zmxPath: String, clearingActivity: Bool = false)
+    -> String
+  {
+    // `k=` is how `zmx` removes a label, so this is one process, not two.
+    let labels = "presence=\(presence.rawValue)" + (clearingActivity ? " activity=" : "")
+    return "if [ -n \"$ZMX_SESSION\" ]; then \(singleQuoted(zmxPath)) set \"$ZMX_SESSION\" "
+      + "\(labels) >/dev/null 2>&1; fi; exit 0"
+  }
+
+  /// The `PreToolUse` body that runs `activityScript`, guarded so a missing file is a
+  /// no-op rather than a hook error printed on the human's own turn.
+  ///
+  /// Left as a second command beside the presence report rather than folded into the
+  /// script: presence is the signal the pill, the attention rollup and `MessageBus` all
+  /// key off, and it must not stop being reported because a `sed` in the reporter of a
+  /// nicety went wrong.
+  static func reportActivity(scriptPath: String) -> String {
+    "if [ -r \(scriptPath) ]; then /bin/sh \(scriptPath); fi; exit 0"
+  }
+
+  /// What the session is doing, in its own words, derived from the `PreToolUse` payload
+  /// on stdin — `"editing LoopNode.swift"`, `"running make check"`.
+  ///
+  /// This is the write half of `LoopNode.activity`, which shipped with a reader, a card
+  /// row and a fallback, and nothing at all that wrote it. Without it every busy loop's
+  /// card said RUNNING over the sentence it was created with, however long ago that was
+  /// and whatever it had moved on to since.
+  ///
+  /// **Why the value is encoded.** A `zmx` label store is `k=v` pairs separated by spaces
+  /// and its parser takes only `[A-Za-z0-9._-]` in a value, so `activity=editing Loop.swift`
+  /// silently stores `editing`. Every disallowed byte becomes a space, every space becomes
+  /// `_20` and every literal underscore `_5F` — percent-encoding with `_` for `%`, since
+  /// `%` is no more allowed than a space is. `ZmxSessionLauncher.decodedActivity` reads it
+  /// back.
+  ///
+  /// **It cannot fail and it cannot block.** A `PreToolUse` hook exiting 2 blocks the tool
+  /// call it was only trying to describe, and any other non-zero exit prints a hook error
+  /// over the human's session. Every path here ends `exit 0`. The payload is read with
+  /// `head -c` for the same reason: a `Write` of a large file arrives here in full, and
+  /// this is not the place to spend it.
+  static func activityScript(zmxPath: String) -> String {
+    """
+    # Written by graphcode. Reports what this session is doing, for its card in the graph.
+    [ -n "$ZMX_SESSION" ] || exit 0
+    payload=$(head -c 4096 | tr '\\n' ' ')
+    field() {
+      printf '%s' "$payload" |
+        sed -n "s/.*\\"$1\\"[[:space:]]*:[[:space:]]*\\"\\([^\\"]*\\)\\".*/\\1/p"
+    }
+    tool=$(field tool_name)
+    case "$tool" in
+      Edit|Write|MultiEdit|NotebookEdit) target=$(field file_path); phrase="editing ${target##*/}" ;;
+      Read) target=$(field file_path); phrase="reading ${target##*/}" ;;
+      Bash|BashOutput) phrase="running $(field command)" ;;
+      Grep) phrase="searching for $(field pattern)" ;;
+      Glob) phrase="looking for $(field pattern)" ;;
+      WebSearch) phrase="searching the web for $(field query)" ;;
+      WebFetch) target=$(field url); target=${target#*//}; phrase="reading ${target%%/*}" ;;
+      Task|Agent) phrase="delegating $(field description)" ;;
+      Skill) phrase="running the $(field skill) skill" ;;
+      TodoWrite|TaskCreate|TaskUpdate) phrase="planning" ;;
+      mcp__*) phrase="using ${tool##*__}" ;;
+      "") phrase="" ;;
+      *) phrase="using $tool" ;;
+    esac
+    encoded=$(printf '%s' "$phrase" | cut -c1-64 |
+      sed 's/_/_5F/g' | tr -c 'A-Za-z0-9._-' ' ' | tr -s ' ' |
+      sed 's/^ *//; s/ *$//; s/ /_20/g')
+    \(singleQuoted(zmxPath)) set "$ZMX_SESSION" "activity=$encoded" >/dev/null 2>&1
+    exit 0
+    """
   }
 
   /// Captures Claude Code's session ID for `--resume` after a reboot.
@@ -98,6 +179,13 @@ public enum PresenceHooks {
 
   public static let remoteSessionsExpression = "\"$HOME/.graphcode/sessions\""
 
+  /// Where `activityScript` lands, in the same two shapes and for the same reason.
+  static var localActivityScriptExpression: String {
+    singleQuoted(activityScriptFile.path)
+  }
+
+  public static let remoteActivityScriptExpression = "\"$HOME/.graphcode/hooks/activity.sh\""
+
   /// The remote twin of `SessionIDStore.file(forNodeID:)` — the file the remote
   /// `SessionStart` hook wrote, as a shell expression the ensure dial can `cat`.
   ///
@@ -115,12 +203,19 @@ public enum PresenceHooks {
   /// path, not a syntax error.
   public static func json(
     forBackend backend: CLISessionBackendKind, zmxPath: String,
-    sessionsDirectory: String? = nil
+    sessionsDirectory: String? = nil, activityScriptPath: String? = nil
   ) -> String? {
     guard let events = events(forBackend: backend) else { return nil }
     let sessions = sessionsDirectory ?? localSessionsExpression
+    let script = activityScriptPath ?? localActivityScriptExpression
     let hooks = events.reduce(into: [String: [Matcher]]()) { result, event in
-      var commands = [Command(command: report(event.1, zmxPath: zmxPath))]
+      let isToolUse = event.0 == "PreToolUse"
+      var commands = [
+        Command(command: report(event.1, zmxPath: zmxPath, clearingActivity: !isToolUse))
+      ]
+      if isToolUse && backend == .claudeCode {
+        commands.append(Command(command: reportActivity(scriptPath: script)))
+      }
       if event.0 == "SessionStart" && backend == .claudeCode {
         commands.append(Command(command: captureSessionID(sessionsDirectory: sessions)))
       }
@@ -145,6 +240,11 @@ public enum PresenceHooks {
     let url = file(forBackend: backend)
     do {
       try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      // Best-effort, and deliberately not part of the `do`: the settings must still be
+      // written if this fails, because presence is the signal that matters and the hook
+      // that runs this file checks it is readable first.
+      try? activityScript(zmxPath: ZmxLocator.binaryURL.path)
+        .write(to: activityScriptFile, atomically: true, encoding: .utf8)
       try json.write(to: url, atomically: true, encoding: .utf8)
       return url
     } catch {
@@ -178,11 +278,17 @@ public enum PresenceHooks {
     guard
       let json = json(
         forBackend: .claudeCode, zmxPath: "zmx",
-        sessionsDirectory: remoteSessionsExpression)
+        sessionsDirectory: remoteSessionsExpression,
+        activityScriptPath: remoteActivityScriptExpression)
     else { return nil }
     // `|| true` so both call sites can chain it with `&&` — a failed write must never
-    // block the launch it precedes.
-    return "{ mkdir -p \"$HOME/.graphcode/hooks\" && printf '%s' \(singleQuoted(json))"
+    // block the launch it precedes. The reporter goes first: the settings that name it
+    // are what makes it run, and a host that takes one write and not the other should
+    // fail towards a hook file pointing at a script that is already there.
+    return "{ mkdir -p \"$HOME/.graphcode/hooks\""
+      + " && printf '%s' \(singleQuoted(activityScript(zmxPath: "zmx")))"
+      + " > \(remoteActivityScriptExpression)"
+      + " && printf '%s' \(singleQuoted(json))"
       + " > \"\(remotePathExpression)\"; } 2>/dev/null || true"
   }
 

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -169,7 +169,44 @@ public enum ZmxSessionLauncher {
       .split(whereSeparator: \.isWhitespace)
       .joined(separator: " ")
     guard !collapsed.isEmpty else { return nil }
-    return String(collapsed.prefix(maxActivityLength))
+    let decoded =
+      decodedActivity(collapsed)
+      .split(whereSeparator: \.isWhitespace)
+      .joined(separator: " ")
+    guard !decoded.isEmpty else { return nil }
+    return String(decoded.prefix(maxActivityLength))
+  }
+
+  /// Turns a label value back into the sentence the hook meant to write: `_20` is a space
+  /// and `_5F` an underscore, per `PresenceHooks.activityScript`, which encodes because a
+  /// `zmx` label value may hold only `[A-Za-z0-9._-]`.
+  ///
+  /// Anything that isn't `_` followed by two hex digits is text, so a value written by a
+  /// graphcode older than the encoding — or by hand — comes back untouched. The one thing
+  /// this cannot tell apart is a filename that genuinely reads `_20`, which the writer
+  /// would have escaped to `_5F20`; a label from anywhere else with that in it decodes to
+  /// a space, and a wrong space in a status line is the smallest failure available here.
+  static func decodedActivity(_ value: String) -> String {
+    var decoded = ""
+    var index = value.startIndex
+    while index < value.endIndex {
+      let character = value[index]
+      let afterEscape = value.index(after: index)
+      // Printable ASCII only. The writer emits two escapes and both are in that range;
+      // anything else claiming to be one is a control character on its way to a label
+      // that is drawn on a card.
+      guard character == "_",
+        let hexEnd = value.index(afterEscape, offsetBy: 2, limitedBy: value.endIndex),
+        let byte = UInt8(value[afterEscape..<hexEnd], radix: 16), (0x20...0x7E).contains(byte)
+      else {
+        decoded.append(character)
+        index = afterEscape
+        continue
+      }
+      decoded.append(Character(UnicodeScalar(byte)))
+      index = hexEnd
+    }
+    return decoded
   }
 
   /// One line of a 250pt card, at 10.5pt mono. Past this a label is not being read, it

--- a/docs/index.md
+++ b/docs/index.md
@@ -322,11 +322,14 @@ the text — otherwise every message rendered in the composer and sat there, uns
 
 ### Reported, never estimated
 
-GraphCode can't see inside a running agent. Presence and token usage are read from
-per-session labels the backend's own hooks can set; without hooks the UI says "not
-reported" rather than showing a zero nobody measured. The same honesty rule shapes the
-metric design: numbers a decision rests on come from running the command, not from the
-loop's account of itself.
+GraphCode can't see inside a running agent. Presence, what a session is currently doing,
+and token usage are read from per-session labels the backend's own hooks can set; without
+hooks the UI says "not reported" rather than showing a zero nobody measured. That third
+label is what puts `editing GraphStore.swift` or `running make check` under a card's
+RUNNING pill — the tool call the agent is making, reported by its own `PreToolUse` hook,
+never scraped from the terminal. A card with nothing reported falls back to the goal or
+prompt the loop was handed. The same honesty rule shapes the metric design: numbers a
+decision rests on come from running the command, not from the loop's account of itself.
 
 ### State: one directory, plain JSON
 

--- a/graphcode/Tests/PresencePollingTests.swift
+++ b/graphcode/Tests/PresencePollingTests.swift
@@ -139,6 +139,88 @@ struct PresencePollingTests {
     #expect(updated?.displayState == .idle)
   }
 
+  // MARK: - The line under the pill
+
+  /// Answers "what is it doing", and counts who was asked — the second half of the cost
+  /// model, since this reading rides the same tick as presence.
+  private actor ActivityProbe {
+    private(set) var asked: [String] = []
+    private var answer = "editing GraphStore.swift"
+
+    func setAnswer(_ text: String) { answer = text }
+
+    func read(_ node: LoopNode) -> String? {
+      asked.append(node.title)
+      return answer
+    }
+  }
+
+  @Test
+  func aWorkingLoopIsAskedWhatItIsWorkingOn() async {
+    // The poll used to refresh presence alone, so a card's live line only ever moved when
+    // a human pressed refresh — every loop said RUNNING over the sentence it was created
+    // with, however long ago that was.
+    let presence = Probe()
+    await presence.answer("A", with: .busy)
+    let activity = ActivityProbe()
+    let store = GraphStore(
+      graph: graph([node("A", .running)]),
+      onReadActivity: { node, _ in await activity.read(node) },
+      onReadPresence: { node, _ in await presence.read(node) })
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+
+    #expect(await activity.asked == ["A"])
+    #expect(await store.graph.nodes.first?.activity == "editing GraphStore.swift")
+  }
+
+  @Test
+  func aQuietLoopIsNotAskedAndStopsClaimingToBeMidEdit() async {
+    // A loop that has answered is not editing anything, whatever its label still holds.
+    // Clearing without a probe is both the honest answer and the cheap one — on a remote
+    // project each of these is an ssh round trip.
+    let presence = Probe()
+    await presence.answer("busy", with: .busy)
+    await presence.answer("quiet", with: .idle)
+    let activity = ActivityProbe()
+    var stale = node("quiet", .running)
+    stale.activity = "editing GraphStore.swift"
+    let store = GraphStore(
+      graph: graph([node("busy", .running), stale, node("done", .succeeded)]),
+      onReadActivity: { node, _ in await activity.read(node) },
+      onReadPresence: { node, _ in await presence.read(node) })
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+
+    #expect(await activity.asked == ["busy"])
+    #expect(await store.graph.nodes[id: stale.id]?.activity == nil)
+  }
+
+  @Test
+  func aChangedActivityAloneIsWorthTellingSomeoneAbout() async {
+    // Presence settles at busy and stays there while the work moves from file to file.
+    // Keying the notify off presence alone would freeze the line at the first reading.
+    let presence = Probe()
+    await presence.answer("A", with: .busy)
+    let activity = ActivityProbe()
+    let store = GraphStore(
+      graph: graph([node("A", .running)]),
+      onReadActivity: { node, _ in await activity.read(node) },
+      onReadPresence: { node, _ in await presence.read(node) })
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    await activity.setAnswer("running make check")
+    await store.pollPresence()
+
+    #expect(await store.graph.nodes.first?.activity == "running make check")
+  }
+
   @Test
   func theIntervalIsSlowEnoughToBeBackgroundNoise() {
     // Fifteen seconds is the lag a human sees between a loop finishing and its card

--- a/graphcode/Tests/PresenceReportingTests.swift
+++ b/graphcode/Tests/PresenceReportingTests.swift
@@ -45,6 +45,186 @@ struct PresenceReportingTests {
     #expect(command(for: "SessionEnd")?.contains("presence=absent") == true)
   }
 
+  // MARK: - What the session is doing
+
+  /// Every command a given event runs, not just the first: `PreToolUse` reports a presence
+  /// *and* runs the activity reporter, and the two are separate on purpose.
+  private func commands(for event: String, zmxPath: String? = nil) -> [String] {
+    guard let matchers = hooks(.claudeCode, zmxPath: zmxPath)?[event] as? [[String: Any]],
+      let entries = matchers.first?["hooks"] as? [[String: Any]]
+    else { return [] }
+    return entries.compactMap { $0["command"] as? String }
+  }
+
+  /// Runs the generated reporter the way Claude Code runs it — `/bin/sh`, the hook payload
+  /// on stdin — against a `zmx` that records what it was asked to set. The label it wrote,
+  /// or `nil` if it wrote nothing.
+  ///
+  /// Through a real shell rather than by asserting on the script's text: the whole risk in
+  /// this file is that a `sed` expression survives being Swift, being JSON and being shell
+  /// and still doesn't match what a hook actually receives.
+  private func reportedLabel(for payload: String) throws -> String? {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("graphcode-activity-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let recording = directory.appendingPathComponent("set.txt")
+    let fakeZmx = directory.appendingPathComponent("zmx")
+    try "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '\(recording.path)'\n"
+      .write(to: fakeZmx, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o755], ofItemAtPath: fakeZmx.path)
+
+    let script = directory.appendingPathComponent("activity.sh")
+    try PresenceHooks.activityScript(zmxPath: fakeZmx.path)
+      .write(to: script, atomically: true, encoding: .utf8)
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sh")
+    process.arguments = [script.path]
+    process.environment = ["ZMX_SESSION": "graphcode-test", "PATH": "/usr/bin:/bin"]
+    let input = Pipe()
+    process.standardInput = input
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    try process.run()
+    input.fileHandleForWriting.write(Data(payload.utf8))
+    try input.fileHandleForWriting.close()
+    process.waitUntilExit()
+
+    // Never non-zero: `PreToolUse` treats 2 as "block this tool call" and anything else
+    // non-zero as an error to print over the human's own session.
+    #expect(process.terminationStatus == 0)
+    guard let recorded = try? String(contentsOf: recording, encoding: .utf8),
+      let line = recorded.split(separator: "\n").last,
+      let label = line.split(separator: " ").last.map(String.init)
+    else { return nil }
+    return label
+  }
+
+  /// What a card would show for a payload — both halves of the channel, since an encoding
+  /// the reader can't undo is the same bug as no encoding at all.
+  private func activity(for payload: String) throws -> String? {
+    guard let label = try reportedLabel(for: payload) else { return nil }
+    return ZmxSessionLauncher.parseActivityLabel(label)
+  }
+
+  private func payload(tool: String, _ input: String) -> String {
+    """
+    {"session_id":"a","cwd":"/w","hook_event_name":"PreToolUse","tool_name":"\(tool)",\
+    "tool_input":\(input),"tool_use_id":"toolu_1"}
+    """
+  }
+
+  @Test
+  func aToolCallSaysWhatItIsDoingToWhat() throws {
+    // The complaint this answers: eight loops, all of them RUNNING, none of them saying
+    // what they were running.
+    #expect(
+      try activity(for: payload(tool: "Edit", #"{"file_path":"/w/GraphStore.swift"}"#))
+        == "editing GraphStore.swift")
+    #expect(
+      try activity(for: payload(tool: "Read", #"{"file_path":"/w/docs/04-cli-backends.md"}"#))
+        == "reading 04-cli-backends.md")
+    #expect(
+      try activity(for: payload(tool: "Bash", #"{"command":"make check","description":"gate"}"#))
+        == "running make check")
+    #expect(
+      try activity(for: payload(tool: "Grep", #"{"pattern":"refreshActivity"}"#))
+        == "searching for refreshActivity")
+    #expect(
+      try activity(for: payload(tool: "Task", #"{"description":"Find flaky tests"}"#))
+        == "delegating Find flaky tests")
+  }
+
+  @Test
+  func aToolNobodyMappedStillSaysSomething() throws {
+    // A card reading "using WebSearch" is worth more than a card reading nothing, and the
+    // set of tools is not ours to keep up with.
+    #expect(try activity(for: payload(tool: "ExitPlanMode", "{}")) == "using ExitPlanMode")
+    #expect(
+      try activity(for: payload(tool: "mcp__playwright__browser_click", "{}"))
+        == "using browser_click")
+  }
+
+  @Test
+  func aPayloadWithNoToolInItReportsNothing() throws {
+    // `k=` is how `zmx` removes a label, so the card falls back to what the loop was
+    // handed rather than keeping the last sentence forever.
+    #expect(try reportedLabel(for: "{}") == "activity=")
+    #expect(try activity(for: "{}") == nil)
+  }
+
+  @Test
+  func theLabelOnlyEverHoldsCharactersZmxWillKeep() throws {
+    // `zmx` takes `[A-Za-z0-9._-]` in a value and silently truncates at the first space:
+    // `activity=editing Loop.swift` stores `editing`. Everything else is encoded, and
+    // this is the assertion that says so for a deliberately hostile command.
+    let hostile = payload(
+      tool: "Bash", #"{"command":"git log --oneline | grep 'fix: don_t' > /tmp/x"}"#)
+    let label = try #require(try reportedLabel(for: hostile))
+    let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz")
+      .union(CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-="))
+
+    #expect(label.unicodeScalars.allSatisfy(allowed.contains))
+    // And it still reads as a sentence on the other side.
+    #expect(try activity(for: hostile)?.hasPrefix("running git log") == true)
+  }
+
+  @Test
+  func anUnderscoreSurvivesTheRoundTrip() {
+    // The one character the encoding has to escape as well as spaces, or every
+    // `snake_case` filename comes back mangled — `_5F` is a literal underscore.
+    #expect(
+      ZmxSessionLauncher.decodedActivity("editing_20loop_5Fnode.swift") == "editing loop_node.swift"
+    )
+    // A value written before the encoding existed, or by hand, is text.
+    #expect(ZmxSessionLauncher.decodedActivity("thinking") == "thinking")
+    #expect(ZmxSessionLauncher.decodedActivity("a_zz") == "a_zz")
+    // And an escape naming a control character is text too, not a control character on a
+    // card: the writer only ever emits printable ones.
+    #expect(ZmxSessionLauncher.decodedActivity("bell_07here") == "bell_07here")
+  }
+
+  @Test
+  func onlyAToolCallKnowsWhatASessionIsDoing() {
+    // Every other event clears the label in the same write that reports its presence: a
+    // card reading "editing GraphStore.swift" under an IDLE pill is the same stale claim
+    // the presence work took out of the pill.
+    for event in ["SessionStart", "UserPromptSubmit", "Notification", "Stop", "SessionEnd"] {
+      #expect(command(for: event)?.contains("activity=") == true)
+    }
+    #expect(command(for: "PreToolUse")?.contains("activity=") == false)
+  }
+
+  @Test
+  func theReporterRidesBesideThePresenceReportRatherThanInsideIt() throws {
+    // Presence is what the pill, the attention rollup and `MessageBus.deliverability` key
+    // off. It must not stop being reported because the reporter of a nicety went wrong —
+    // hence two commands, and hence the guard that makes a missing file a no-op instead
+    // of a hook error printed over someone's turn.
+    let bodies = commands(for: "PreToolUse")
+
+    #expect(bodies.count == 2)
+    #expect(bodies.first?.contains("presence=busy") == true)
+    #expect(bodies.last?.hasPrefix("if [ -r ") == true)
+    #expect(bodies.last?.contains("activity.sh") == true)
+    #expect(bodies.last?.hasSuffix("exit 0") == true)
+  }
+
+  @Test
+  func aRemoteSessionIsHandedTheReporterTooNotJustTheSettingsThatNameIt() throws {
+    let fragment = try #require(PresenceHooks.remoteWriteFragment())
+
+    // The script itself, written on the host where it will run — a settings file naming a
+    // path that was never created is a silent no-op on every remote loop.
+    #expect(fragment.contains("$HOME/.graphcode/hooks/activity.sh"))
+    #expect(fragment.contains("tool_name"))
+    // And by bare name there, because that host's `zmx` is not at this Mac's path.
+    #expect(fragment.contains("/Users/") == false)
+  }
+
   @Test
   func aSubagentFinishingIsNotTheLoopFinishing() {
     // `SubagentStop` fires while the main agent is still working. Reporting idle there


### PR DESCRIPTION
Every busy card read RUNNING over the sentence its loop was created with. `LoopNode.activity` shipped with a reader, a card row and a fallback — and nothing that ever wrote it.

## What changes

| | Before | After |
|---|---|---|
| Card line | the goal/prompt the loop was handed, forever | `editing GraphStore.swift`, `running make check`, `searching for refreshActivity` |
| When it moves | only when a human pressed Refresh | every presence tick (15s) |
| When it stops | never — the label had no writer, so nothing to go stale | cleared by every non-tool event, and by the tick for any session that isn't busy |

- **A writer for the channel.** Claude Code's `PreToolUse` hook runs a small script graphcode writes beside its settings; it derives the phrase from the hook payload on stdin and writes the `activity` label. Remote hosts get the same script written next to their own hooks file.
- **It cannot block.** A `PreToolUse` hook exiting 2 blocks the tool call it was describing, and any other non-zero exit prints an error over the human's turn. Every path ends `exit 0`, the payload is capped with `head -c`, and the whole thing is guarded so a missing script is a no-op. It rides *beside* the presence report, not inside it, so presence keeps being reported whatever the reporter does.
- **Encoding.** `zmx` label values take only `[A-Za-z0-9._-]` and truncate at the first space — `activity=editing Loop.swift` silently stores `editing`. The phrase is written percent-encoded with `_` for `%` (`_20` space, `_5F` underscore) and decoded in `parseActivityLabel`.
- **The tick reads it.** `pollPresence` refreshes both, and notifies when either moved — presence settles at busy and stays there while the work moves from file to file. Only sessions that tick just found busy are asked; a quiet loop's line is cleared without a probe, which on a remote project saves an ssh round trip per quiet loop.

## Verification

- 754 tests pass; 11 new ones, including five that run the generated script through a real `/bin/sh` against a fake `zmx` — the risk here is a `sed` surviving Swift, JSON and shell and still not matching a real payload.
- Checked live against the real `zmx` and a real session: `editing_20Presence_5FHooks.swift` stored and read back as `editing Presence_Hooks.swift`, `presence=busy activity=` clears in one write.
- `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)