### PR TITLE
Report what Copilot and Codex loops are doing, not just Claude Code's

### DIFF
--- a/GraphcodeKit/Sources/Domain/CLISessionBackendKind.swift
+++ b/GraphcodeKit/Sources/Domain/CLISessionBackendKind.swift
@@ -1,8 +1,8 @@
 /// Which CLI coding-agent backend a `LoopNode` runs inside — see
-/// docs/04-cli-backends.md. Only `.claudeCode` has a live implementation (the app's
-/// `CLISessionClient` and `graphcoded`'s `ZmxSessionLauncher`); the other two cases
-/// exist because the backend set itself is fixed vocabulary, not because they're usable
-/// yet (see docs/07-roadmap.md).
+/// docs/04-cli-backends.md. All three are spiked and share the zmx-backed adapter
+/// (`CLISessionBackend.zmxBacked`); what differs per backend is how a session can be
+/// asked what it is doing, which is why `presence` and `activity` are the two operations
+/// that switch on this and the rest are not.
 ///
 /// A time-based node's recurrence is expressed in its own prompt using whichever looping
 /// skill its backend provides (`/loop` for `.claudeCode`), so nothing here needs a

--- a/GraphcodeKit/Sources/Sessions/CLISessionBackend.swift
+++ b/GraphcodeKit/Sources/Sessions/CLISessionBackend.swift
@@ -111,8 +111,19 @@ extension CLISessionBackend {
       usage: { node, projectPath in
         await ZmxSessionLauncher.usage(of: node, projectPath: projectPath)
       },
+      // Per-backend for the same reason `presence` is, and it was not: the label this
+      // used to read for all three is written by a hook only Claude Code has, so Copilot
+      // and Codex loops reported `nil` forever and their cards kept showing the goal they
+      // were created with. Both write their own logs, and those name every tool call.
       activity: { node, projectPath in
-        await ZmxSessionLauncher.activity(of: node, projectPath: projectPath)
+        switch kind {
+        case .claudeCode:
+          return await ZmxSessionLauncher.activity(of: node, projectPath: projectPath)
+        case .copilotCLI:
+          return await CopilotSessionLog.activity(of: node, projectPath: projectPath)
+        case .codex:
+          return await CodexSessionLog.activity(of: node, projectPath: projectPath)
+        }
       }
     )
   }

