### PR TITLE
Refuse a project path that names no directory, and the root

### DIFF
--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -186,13 +186,19 @@ public actor ProjectRegistry {
       send(.recentProjectsListed(persistence.loadRecentProjects()), to: fileDescriptor)
 
     case .openProject(let path):
+      guard Self.isOpenable(path) else { break }
       await open(Self.canonicalize(path), for: connectionID, fileDescriptor: fileDescriptor)
 
     case .restoreOpenProjects:
       // Each of these broadcasts a `.graphChanged` exactly as `.openProject` would, so
       // the app reuses its ordinary "graph for a project I don't know yet = project
       // opened" path instead of needing a restore-shaped event of its own.
-      for path in persistence.loadOpenProjects() {
+      //
+      // Only the spelling is re-checked here, not whether the directory is there: these
+      // paths were openable when they were added, and a project on an unmounted volume
+      // has to come back when the volume does. Nothing is deleted from the stored set
+      // either way — `close` is the only thing that removes from it.
+      for path in persistence.loadOpenProjects() where Self.isWellFormedProjectPath(path) {
         await open(path, for: connectionID, fileDescriptor: fileDescriptor)
       }
 
@@ -332,6 +338,43 @@ public actor ProjectRegistry {
   /// is an `ssh://` one — neither is a folder, and running either through
   /// `fileURLWithPath` would mangle it into a relative path under the cwd and route its
   /// commands to a store that doesn't exist.
+  /// Whether a path is even the *shape* of a project — checked before `canonicalize`,
+  /// which is where the damage was done.
+  ///
+  /// `URL(fileURLWithPath:)` resolves a relative path against the process's working
+  /// directory, and an empty one resolves to that directory outright. `graphcoded` runs
+  /// under launchd, whose working directory is `/`, so an empty path arriving from any
+  /// client — `graphcode status "$UNSET"` is all it takes — became the root directory,
+  /// which exists, so it opened, persisted, and came back every launch as a folder
+  /// called "/".
+  ///
+  /// The root is refused even when spelled out. A project is scanned by the worktree
+  /// sweeper and by git; pointed at `/` that is the whole disk.
+  static func isWellFormedProjectPath(_ path: String) -> Bool {
+    if path == LoopGraphScope.globalPath { return true }
+    if RemoteProjectLocation.parse(projectPath: path) != nil { return true }
+    // Absolute, and not the root however it is spelled: `/`, `//`, `/..` and `/a/..` all
+    // reduce to the same directory.
+    guard path.hasPrefix("/") else { return false }
+    return RemoteProjectLocation.normalizedPath(path) != "/"
+  }
+
+  /// Whether a path can be opened as a project right now: well-formed, and a directory
+  /// that is actually there.
+  ///
+  /// The existence half is deliberately not applied when restoring. It is applied here
+  /// because this is the door every client knocks on, and without it a mistyped or
+  /// already-deleted path became a project with a store, a recents entry and a place in
+  /// the restore set — `~/.graphcode/projects` accumulates one JSON per such ghost.
+  static func isOpenable(_ path: String) -> Bool {
+    guard isWellFormedProjectPath(path) else { return false }
+    if path == LoopGraphScope.globalPath { return true }
+    if RemoteProjectLocation.parse(projectPath: path) != nil { return true }
+    var isDirectory: ObjCBool = false
+    let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+    return exists && isDirectory.boolValue
+  }
+
   private static func canonicalize(_ path: String) -> String {
     guard path != LoopGraphScope.globalPath,
       RemoteProjectLocation.parse(projectPath: path) == nil

--- a/graphcode/Tests/ProjectPathValidationTests.swift
+++ b/graphcode/Tests/ProjectPathValidationTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// What may become a project at all.
+///
+/// `ProjectRegistry` used to open whatever string it was handed. `canonicalize` runs the
+/// path through `URL(fileURLWithPath:)`, which resolves a relative path against the
+/// process's working directory and an empty one to that directory outright — and
+/// `graphcoded` runs under launchd, whose working directory is `/`. So an empty path from
+/// any client became the root directory, which exists, so it opened, persisted, and came
+/// back every launch as a folder called "/". Paths that named nothing at all became
+/// projects too, each with its own JSON under `~/.graphcode/projects`.
+@Suite
+struct ProjectPathValidationTests {
+  @Test
+  func theRootIsRefusedHoweverItIsSpelled() {
+    // The empty path is the one that actually happened: `graphcode status "$UNSET"`.
+    #expect(!ProjectRegistry.isWellFormedProjectPath(""))
+    #expect(!ProjectRegistry.isWellFormedProjectPath("/"))
+    #expect(!ProjectRegistry.isWellFormedProjectPath("//"))
+    #expect(!ProjectRegistry.isWellFormedProjectPath("/.."))
+    #expect(!ProjectRegistry.isWellFormedProjectPath("/tmp/.."))
+    // A project is scanned by the sweeper and by git; pointed at the root that is the
+    // whole disk, so this is refused even when someone means it.
+    #expect(!ProjectRegistry.isOpenable("/"))
+  }
+
+  @Test
+  func aRelativePathIsNotAProject() {
+    // These are the ones `URL(fileURLWithPath:)` silently rebases onto the daemon's own
+    // working directory, inventing an absolute path nobody named.
+    #expect(!ProjectRegistry.isWellFormedProjectPath("relative/path"))
+    #expect(!ProjectRegistry.isWellFormedProjectPath("."))
+    #expect(!ProjectRegistry.isWellFormedProjectPath("~/projects/widget"))
+  }
+
+  @Test
+  func aDirectoryThatIsNotThereIsNotOpened() throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("project-validation-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    #expect(ProjectRegistry.isOpenable(root.path))
+
+    let missing = root.appendingPathComponent("gone", isDirectory: true).path
+    #expect(ProjectRegistry.isWellFormedProjectPath(missing))
+    #expect(!ProjectRegistry.isOpenable(missing))
+
+    // A file is a real path and still not a project.
+    let file = root.appendingPathComponent("notes.txt")
+    try "x".write(to: file, atomically: true, encoding: .utf8)
+    #expect(!ProjectRegistry.isOpenable(file.path))
+  }
+
+  @Test
+  func theTwoPathsThatAreNotDirectoriesStillOpen() {
+    // The global graph names no directory, and a remote project's directory is on another
+    // machine — neither can be answered by asking this filesystem.
+    #expect(ProjectRegistry.isOpenable(LoopGraphScope.globalPath))
+    #expect(ProjectRegistry.isOpenable("ssh://dev@build-box:22/home/dev/widget"))
+  }
+
+  /// Restoring re-checks the spelling and not the filesystem: these paths were openable
+  /// when they were added, and this user's projects live on an external volume. Dropping
+  /// them while it is unmounted would empty the sidebar, and they must come back with it.
+  @Test
+  func restoringToleratesAVolumeThatIsNotMountedButNotJunk() {
+    #expect(ProjectRegistry.isWellFormedProjectPath("/Volumes/External/wd/widget"))
+    #expect(!ProjectRegistry.isOpenable("/Volumes/External/wd/widget"))
+    #expect(!ProjectRegistry.isWellFormedProjectPath(""))
+  }
+}

--- a/graphcode/Tests/ProjectRegistryTests.swift
+++ b/graphcode/Tests/ProjectRegistryTests.swift
@@ -16,6 +16,16 @@ import Testing
 /// on disk via `ProjectPersistence`.
 @Suite
 struct ProjectRegistryTests {
+  /// The registry refuses a path that names no directory, so the folders these tests open
+  /// have to be there. They were not, and the tests passed anyway — which is exactly how
+  /// `/tmp/x` and a folder called "/" ended up as real projects with real stores.
+  init() throws {
+    for name in ["project-a", "project-b", "project-c", "project-d", "project-e"] {
+      try FileManager.default.createDirectory(
+        atPath: "/tmp/\(name)", withIntermediateDirectories: true)
+    }
+  }
+
   private func makeRegistryAndPersistence() -> (ProjectRegistry, ProjectPersistence) {
     let directory = FileManager.default.temporaryDirectory
       .appendingPathComponent("graphcode-tests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
A folder called `/` kept appearing in the sidebar's local folders.

## Root cause

`ProjectRegistry` opened whatever string it was handed — there was no validation anywhere on the path:

```swift
case .openProject(let path):
  await open(Self.canonicalize(path), for: connectionID, fileDescriptor: fileDescriptor)
```

`canonicalize` runs it through `URL(fileURLWithPath:)`, which **resolves a relative path against the process's working directory, and an empty one to that directory outright**. `graphcoded` runs under launchd, whose working directory is `/`.

Measured, not assumed:

| input | canonicalized | display name |
|---|---|---|
| `""` | `/` | `/` |
| `"relative/path"` | `/relative/path` | `path` |
| `"~"` | `/Users/scg` | `scg` |

So an empty path from any client became the root directory — which *exists*, so it opened, persisted to `open-projects.json`, and came back every launch. `graphcode status "$UNSET"` is the entire trigger, and loops drive that CLI constantly.

## The same gap, wider

Nothing required the path to exist at all. On my machine right now:

```
~/.graphcode/projects/_tmp_x.json
~/.graphcode/projects/_Users_scg_graphcode-probe.json
```

Neither `/tmp/x` nor `/Users/scg/graphcode-probe` exists. Both got a full project store, a recents entry, and a place in the restore set.

## The fix

Opening requires an absolute path that is a directory on disk. The root is refused however it is spelled (`/`, `//`, `/..`, `/tmp/..`) — including when someone means it, because a project is scanned by the worktree sweeper and by git, and pointed at `/` that is the whole disk.

Two exemptions, both because the local filesystem cannot answer for them: the global graph (`graphcode://global`, which names no directory) and remote `ssh://` projects (whose directory is on another machine).

**Restoring re-checks only the spelling, never existence.** This matters: these paths were openable when they were added, and projects living on an external volume must come back when the volume is mounted rather than be dropped while it isn't. Nothing is removed from the stored set either way — `close` remains the only thing that removes from it.

## A note on the existing tests

`ProjectRegistryTests` opened `/tmp/project-a` … `/tmp/project-e`, none of which ever existed. They now create them. That the suite passed regardless is precisely how this shipped — the tests encoded the bug as the contract.

## Verification

| Check | Result |
|---|---|
| `xcodebuild test` | ✅ Test Succeeded |
| New suite | ✅ `ProjectPathValidationTests`, 5 tests |
| Existing registry suite | ✅ passes against real directories |
| `make check` | ✅ exit 0 |
| Non-vacuous | ✅ the 5 registry tests failed under the new guard until their fixtures were made real |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
