### PR TITLE
Restore a remote loop's pane after the host reboots, without relaunching the app

### DIFF
--- a/GraphcodeKit/Sources/Domain/RemoteBootMarker.swift
+++ b/GraphcodeKit/Sources/Domain/RemoteBootMarker.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Tells apart the reconnect dial's one ambiguous observation: `zmx get` reporting "no
+/// such session" means either the loop finished while disconnected *or* the host
+/// rebooted and took every session with it. The two demand opposite reactions — closing
+/// the pane versus restoring the session — and nothing in the exit code distinguishes
+/// them.
+///
+/// The marker is the boot the pane last attached under, kept with the other per-session
+/// state under `~/.graphcode`. A reconnect that finds the session gone compares the
+/// current boot against it: same boot → the session ended on its own, close as before;
+/// different boot → the session died with the machine, which is
+/// `GhosttyTerminalView.remoteCommand`'s cue to restore it instead — see the restore
+/// branch there.
+///
+/// The probe reads Linux's per-boot UUID and falls back to macOS's `kern.boottime`. A
+/// host offering neither captures empty, which the reconnect treats as "unknown" and
+/// keeps the pre-marker behaviour; so does a session attached before the marker existed,
+/// whose file is simply absent until the next attach writes one.
+public enum RemoteBootMarker {
+  /// Assigns the current boot's identity to `gc_boot`, or empty when unknowable.
+  public static let captureFragment =
+    "gc_boot=$({ cat /proc/sys/kernel/random/boot_id || sysctl -n kern.boottime; } 2>/dev/null)"
+
+  /// Where one session's marker lives, as `$HOME` shell text — the file is on the
+  /// session's host, and only a shell there knows that home directory (the
+  /// `PresenceHooks.remoteSessionsExpression` arrangement).
+  public static func markerExpression(forSessionName name: String) -> String {
+    "\"$HOME/.graphcode/boots/\(name)\""
+  }
+
+  /// Captures and records the current boot for `name`. Never fails, so it can sit in an
+  /// `&&` chain without a marker problem aborting the attach it precedes.
+  public static func writeFragment(forSessionName name: String) -> String {
+    "{ \(captureFragment); mkdir -p \"$HOME/.graphcode/boots\" && "
+      + "printf '%s' \"$gc_boot\" >\(markerExpression(forSessionName: name)); } 2>/dev/null || true"
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -689,8 +689,9 @@ public enum ZmxSessionLauncher {
   static let remoteResumeIDPlaceholder = "__graphcode_remote_resume_id__"
 
   /// The shell variable `remoteEnsureInvocation` assigns the captured ID to, and that
-  /// `remoteResumeIDPlaceholder` expands into.
-  static let remoteResumeIDVariable = "GRAPHCODE_RESUME_ID"
+  /// `remoteResumeIDPlaceholder` expands into. Public because the app's reboot-restore
+  /// dial reads the same file into the same variable (`GhosttyTerminalView.remoteCommand`).
+  public static let remoteResumeIDVariable = "GRAPHCODE_RESUME_ID"
 
   /// The directories a loop's work legitimately spans: the project, and its worktree when
   /// it has one. A backend that verifies paths (Copilot) is told about both, because a

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
@@ -1,0 +1,169 @@
+import GraphcodeKit
+
+/// The remote half of `GhosttyTerminalView`: the ssh dial a surface runs when its
+/// project lives on another machine, and the reconnect behaviour that keeps it alive
+/// across network drops and host reboots.
+extension GhosttyTerminalView {
+  /// The argv for a surface whose project is remote: a local `/bin/sh` reconnect loop
+  /// (`SSHReconnectLoop`) around the `ssh -t … zmx attach` dial — both kinds: an agent
+  /// surface attaches (or creates) the loop's session on the remote host, and a plain
+  /// shell opens a remote shell in the repository, which is the shell a remote project's
+  /// extra tabs should give you.
+  ///
+  /// The opening prompt cannot ride in through the local environment the way it does
+  /// locally: sshd does not accept arbitrary client env. It is assigned inside the
+  /// remote command instead, single-quote-escaped, where the session's shell — spawned
+  /// by remote zmx under this very process — inherits it and expands the same
+  /// `"$GRAPHCODE_TRIGGER_PROMPT"` reference the local path uses.
+  ///
+  /// The loop's *reconnect* line is deliberately not the connect line again. For an
+  /// agent surface it reattaches a session that still exists; one that is gone is
+  /// either the loop finishing (or being killed) while disconnected — recreating it
+  /// then would re-export the prompt and launch a second agent pass behind the human's
+  /// back, so the pane closes with a notice — or the remote machine rebooting out from
+  /// under it, which only a boot comparison can tell apart (`RemoteBootMarker`). A
+  /// changed boot proves the session died with the machine, not that it finished, so
+  /// the reconnect restores it the way relaunching the app always has: resume the
+  /// backend session whose ID the `SessionStart` hook banked (the daemon's
+  /// `remoteCreateScript` arrangement), or start fresh when there is nothing to
+  /// resume. A plain shell has no such side effect, so its reconnect is the same
+  /// create-or-attach as its connect.
+  func remoteCommand(
+    at location: RemoteProjectLocation, settings: GraphcodeSettings
+  ) -> [String] {
+    RemoteProjectLocation.prepareControlSocketDirectory()
+    let quoted = RemoteProjectLocation.shellQuoted
+    let delivery =
+      ZmxSessionLauncher.remoteDeliveryScript(forNode: nil, at: location, settings: settings)
+      .map { $0 + "; " } ?? ""
+    let briefingPath = remoteBriefingPath(settings: settings)
+    var script = delivery + "cd \(quoted(location.remotePath)) && "
+    let reconnectScript: String
+    let agentLaunch =
+      launchesClaudeCode
+      ? agentCommand(
+        settings: settings, briefingPath: briefingPath,
+        remoteSettingsPath: backend == .claudeCode ? PresenceHooks.remotePathExpression : nil)
+      : nil
+    if let agentLaunch {
+      let markerWrite = RemoteBootMarker.writeFragment(forSessionName: sessionName)
+      let hooksWrite = backend == .claudeCode ? PresenceHooks.remoteWriteFragment() : nil
+      var promptExport = ""
+      if let prompt = sessionEnvironment(briefingPath: briefingPath)[Self.promptVariable] {
+        promptExport = "export \(Self.promptVariable)=\(quoted(prompt)) && "
+      }
+      script += markerWrite + " && "
+      if let hooksWrite { script += hooksWrite + " && " }
+      script += promptExport
+      script += ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName] + agentLaunch)
+      reconnectScript = agentReconnectScript(
+        delivery: delivery, promptExport: promptExport, agentLaunch: agentLaunch,
+        at: location, settings: settings)
+    } else {
+      script += ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])
+      reconnectScript = script
+    }
+    let connect = location.sshCommandLine(
+      remoteCommand: location.remoteLoginShellCommand(script), interactive: true)
+    let reconnect = location.sshCommandLine(
+      remoteCommand: location.remoteLoginShellCommand(reconnectScript), interactive: true)
+    return ["/bin/sh", "-c", SSHReconnectLoop.script(connect: connect, reconnect: reconnect)]
+  }
+
+  /// An agent surface's reconnect line, and the restore branch a proven reboot runs.
+  ///
+  /// `zmx get` exits 0 for a live session and 1 for a missing one — the same existence
+  /// probe the daemon's ensure uses. Only that explicit 1 may even consider ending the
+  /// pane: any other failure (`command not found` while the remote host is still
+  /// booting, a broken login shell after wake) says nothing about the session, so it
+  /// exits 255 — the one code the outer loop retries — instead of letting a transient
+  /// error read as "the loop finished". A missing session then splits on the boot
+  /// marker: same boot (or no marker to compare) closes the pane as before; a changed
+  /// boot runs the restore. The get-then-attach race (session dying in between)
+  /// recreates a blank shell, accepted because the window is milliseconds.
+  ///
+  /// The restore is the connect dial's own preparation (delivery, cd, marker, hooks),
+  /// then resume-or-fresh. The resume ID is consumed before the attempt, exactly like
+  /// `ZmxSessionLauncher.remoteCreateScript` and for the same reason: a dead ID retried
+  /// forever would starve the fresh branch. The trailing `exit 255` catches a
+  /// preparation step failing (the repository directory not mounted yet, a hooks write
+  /// refused) — the host is mid-boot, so keep dialing rather than letting it read as
+  /// "the loop finished".
+  private func agentReconnectScript(
+    delivery: String, promptExport: String, agentLaunch: [String],
+    at location: RemoteProjectLocation, settings: GraphcodeSettings
+  ) -> String {
+    let quoted = RemoteProjectLocation.shellQuoted
+    let markerWrite = RemoteBootMarker.writeFragment(forSessionName: sessionName)
+    let hooksWrite = backend == .claudeCode ? PresenceHooks.remoteWriteFragment() : nil
+    var restore = delivery + "if cd \(quoted(location.remotePath)); then \(markerWrite)"
+    if let hooksWrite { restore += " && " + hooksWrite }
+    restore += " && { "
+    let nodeID = SurfaceRef.nodeID(fromZmxSessionName: sessionName)
+    let resumeLaunch = resumeCommand(
+      settings: settings,
+      remoteSettingsPath: backend == .claudeCode ? PresenceHooks.remotePathExpression : nil)
+    if let nodeID, let resumeLaunch {
+      let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: nodeID)
+      let idVariable = ZmxSessionLauncher.remoteResumeIDVariable
+      restore +=
+        "\(idVariable)=$(cat \(idFile) 2>/dev/null); "
+        + "if [ -n \"$\(idVariable)\" ]; then rm -f \(idFile); export \(idVariable); "
+        + "exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName] + resumeLaunch)); fi; "
+    }
+    restore +=
+      promptExport
+      + "exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName] + agentLaunch)); }; fi"
+    let markerFile = RemoteBootMarker.markerExpression(forSessionName: sessionName)
+    return
+      "\(ZmxSessionLauncher.quotedCommand(["zmx", "get", sessionName])) >/dev/null 2>&1; "
+      + "gc_rc=$?; if [ \"$gc_rc\" -eq 0 ]; then \(markerWrite); "
+      + "exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])); fi; "
+      + "[ \"$gc_rc\" -ne 1 ] && exit 255; "
+      + "\(RemoteBootMarker.captureFragment); gc_last=$(cat \(markerFile) 2>/dev/null); "
+      + "if [ -n \"$gc_boot\" ] && [ -n \"$gc_last\" ] && [ \"$gc_boot\" != \"$gc_last\" ]; then "
+      + #"printf '\033[1;33m── Remote machine rebooted; restoring the session. ──\033[0m\r\n'; "#
+      + restore + "; exit 255; fi; "
+      + #"printf '\033[2m── Remote session ended while disconnected. ──\033[0m\r\n'; exit 0"#
+  }
+
+  /// `agentCommand` for a session the remote machine's reboot killed: the same model and
+  /// permission arguments, but resuming the backend session whose ID the `SessionStart`
+  /// hook banked in `~/.graphcode/sessions` instead of starting a fresh one — what the
+  /// daemon's ensure does after a reboot (`ZmxSessionLauncher.remoteCreateScript`),
+  /// built here for the pane that is already dialing. `nil` when the backend cannot
+  /// resume (Codex), which sends the restore branch to the fresh launch instead.
+  ///
+  /// The ID reaches the session as `"$GRAPHCODE_RESUME_ID"`, unexpanded inside this
+  /// single-quoted script the same way the opening prompt does: the restore shell reads
+  /// the file, exports the variable, and the session's shell — spawned by remote zmx
+  /// under that very process — inherits it. No opening prompt and no briefing: a resumed
+  /// conversation already had both. No `--name` for Copilot either — it is mutually
+  /// exclusive with `--resume` (see `ZmxSessionLauncher.resumeArguments`).
+  func resumeCommand(
+    settings: GraphcodeSettings, remoteSettingsPath: String?
+  ) -> [String]? {
+    guard backend == .claudeCode || backend == .copilotCLI,
+      let executable = backend.executableName
+    else { return nil }
+    let tier = ModelTier.resolved(
+      pinned: pinnedModelTier, for: loopType, autoSelecting: settings.autoSelectsModel)
+    let model = backend.modelArguments(for: tier).joined(separator: " ")
+    let permissions = backend.permissionArguments(settings).joined(separator: " ")
+    var parts = ["exec", executable]
+    if !model.isEmpty { parts.append(model) }
+    if !permissions.isEmpty { parts.append(permissions) }
+    if let remoteSettingsPath { parts.append("--settings \"\(remoteSettingsPath)\"") }
+    parts.append("--resume \"$\(ZmxSessionLauncher.remoteResumeIDVariable)\"")
+    return ["/bin/zsh", "-i", "-l", "-c", parts.joined(separator: " ")]
+  }
+
+  /// The remote twin of `briefingFile`: the `~/`-relative path the briefing is
+  /// delivered to on the remote host, under the same guards.
+  func remoteBriefingPath(settings: GraphcodeSettings = GraphcodeSettingsStore.load()) -> String? {
+    guard launchesClaudeCode, initialPrompt != nil, settings.briefsSessionsAboutTheGraph,
+      remoteLocation != nil, let projectPath
+    else { return nil }
+    return RemoteGraphAccess.briefingPath(forProjectPath: projectPath)
+  }
+}

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -66,7 +66,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
   /// Carries `initialPrompt` into the shell as a variable instead of interpolating it
   /// into the command string, so a prompt containing quotes, `$`, or backticks can't
   /// break out of (or inject into) the command Ghostty runs.