--- a/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+/// Codex's activity, read out of the rollout file it already writes.
+///
+/// Codex reports one lifecycle edge and no tool calls: `notify` fires on
+/// `agent-turn-complete` (`PresenceHooks.codexNotifyOverride`), which is enough for
+/// presence — see `ZmxSessionLauncher.codexPresence` — and says nothing about what the
+/// turn is *doing*. So activity comes from the other end, the way `CopilotSessionLog`
+/// takes Copilot's: every session appends
+/// `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<stamp>-<uuid>.jsonl`, and each tool call
+/// is a record in it.
+///
+/// This is the "scanned" tier of docs/04-cli-backends.md#presence — a reading the backend
+/// did not volunteer, taken from outside — and `LoopNode.activity` carries no confidence
+/// of its own, so nothing here claims the agent said it.
+public enum CodexSessionLog {
+  /// Where Codex keeps its rollouts, one directory per day. A `var` only so tests can
+  /// point it at a fixture; nothing in the app writes it.
+  public static var sessionsDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".codex/sessions", isDirectory: true)
+
+  /// How much of the tail is enough to find the last tool call. A rollout carries whole
+  /// model turns including reasoning, so the records are far larger than Copilot's events
+  /// and the window has to be correspondingly wider.
+  static let tailBytes = 256 * 1024
+
+  /// How many recent rollouts to consider before giving up on matching one to a node.
+  ///
+  /// The directory grows one file per session forever, and the answer is always among the
+  /// newest — a node's session is either running now or it is not the one being asked
+  /// about. Bounded so a machine with a year of Codex history costs the same as a fresh
+  /// one on every poll.
+  static let recentRolloutLimit = 40
+
+  /// Every rollout file, newest first, capped at `recentRolloutLimit`.
+  static func recentRollouts() -> [URL] {
+    let manager = FileManager.default
+    guard
+      let walker = manager.enumerator(
+        at: sessionsDirectory, includingPropertiesForKeys: [.contentModificationDateKey])
+    else { return [] }
+    let files = walker.compactMap { $0 as? URL }.filter { $0.pathExtension == "jsonl" }
+    return
+      files
+      .map { url -> (URL, Date) in
+        let date =
+          (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+          .contentModificationDate ?? .distantPast
+        return (url, date)
+      }
+      .sorted { $0.1 > $1.1 }
+      .prefix(recentRolloutLimit)
+      .map(\.0)
+  }
+
+  /// The directory a rollout was started in, off its `session_meta` record.
+  ///
+  /// Always the first line, so only the first line is read — the alternative is parsing
+  /// megabytes of transcript to answer a question the header already answers.
+  static func workingDirectory(ofRolloutAt url: URL) -> String? {
+    guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+    defer { try? handle.close() }
+    guard let data = try? handle.read(upToCount: 64 * 1024) else { return nil }
+    guard let firstLine = String(decoding: data, as: UTF8.self).split(separator: "\n").first,
+      let object = try? JSONSerialization.jsonObject(with: Data(firstLine.utf8)),
+      let record = object as? [String: Any],
+      record["type"] as? String == "session_meta",
+      let payload = record["payload"] as? [String: Any]
+    else { return nil }
+    return payload["cwd"] as? String
+  }
+
+  /// The rollout belonging to a node, matched on the directory its session opened in.
+  ///
+  /// Codex has no equivalent of Copilot's `--name`, so the working directory is the only
+  /// handle graphcode has on which rollout is whose. That is exact for a node bound to
+  /// its own worktree and ambiguous for several loops sharing one project folder, where
+  /// newest-first resolves it the same way `CopilotSessionLog.directory` does — the one
+  /// being written to now is the one that matters.
+  ///
+  /// Paths are compared normalized because `session_meta` records the directory as Codex
+  /// resolved it, and a node's worktree path can reach the same place by another spelling
+  /// — the same mismatch that put a whole repository in the worktree sweeper.
+  static func rollout(forWorkingDirectory directory: String) -> URL? {
+    let wanted = RemoteProjectLocation.normalizedPath(directory)
+    return recentRollouts().first { url in
+      guard let cwd = workingDirectory(ofRolloutAt: url) else { return false }
+      return RemoteProjectLocation.normalizedPath(cwd) == wanted
+    }
+  }
+
+  /// What one tool-call record is doing, in the same voice as the other two backends.
+  static func phrase(forRecord payload: [String: Any]) -> String? {
+    func trimmed(_ value: Any?) -> String? {
+      guard let text = value as? String else { return nil }
+      let clean = text.trimmingCharacters(in: .whitespacesAndNewlines)
+      return clean.isEmpty ? nil : clean
+    }
+    switch payload["type"] as? String {
+    case "function_call":
+      guard let name = payload["name"] as? String else { return nil }
+      // `arguments` is a JSON *string*, not an object — the wire shape of a tool call.
+      let decoded = trimmed(payload["arguments"])
+        .flatMap { try? JSONSerialization.jsonObject(with: Data($0.utf8)) }
+      let arguments = decoded as? [String: Any] ?? [:]
+      let specific: String?
+      switch name {
+      case "shell", "shell_command", "local_shell", "container.exec":
+        // `command` is a string in some Codex versions and an argv array in others.
+        let command =
+          trimmed(arguments["command"])
+          ?? trimmed(
+            (arguments["command"] as? [Any])?
+              .compactMap { $0 as? String }
+              .joined(separator: " "))
+        specific = command.map { "running \($0)" }
+      case "read_file", "view":
+        specific = trimmed(arguments["path"]).map { "reading \(leaf($0))" }
+      case "update_plan":
+        specific = "planning"
+      default:
+        specific = nil
+      }
+      // As in `CopilotSessionLog.phrase`: a recognised tool whose arguments aren't the
+      // shape expected names itself rather than going quiet.
+      return specific ?? "using \(name)"
+    case "custom_tool_call":
+      guard let name = payload["name"] as? String else { return nil }
+      guard name == "apply_patch" else { return "using \(name)" }
+      // The patch envelope names its own files; the first is the one to report.
+      guard let input = trimmed(payload["input"]) else { return "editing files" }
+      return patchedFile(in: input).map { "editing \($0)" } ?? "editing files"
+    case "web_search_call":
+      let action = payload["action"] as? [String: Any] ?? [:]
+      return trimmed(action["query"]).map { "searching the web for \($0)" }
+        ?? "searching the web"
+    default:
+      return nil
+    }
+  }
+
+  /// The first path named by an `apply_patch` envelope, whichever verb introduces it.
+  static func patchedFile(in patch: String) -> String? {
+    let verbs = ["*** Update File: ", "*** Add File: ", "*** Delete File: "]
+    for line in patch.split(separator: "\n") {
+      for verb in verbs where line.hasPrefix(verb) {
+        return leaf(String(line.dropFirst(verb.count)).trimmingCharacters(in: .whitespaces))
+      }
+    }
+    return nil
+  }
+
+  static func leaf(_ path: String) -> String {
+    String(path.split(separator: "/").last ?? Substring(path))
+  }
+
+  /// The tool call this rollout is inside right now, or `nil` when it is between calls.
+  ///
+  /// Outputs are what end a call: `function_call_output` and `custom_tool_call_output`
+  /// carry the `call_id` of the call they answer, so walking backwards and remembering
+  /// them is what distinguishes a call still running from one already answered. Without
+  /// that a finished command would sit on the card through the whole of the next think.
+  static func lastActivity(inRolloutAt url: URL) -> String? {
+    guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+    defer { try? handle.close() }
+    guard let end = try? handle.seekToEnd() else { return nil }
+    let start = end > UInt64(tailBytes) ? end - UInt64(tailBytes) : 0
+    try? handle.seek(toOffset: start)
+    guard let data = try? handle.readToEnd() else { return nil }
+    var lines = String(decoding: data, as: UTF8.self).split(separator: "\n")
+    if start > 0, !lines.isEmpty { lines.removeFirst() }
+
+    var answered = Set<String>()
+    for line in lines.reversed() {
+      guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
+        let record = object as? [String: Any],
+        let payload = record["payload"] as? [String: Any]
+      else { continue }
+      let type = payload["type"] as? String
+      let callID = payload["call_id"] as? String
+      if type == "function_call_output" || type == "custom_tool_call_output" {
+        if let callID { answered.insert(callID) }
+        continue
+      }
+      if let callID, answered.contains(callID) { continue }
+      if let phrase = phrase(forRecord: payload) {
+        return ZmxSessionLauncher.condensedActivity(phrase)
+      }
+    }
+    return nil
+  }
+
+  /// What this node's Codex session is doing, or `nil` when nothing says.
+  ///
+  /// Local only, for the reason `CopilotSessionLog.activity` is: the rollout lives on
+  /// whichever machine ran Codex, and carrying a JSON record back through a remote shell
+  /// is a larger change than this. Remote Codex activity stays `nil`, which is what every
+  /// Codex node reported before this.
+  public static func activity(of node: LoopNode, projectPath: String? = nil) async -> String? {
+    if let projectPath, RemoteProjectLocation.parse(projectPath: projectPath) != nil {
+      return nil
+    }
+    guard ZmxLocator.isInstalled, await ZmxSessionLauncher.sessionExists(node),
+      let directory = ZmxSessionLauncher.workingDirectory(
+        forNode: node, projectPath: projectPath),
+      let rollout = rollout(forWorkingDirectory: directory)
+    else { return nil }
+    return lastActivity(inRolloutAt: rollout)
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -91,21 +91,117 @@ public enum CopilotSessionLog {
     return nil
   }
 
-  /// The last event in a log that says anything about what the session is doing.
-  static func lastStateChange(inLogAt url: URL) -> Presence? {
-    guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+  /// What one `tool.execution_start` record is doing, in the same voice as Claude Code's
+  /// hook script — `editing Foo.swift`, `running make check`.
+  ///
+  /// Copilot's own `description` argument is preferred where it exists, because it is a
+  /// sentence a model wrote to explain the call rather than one assembled here from a
+  /// tool name. An unknown tool falls through to its own name rather than being dropped:
+  /// "using fetch" is worth more than silence, and the tool vocabulary is the backend's
+  /// to change without notice.
+  static func phrase(forTool name: String, arguments: [String: Any]) -> String? {
+    func text(_ key: String) -> String? {
+      guard let raw = arguments[key] as? String else { return nil }
+      let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? nil : trimmed
+    }
+    func leaf(_ key: String) -> String? {
+      text(key).map { String($0.split(separator: "/").last ?? Substring($0)) }
+    }
+    let specific: String?
+    switch name {
+    case "bash", "shell":
+      specific = (text("description") ?? text("command")).map { "running \($0)" }
+    case "view", "read":
+      specific = leaf("path").map { "reading \($0)" }
+    case "create", "edit", "str_replace_editor", "write":
+      specific = leaf("path").map { "editing \($0)" }
+    case "grep", "search":
+      specific = text("pattern").map { "searching for \($0)" }
+    case "glob":
+      specific = text("pattern").map { "looking for \($0)" }
+    case "fetch":
+      specific = text("url").map { "reading \($0)" }
+    default:
+      specific = nil
+    }
+    // A recognised tool whose arguments aren't the shape expected falls back rather than
+    // vanishing: the backend can rename an argument without warning, and "using view" is
+    // worth more than a card that goes quiet mid-call.
+    return specific ?? text("description") ?? "using \(name)"
+  }
+
+  /// The tool call this session is inside right now, or `nil` when it is between calls.
+  ///
+  /// Started-but-not-completed rather than simply "the last start": every call writes both
+  /// a `tool.execution_start` and a `tool.execution_complete` carrying the same
+  /// `toolCallId`, so the completions seen while walking backwards are what say which
+  /// starts are already over. Reporting the last start regardless would leave a finished
+  /// command on the card for the whole of the model's next think, which is the stale label
+  /// this feature exists to remove.
+  static func lastActivity(inLogAt url: URL) -> String? {
+    var completed = Set<String>()
+    for line in tailLines(ofLogAt: url).reversed() {
+      guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
+        let event = object as? [String: Any],
+        let type = event["type"] as? String
+      else { continue }
+      let data = event["data"] as? [String: Any] ?? [:]
+      let callID = data["toolCallId"] as? String
+      switch type {
+      case "tool.execution_complete":
+        if let callID { completed.insert(callID) }
+      case "tool.execution_start":
+        guard let name = data["toolName"] as? String else { continue }
+        if let callID, completed.contains(callID) { continue }
+        let phrase = phrase(forTool: name, arguments: data["arguments"] as? [String: Any] ?? [:])
+        return phrase.flatMap(ZmxSessionLauncher.condensedActivity)
+      // A turn that has ended is not inside a tool call, whatever started before it.
+      case "assistant.turn_end", "session.shutdown":
+        return nil
+      default:
+        continue
+      }
+    }
+    return nil
+  }
+
+  /// The tail of a log, as whole lines.
+  ///
+  /// The first line of a mid-file read is a fragment. It is dropped rather than repaired:
+  /// one event's worth of tail is nowhere near the window this reads.
+  static func tailLines(ofLogAt url: URL) -> [Substring] {
+    guard let handle = try? FileHandle(forReadingFrom: url) else { return [] }
     defer { try? handle.close() }
-    guard let end = try? handle.seekToEnd() else { return nil }
+    guard let end = try? handle.seekToEnd() else { return [] }
     let start = end > UInt64(tailBytes) ? end - UInt64(tailBytes) : 0
     try? handle.seek(toOffset: start)
-    guard let data = try? handle.readToEnd() else { return nil }
-
-    // The first line of a mid-file read is a fragment. It is dropped rather than repaired:
-    // one event's worth of tail is nowhere near the window this reads.
+    guard let data = try? handle.readToEnd() else { return [] }
     var lines = String(decoding: data, as: UTF8.self).split(separator: "\n")
     if start > 0, !lines.isEmpty { lines.removeFirst() }
+    return lines
+  }
 
-    for line in lines.reversed() {
+  /// What this node's Copilot session is doing, or `nil` when nothing says.
+  ///
+  /// Local only, deliberately. The remote twin of this would have to carry a JSON record
+  /// back through a shell pipeline, where `remotePresence` needs only an event name; that
+  /// is a bigger change than this one and remote Copilot activity stays `nil` — which is
+  /// what every Copilot node reported before this, so no reading gets worse.
+  public static func activity(of node: LoopNode, projectPath: String? = nil) async -> String? {
+    if let projectPath, RemoteProjectLocation.parse(projectPath: projectPath) != nil {
+      return nil
+    }
+    let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
+    guard ZmxLocator.isInstalled, await ZmxSessionLauncher.sessionExists(node),
+      let directory = directory(forSessionNamed: name)
+    else { return nil }
+    return lastActivity(inLogAt: directory.appendingPathComponent("events.jsonl"))
+  }
+
+  /// The last event in a log that says anything about what the session is doing.
+  static func lastStateChange(inLogAt url: URL) -> Presence? {
+    for line in tailLines(ofLogAt: url).reversed() {
       guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
         let event = (object as? [String: Any])?["type"] as? String,
         let presence = presence(forEvent: event)

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -213,6 +213,19 @@ public enum ZmxSessionLauncher {
   /// is being truncated somewhere further down where nobody chose the cut.
   static let maxActivityLength = 80
 
+  /// One line, bounded, or `nil` when there is nothing left.
+  ///
+  /// Every activity reading goes through this whatever backend produced it. The hook
+  /// script Claude Code runs caps and flattens its own label before writing it; the
+  /// scanned backends read raw arguments straight out of a log, where a single
+  /// `cat > file <<'EOF'` heredoc is hundreds of characters across dozens of lines —
+  /// measured on a real rollout, not imagined.
+  static func condensedActivity(_ value: String) -> String? {
+    let collapsed = value.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    guard !collapsed.isEmpty else { return nil }
+    return String(collapsed.prefix(maxActivityLength))
+  }
+
   static func usage(of node: LoopNode, projectPath: String? = nil) async -> UsageSample? {
     if let projectPath, let remote = RemoteProjectLocation.parse(projectPath: projectPath) {
       guard case .live(let label) = await remoteStatus(of: node, label: "usage", at: remote),

--- a/graphcode/Tests/BackendActivityTests.swift
+++ b/graphcode/Tests/BackendActivityTests.swift
@@ -1,0 +1,272 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// What Copilot and Codex loops say they are doing, read out of the logs they already
+/// write. Claude Code reports its own activity through a hook it installs; neither of
+/// these has one, so both are scanned from outside — the same arrangement
+/// `CopilotSessionLog.presence` already uses for presence.
+///
+/// Every fixture record here is shaped after a real one taken off this machine's
+/// `~/.copilot/session-state` and `~/.codex/sessions`, keys and nesting included, because
+/// a hand-invented schema would test the parser against nothing.
+@Suite
+struct BackendActivityTests {
+  private func temporaryRoot(_ prefix: String) throws -> URL {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+  }
+
+  private func log(_ lines: [String], named name: String, in root: URL) throws -> URL {
+    let url = root.appendingPathComponent(name)
+    try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+    return url
+  }
+
+  /// Fixtures are serialized rather than hand-written: `arguments` is a JSON string
+  /// *inside* a JSON string, and hand-escaping that wrong silently tests the
+  /// unparseable-arguments path instead of the one named in the test.
+  private func line(_ object: [String: Any]) throws -> String {
+    String(decoding: try JSONSerialization.data(withJSONObject: object), as: UTF8.self)
+  }
+
+  private func copilotStart(_ id: String, _ tool: String, _ arguments: [String: Any]) throws
+    -> String
+  {
+    try line([
+      "type": "tool.execution_start",
+      "data": ["toolCallId": id, "toolName": tool, "arguments": arguments],
+    ])
+  }
+
+  private func copilotComplete(_ id: String) throws -> String {
+    try line(["type": "tool.execution_complete", "data": ["toolCallId": id]])
+  }
+
+  private func codexCall(_ id: String, _ name: String, _ arguments: [String: Any]) throws -> String
+  {
+    let encoded = String(
+      decoding: try JSONSerialization.data(withJSONObject: arguments), as: UTF8.self)
+    return try line([
+      "type": "response_item",
+      "payload": [
+        "type": "function_call", "name": name, "arguments": encoded, "call_id": id,
+      ],
+    ])
+  }
+
+  private func codexOutput(_ id: String) throws -> String {
+    try line([
+      "type": "response_item",
+      "payload": ["type": "function_call_output", "call_id": id, "output": "Exit code: 0"],
+    ])
+  }
+
+  // MARK: - Copilot
+
+  @Test
+  func copilotToolCallsBecomeTheSentenceOnTheCard() {
+    #expect(
+      CopilotSessionLog.phrase(forTool: "view", arguments: ["path": "/tmp/repo/GraphStore.swift"])
+        == "reading GraphStore.swift")
+    #expect(
+      CopilotSessionLog.phrase(forTool: "grep", arguments: ["pattern": "refreshActivity"])
+        == "searching for refreshActivity")
+    // Copilot writes its own one-line description of a shell call, which is a better
+    // sentence than anything assembled from the command here.
+    #expect(
+      CopilotSessionLog.phrase(
+        forTool: "bash",
+        arguments: ["command": "ls -la", "description": "List the repository root"])
+        == "running List the repository root")
+    #expect(
+      CopilotSessionLog.phrase(forTool: "bash", arguments: ["command": "make check"])
+        == "running make check")
+    // The tool vocabulary is the backend's to change; an unknown one is still worth naming.
+    #expect(CopilotSessionLog.phrase(forTool: "fetch", arguments: [:]) == "using fetch")
+  }
+
+  @Test
+  func copilotReportsTheCallItIsStillInside() throws {
+    let root = try temporaryRoot("copilot-activity")
+    defer { try? FileManager.default.removeItem(at: root) }
+    let url = try log(
+      [
+        try line(["type": "assistant.turn_start", "data": [:]]),
+        try copilotStart("call_1", "bash", ["command": "make check"]),
+      ], named: "events.jsonl", in: root)
+
+    #expect(CopilotSessionLog.lastActivity(inLogAt: url) == "running make check")
+  }
+
+  @Test
+  func copilotDropsACallThatHasAlreadyCompleted() throws {
+    let root = try temporaryRoot("copilot-activity")
+    defer { try? FileManager.default.removeItem(at: root) }
+    // The completion carries the same `toolCallId` as its start. Without matching them the
+    // finished command would sit on the card through the whole of the next think — the
+    // stale label this feature exists to remove.
+    let url = try log(
+      [
+        try copilotStart("call_1", "bash", ["command": "make check"]),
+        try copilotComplete("call_1"),
+      ], named: "events.jsonl", in: root)
+
+    #expect(CopilotSessionLog.lastActivity(inLogAt: url) == nil)
+  }
+
+  @Test
+  func copilotReportsTheSecondCallWhileTheFirstIsDone() throws {
+    let root = try temporaryRoot("copilot-activity")
+    defer { try? FileManager.default.removeItem(at: root) }
+    let url = try log(
+      [
+        try copilotStart("call_1", "bash", ["command": "make check"]),
+        try copilotComplete("call_1"),
+        try copilotStart("call_2", "view", ["path": "/tmp/a/GraphStore.swift"]),
+      ], named: "events.jsonl", in: root)
+
+    #expect(CopilotSessionLog.lastActivity(inLogAt: url) == "reading GraphStore.swift")
+  }
+
+  @Test
+  func copilotIsDoingNothingOnceTheTurnHasEnded() throws {
+    let root = try temporaryRoot("copilot-activity")
+    defer { try? FileManager.default.removeItem(at: root) }
+    // `assistant.turn_end` after an unmatched start: a session killed mid-call leaves its
+    // log ending exactly this way, and a card claiming work would outlive the work.
+    let url = try log(
+      [
+        try copilotStart("call_1", "bash", ["command": "make check"]),
+        try line(["type": "assistant.turn_end", "data": [:]]),
+      ], named: "events.jsonl", in: root)
+
+    #expect(CopilotSessionLog.lastActivity(inLogAt: url) == nil)
+  }
+
+  // MARK: - Codex
+
+  @Test
+  func codexToolCallsBecomeTheSentenceOnTheCard() {
+    // `arguments` arrives as a JSON *string*, which is the wire shape of a tool call.
+    #expect(
+      CodexSessionLog.phrase(forRecord: [
+        "type": "function_call", "name": "shell_command",
+        "arguments": #"{"command":"ls","workdir":"/tmp/repo"}"#,
+      ]) == "running ls")
+    #expect(
+      CodexSessionLog.phrase(forRecord: [
+        "type": "web_search_call", "action": ["type": "search", "query": "SwiftTerm usage"],
+      ]) == "searching the web for SwiftTerm usage")
+    #expect(
+      CodexSessionLog.phrase(forRecord: [
+        "type": "custom_tool_call", "name": "apply_patch",
+        "input": "*** Begin Patch\n*** Update File: /tmp/repo/TerminalSession.swift\n@@\n-a\n+b\n",
+      ]) == "editing TerminalSession.swift")
+    #expect(
+      CodexSessionLog.phrase(forRecord: ["type": "function_call", "name": "update_plan"])
+        == "planning")
+    #expect(
+      CodexSessionLog.phrase(forRecord: ["type": "function_call", "name": "browser_open"])
+        == "using browser_open")
+    // Reasoning and messages are not tool calls and must not be mistaken for activity.
+    #expect(CodexSessionLog.phrase(forRecord: ["type": "message", "role": "assistant"]) == nil)
+  }
+
+  @Test
+  func codexAcceptsAnArgvArrayAsWellAsAString() {
+    // Older Codex builds pass `command` as an argv array rather than a string.
+    #expect(
+      CodexSessionLog.phrase(forRecord: [
+        "type": "function_call", "name": "shell",
+        "arguments": #"{"command":["bash","-lc","make check"]}"#,
+      ]) == "running bash -lc make check")
+  }
+
+  @Test
+  func codexReportsTheCallItIsStillInside() throws {
+    let root = try temporaryRoot("codex-activity")
+    defer { try? FileManager.default.removeItem(at: root) }
+    let url = try log(
+      [try codexCall("call_1", "shell_command", ["command": "make check"])],
+      named: "rollout.jsonl", in: root)
+
+    #expect(CodexSessionLog.lastActivity(inRolloutAt: url) == "running make check")
+  }
+
+  @Test
+  func codexDropsACallItsOutputHasAlreadyAnswered() throws {
+    let root = try temporaryRoot("codex-activity")
+    defer { try? FileManager.default.removeItem(at: root) }
+    let url = try log(
+      [
+        try codexCall("call_1", "shell_command", ["command": "make check"]),
+        try codexOutput("call_1"),
+      ], named: "rollout.jsonl", in: root)
+
+    #expect(CodexSessionLog.lastActivity(inRolloutAt: url) == nil)
+  }
+
+  // MARK: - Bounds
+
+  /// Found by running the parser over a real rollout rather than a fixture: Codex writes
+  /// whole `cat > file <<'EOF'` heredocs as one `command`, hundreds of characters across
+  /// dozens of lines. Claude Code's hook caps and flattens before writing its label, so
+  /// only the scanned backends can produce this — and a card is one line.
+  @Test
+  func aHeredocCommandIsFlattenedAndBounded() throws {
+    let root = try temporaryRoot("codex-activity")
+    defer { try? FileManager.default.removeItem(at: root) }
+    // Built rather than hand-escaped: `arguments` is a JSON string *inside* a JSON
+    // string, and getting that wrong silently tests the unparseable-arguments path.
+    let heredoc = "cat > Package.swift <<'EOF'\nimport PackageDescription\n\nlet package = 1\nEOF"
+    let arguments = String(
+      decoding: try JSONSerialization.data(withJSONObject: ["command": heredoc]), as: UTF8.self)
+    let record: [String: Any] = [
+      "type": "response_item",
+      "payload": [
+        "type": "function_call", "name": "shell_command",
+        "arguments": arguments, "call_id": "call_1",
+      ],
+    ]
+    let line = String(
+      decoding: try JSONSerialization.data(withJSONObject: record), as: UTF8.self)
+    let url = try log([line], named: "rollout.jsonl", in: root)
+
+    let activity = try #require(CodexSessionLog.lastActivity(inRolloutAt: url))
+    #expect(!activity.contains("\n"))
+    #expect(activity.count <= 80)
+    #expect(activity.hasPrefix("running cat > Package.swift"))
+  }
+
+  @Test
+  func codexFindsTheRolloutByTheDirectoryItOpenedIn() throws {
+    let root = try temporaryRoot("codex-sessions")
+    defer { try? FileManager.default.removeItem(at: root) }
+    let day = root.appendingPathComponent("2026/08/09", isDirectory: true)
+    try FileManager.default.createDirectory(at: day, withIntermediateDirectories: true)
+    _ = try log(
+      [
+        try line(["type": "session_meta", "payload": ["session_id": "a", "cwd": "/tmp/other"]]),
+        try codexCall("x", "shell_command", ["command": "wrong"]),
+      ], named: "rollout-a.jsonl", in: day)
+    _ = try log(
+      [
+        try line(["type": "session_meta", "payload": ["session_id": "b", "cwd": "/tmp/wanted"]]),
+        try codexCall("y", "shell_command", ["command": "right"]),
+      ], named: "rollout-b.jsonl", in: day)
+
+    let previous = CodexSessionLog.sessionsDirectory
+    CodexSessionLog.sessionsDirectory = root
+    defer { CodexSessionLog.sessionsDirectory = previous }
+
+    // Trailing slash on purpose: `session_meta` records the directory as Codex resolved
+    // it, and a node's worktree path can reach the same place by another spelling.
+    let found = CodexSessionLog.rollout(forWorkingDirectory: "/tmp/wanted/")
+    #expect(found?.lastPathComponent == "rollout-b.jsonl")
+    #expect(CodexSessionLog.rollout(forWorkingDirectory: "/tmp/absent") == nil)
+  }
+}