-  private static let promptVariable = "GRAPHCODE_TRIGGER_PROMPT"
+  static let promptVariable = "GRAPHCODE_TRIGGER_PROMPT"
 
   /// Returns a *host* rather than the surface itself, because the surface isn't this
   /// view's to own — `TerminalSurfaceStore` holds it, and this borrows it for as long as
@@ -215,15 +215,6 @@ struct GhosttyTerminalView: NSViewRepresentable {
     return SessionBriefing.write(projectPath: projectPath)
   }
 
-  /// The remote twin of `briefingFile`: the `~/`-relative path the briefing is
-  /// delivered to on the remote host, under the same guards.
-  func remoteBriefingPath(settings: GraphcodeSettings = GraphcodeSettingsStore.load()) -> String? {
-    guard launchesClaudeCode, initialPrompt != nil, settings.briefsSessionsAboutTheGraph,
-      remoteLocation != nil, let projectPath
-    else { return nil }
-    return RemoteGraphAccess.briefingPath(forProjectPath: projectPath)
-  }
-
   /// Where this session's presence hooks landed, or `nil` when it shouldn't get any: a
   /// plain shell has no agent to report, and a remote session runs on a machine this file
   /// was never written to.
@@ -261,74 +252,6 @@ struct GhosttyTerminalView: NSViewRepresentable {
       prompt = "\(SessionBriefing.pointer(toBriefingAt: briefingPath)) \(prompt)"
     }
     return [Self.promptVariable: prompt]