### PR DESCRIPTION
Follow-up to #77, which fixed activity for one backend out of three.

## The gap

`LoopNode.activity` had exactly one writer: a `PreToolUse` hook script, installed only for Claude Code. But `CLISessionBackend.zmxBacked` called that same label reader for every backend:

```swift
activity: { node, projectPath in
  await ZmxSessionLauncher.activity(of: node, projectPath: projectPath)   // reads a zmx label
}
```

Nothing writes that label for Copilot or Codex, so both reported `nil` forever and their cards kept showing the goal they were created with — the exact failure #77 set out to fix, still in place for two backends.

## Why not hooks

Neither CLI has a hook mechanism, and `PresenceHooks.events(forBackend:)` already returns `nil` for both. So neither is asked. Both are read the way `CopilotSessionLog` already reads Copilot's *presence*: out of the log the backend writes anyway.

| Backend | Source | Records used |
|---|---|---|
| Claude Code | zmx label (hook-written) | unchanged |
| Copilot CLI | `~/.copilot/session-state/<id>/events.jsonl` | `tool.execution_start` → `toolName` + `arguments` |
| Codex | `~/.codex/sessions/**/rollout-*.jsonl` | `function_call`, `custom_tool_call`, `web_search_call` |

`activity` becomes a per-backend switch — which is what `presence` already is, and for the same reason.

Codex has no equivalent of Copilot's `--name`, so its rollout is matched on `session_meta.cwd` against the node's working directory, normalized both sides (the same mismatch that put a whole repository in the worktree sweeper in #75).

## Inside the call, not the last call

Both readers report the call they are still *inside*. Completions carry the id of the call they answer (`toolCallId` / `call_id`), so walking backwards and remembering them distinguishes a running call from an answered one. Reporting the last start regardless would leave a finished command on the card through the whole of the model's next think — the stale label this feature exists to remove.

## Two fixes that came from real logs, not fixtures

I ran the parser over actual `~/.codex/sessions` rollouts on this machine (28 tool records phrased), which caught two things no fixture would have:

1. **Heredocs.** Codex writes a whole `cat > file <<'EOF' … EOF` as one `command` — hundreds of characters across dozens of lines, onto a card that is one line. Every reading is now flattened and bounded through a shared `condensedActivity`, the same 80-character bound the Claude Code path already applied.
2. **Unknown argument shapes.** A *recognised* tool whose arguments aren't the expected shape returned `nil`, so the card went quiet mid-call. It now falls back to naming itself (`using view`). Caught by a test, not by reading.

## Scope

Remote Copilot and Codex activity stays `nil` — the log lives on the far host, and carrying a JSON record back through a shell pipeline is a larger change than this one. That is what both reported before, so no reading gets worse.

Also corrects the `CLISessionBackendKind` doc comment, which still claimed only Claude Code had a live implementation. All three have been spiked since; the stale comment is what made this gap easy to miss.

## Verification

| Check | Result |
|---|---|
| `xcodebuild test` | ✅ Test Succeeded |
| New suite | ✅ `BackendActivityTests`, 11 tests |
| `make check` | ✅ exit 0 |
| Real-log probe | ✅ parser run over an actual Codex rollout, 28 records phrased |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