-  }
-
-  /// The argv for a surface whose project is remote: a local `/bin/sh` reconnect loop
-  /// (`SSHReconnectLoop`) around the `ssh -t … zmx attach` dial — both kinds: an agent
-  /// surface attaches (or creates) the loop's session on the remote host, and a plain
-  /// shell opens a remote shell in the repository, which is the shell a remote project's
-  /// extra tabs should give you.
-  ///
-  /// The opening prompt cannot ride in through the local environment the way it does
-  /// locally: sshd does not accept arbitrary client env. It is assigned inside the
-  /// remote command instead, single-quote-escaped, where the session's shell — spawned
-  /// by remote zmx under this very process — inherits it and expands the same
-  /// `"$GRAPHCODE_TRIGGER_PROMPT"` reference the local path uses.
-  ///
-  /// The loop's *reconnect* line is deliberately not the connect line again. For an
-  /// agent surface it reattaches only a session that still exists and otherwise closes
-  /// the pane with a notice: the session ending while disconnected is the loop
-  /// finishing (or being killed), and recreating it would re-export the prompt and
-  /// launch a second agent pass behind the human's back. A plain shell has no such
-  /// side effect, so its reconnect is the same create-or-attach as its connect.
-  func remoteCommand(
-    at location: RemoteProjectLocation, settings: GraphcodeSettings
-  ) -> [String] {
-    RemoteProjectLocation.prepareControlSocketDirectory()
-    let quoted = RemoteProjectLocation.shellQuoted
-    let delivery =
-      ZmxSessionLauncher.remoteDeliveryScript(forNode: nil, at: location, settings: settings)
-      .map { $0 + "; " } ?? ""
-    let briefingPath = remoteBriefingPath(settings: settings)
-    var script = delivery + "cd \(quoted(location.remotePath)) && "
-    let reconnectScript: String
-    let agentLaunch =
-      launchesClaudeCode
-      ? agentCommand(
-        settings: settings, briefingPath: briefingPath,
-        remoteSettingsPath: backend == .claudeCode ? PresenceHooks.remotePathExpression : nil)
-      : nil
-    if let agentLaunch {
-      if backend == .claudeCode, let hooksWrite = PresenceHooks.remoteWriteFragment() {
-        script += hooksWrite + " && "
-      }
-      if let prompt = sessionEnvironment(briefingPath: briefingPath)[Self.promptVariable] {
-        script += "export \(Self.promptVariable)=\(quoted(prompt)) && "
-      }
-      script += ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName] + agentLaunch)
-      // `zmx get` exits 0 for a live session and 1 for a missing one — the same
-      // existence probe the daemon's ensure uses. Only that explicit 1 may end the
-      // pane: any other failure (`command not found` while the remote host is still
-      // booting, a broken login shell after wake) says nothing about the session, so
-      // it exits 255 — the one code the outer loop retries — instead of letting a
-      // transient error read as "the loop finished". The get-then-attach race (session
-      // dying in between) recreates a blank shell, accepted because the window is
-      // milliseconds.
-      reconnectScript =
-        "\(ZmxSessionLauncher.quotedCommand(["zmx", "get", sessionName])) >/dev/null 2>&1; "
-        + "gc_rc=$?; if [ \"$gc_rc\" -eq 0 ]; "
-        + "then exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])); fi; "
-        + "[ \"$gc_rc\" -ne 1 ] && exit 255; "
-        + #"printf '\033[2m── Remote session ended while disconnected. ──\033[0m\r\n'; exit 0"#
-    } else {
-      script += ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])
-      reconnectScript = script
-    }
-    let connect = location.sshCommandLine(
-      remoteCommand: location.remoteLoginShellCommand(script), interactive: true)
-    let reconnect = location.sshCommandLine(
-      remoteCommand: location.remoteLoginShellCommand(reconnectScript), interactive: true)
-    return ["/bin/sh", "-c", SSHReconnectLoop.script(connect: connect, reconnect: reconnect)]
   }
 
   private func command(briefingPath: String?) -> [String] {

--- a/graphcode/Tests/RemoteLoopSurvivalTests.swift
+++ b/graphcode/Tests/RemoteLoopSurvivalTests.swift
@@ -177,9 +177,13 @@ struct RemoteLoopSurvivalTests {
 
   // MARK: - The reconnect line
 
-  private func agentSurface() -> GhosttyTerminalView {
+  private func agentSurface(
+    nodeID: UUID = UUID(), backend: CLISessionBackendKind = .claudeCode
+  ) -> GhosttyTerminalView {
     GhosttyTerminalView(
-      surfaceID: UUID(), sessionName: "graphcode-s", launchesClaudeCode: true,
+      surfaceID: nodeID,
+      sessionName: SurfaceRef(id: nodeID, launchesClaudeCode: true).zmxSessionName,
+      launchesClaudeCode: true, backend: backend,
       initialPrompt: "fix the build", workingDirectory: location.projectPath,
       projectPath: location.projectPath, onProcessExited: { _ in })
   }
@@ -196,6 +200,64 @@ struct RemoteLoopSurvivalTests {
     #expect(loopBody.contains(#"-ne 1"#))
     #expect(loopBody.contains("exit 255"))
     #expect(loopBody.contains("ended while disconnected"))
+  }
+
+  // MARK: - Reboot restore
+
+  @Test
+  func aProvenRebootRestoresTheSessionInsteadOfClosingThePane() throws {
+    // A missing session used to close the pane unconditionally, which read a host
+    // reboot as "the loop finished": the session died with the machine, the pane gave
+    // up, and only relaunching the app brought the loop back. The reconnect line now
+    // compares the boot it last attached under (`RemoteBootMarker`) and, when the boot
+    // changed, restores the session in place — resuming the backend session whose ID
+    // the remote hook banked, with the ID consumed first exactly like the daemon's
+    // ensure, so a dead one costs a single fresh launch rather than a trapped loop.
+    let nodeID = UUID()
+    let view = agentSurface(nodeID: nodeID)
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    let loopBody = try #require(script.range(of: "while :; do").map { script[$0.upperBound...] })
+    #expect(loopBody.contains("boot_id"))
+    #expect(loopBody.contains(".graphcode/boots/graphcode-\(nodeID.uuidString)"))
+    #expect(loopBody.contains(#"[ "$gc_boot" != "$gc_last" ]"#))
+    #expect(loopBody.contains("\(nodeID.uuidString).id"))
+    #expect(loopBody.contains(#"--resume "$GRAPHCODE_RESUME_ID""#))
+    #expect(loopBody.contains("rm -f"))
+    // Same boot — or no boot to compare — still closes with the notice: a session that
+    // ended on its own must not be relaunched behind the human's back.
+    #expect(loopBody.contains("ended while disconnected"))
+  }
+
+  @Test
+  func everyAttachRecordsTheBootItHappenedUnder() throws {
+    // The connect line writes the marker the reconnect line will later compare, and a
+    // plain reattach refreshes it — a marker left stale across a survived reboot would
+    // make the *next* ordinary session end read as another reboot and resume a
+    // conversation that had finished.
+    let view = agentSurface()
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    let splitAt = try #require(script.range(of: "while :; do"))
+    let connectLine = script[..<splitAt.lowerBound]
+    let loopBody = script[splitAt.upperBound...]
+    #expect(connectLine.contains(".graphcode/boots"))
+    let reattach = try #require(loopBody.range(of: "-eq 0"))
+    let successBranch = loopBody[reattach.upperBound...]
+    let branchEnd = try #require(successBranch.range(of: "fi;"))
+    #expect(successBranch[..<branchEnd.lowerBound].contains(".graphcode/boots"))
+  }
+
+  @Test
+  func copilotRestoreResumesWithoutANameAndCodexCannotResume() {
+    // Copilot's `--name` and `--resume` are mutually exclusive; Codex has no resume at
+    // all, so its restore goes straight to the fresh launch.
+    let copilot = agentSurface(backend: .copilotCLI)
+      .resumeCommand(settings: GraphcodeSettings(), remoteSettingsPath: nil)?
+      .joined(separator: " ")
+    #expect(copilot?.contains(#"--resume "$GRAPHCODE_RESUME_ID""#) == true)
+    #expect(copilot?.contains("--name") == false)
+    let codex = agentSurface(backend: .codex)
+      .resumeCommand(settings: GraphcodeSettings(), remoteSettingsPath: nil)
+    #expect(codex == nil)
   }
 
   // MARK: - Remote presence hooks
@@ -224,9 +286,12 @@ struct RemoteLoopSurvivalTests {
     let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
     #expect(script.contains("claude-code.json"))
     #expect(script.contains("--settings"))
-    // But only the connect line, which may create the session — the reconnect line
-    // reattaches an existing one and has nothing to configure.
+    // The reconnect line configures nothing on a plain reattach — hooks appear in its
+    // restore branch alone, which recreates the session and so writes them the way the
+    // connect line does, behind the boot comparison that proves recreating is safe.
     let loopBody = try #require(script.range(of: "while :; do").map { script[$0.upperBound...] })
-    #expect(!loopBody.contains("claude-code.json"))
+    let hooksInLoop = try #require(loopBody.range(of: "claude-code.json"))
+    let rebootCheck = try #require(loopBody.range(of: #"[ "$gc_boot" != "$gc_last" ]"#))
+    #expect(rebootCheck.upperBound <= hooksInLoop.lowerBound)
   }
 }

--- a/graphcode/Tests/RemoteRepositoryTests.swift
+++ b/graphcode/Tests/RemoteRepositoryTests.swift
@@ -143,18 +143,23 @@ struct RemoteRepositoryTests {
   }
 
   @Test
-  func anAgentSurfaceReconnectNeverRelaunchesTheAgent() throws {
+  func anAgentSurfaceReconnectRelaunchesOnlyBehindAProvenReboot() throws {
     // The session ending while disconnected is the loop finishing, not a reason to
-    // start a second agent pass: the reconnect line reattaches an existing session
-    // only, and otherwise closes the pane with a notice.
+    // start a second agent pass: an ordinary reconnect reattaches an existing session
+    // only, and otherwise closes the pane with a notice. The one exception is a boot
+    // change (`RemoteBootMarker`) proving the session died with the machine rather
+    // than finished — every relaunch ingredient sits behind that comparison.
     let view = surface(launchesClaudeCode: true, prompt: "fix the build")
     let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
     let loopBody = try #require(script.range(of: "while :; do").map { script[$0.upperBound...] })
     #expect(loopBody.contains("'get'"))
     #expect(loopBody.contains("attach"))
     #expect(loopBody.contains("ended while disconnected"))
-    #expect(!loopBody.contains("claude"))
-    #expect(!loopBody.contains("GRAPHCODE_TRIGGER_PROMPT"))
+    let rebootCheck = try #require(loopBody.range(of: #"[ "$gc_boot" != "$gc_last" ]"#))
+    #expect(!loopBody[..<rebootCheck.lowerBound].contains("claude"))
+    #expect(!loopBody[..<rebootCheck.lowerBound].contains("GRAPHCODE_TRIGGER_PROMPT"))
+    #expect(loopBody[rebootCheck.upperBound...].contains("claude"))
+    #expect(loopBody[rebootCheck.upperBound...].contains("GRAPHCODE_TRIGGER_PROMPT"))
   }
 
   @Test


### PR DESCRIPTION
## Problem

When a remote machine shuts down, the pane's ssh exits 255 and the `SSHReconnectLoop` keeps dialing — that part worked. But once the machine came back, the reconnect line's `zmx get` found no session (it died with the machine), and the attach-only reconnect closed the pane with *"Remote session ended while disconnected"*. Nothing in the running app ever re-dialed; only quitting and relaunching the app brought the loop back (create-or-attach connect line + the daemon's resume path).

## Root cause

The reconnect line was deliberately attach-only: a missing session was read as *the loop finished while disconnected*, where recreating would re-export the prompt and launch a second agent pass behind the human's back. A host reboot produces the exact same observable (`zmx get` → exit 1), and nothing distinguished the two. Worse, the closing pane's exit resolved the node, which disarmed the daemon's 60s liveness sweep — the one mechanism built for remote reboots.

## Fix

A boot marker (`RemoteBootMarker`) makes the two cases distinguishable:

- Every attach records the boot it happened under (`~/.graphcode/boots/<session>`; Linux `boot_id`, macOS `kern.boottime`), and refreshes it on reattach so a survived reboot can't poison the next verdict.
- A missing session now splits on the boot comparison. Same boot — or nothing to compare — keeps today's behaviour: close with the notice. A changed boot proves the session died with the machine, so the pane restores it in place: the connect dial's own preparation (delivery, cd, marker, hooks), then **resume** from the session ID the `SessionStart` hook banked — consumed before the attempt, exactly like the daemon's `remoteCreateScript` — or a fresh launch when there is nothing to resume (Codex, or no banked ID).
- Restore-preparation failures (repository not mounted yet mid-boot) exit 255 and keep dialing rather than reading as "the loop finished".

Because the pane never exits in the reboot case, the node is no longer mis-resolved, so the daemon's sweep stays armed as well.

The remote dial moves to `GhosttyTerminalView+Remote.swift` to keep both files inside the lint budget.

## Testing

- 773/773 tests pass; swiftlint at main's baseline (80), `swift format lint --strict` clean.
- New tests: restore only behind a proven reboot (`RemoteRepositoryTests.anAgentSurfaceReconnectRelaunchesOnlyBehindAProvenReboot`), resume consumes the banked ID, every attach records its boot, Copilot resume drops `--name`, Codex falls back to fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y8PXuUFDWCRuNJsVdFuuJ