### PR TITLE
Stop the pane racing the daemon's restore, and harden the reboot path

### DIFF
--- a/GraphcodeKit/Sources/Domain/BackendCommand.swift
+++ b/GraphcodeKit/Sources/Domain/BackendCommand.swift
@@ -139,6 +139,15 @@ extension CLISessionBackendKind {
     }
   }
 
+  /// Whether the backend can pick a session back up from a persisted ID (`--resume`).
+  /// The one answer both resumers consult — the daemon's ensure
+  /// (`ZmxSessionLauncher.resumeArguments`) and the app's reboot restore
+  /// (`GhosttyTerminalView.resumeCommand`) — so a backend gaining or losing resume
+  /// support changes both paths together rather than one silently drifting.
+  public var supportsResume: Bool {
+    self == .claudeCode || self == .copilotCLI
+  }
+
   /// The argv that makes a backend's session observable — what graphcode adds so that
   /// "is this loop actually working?" has an answer.
   ///

--- a/GraphcodeKit/Sources/Domain/RemoteBootMarker.swift
+++ b/GraphcodeKit/Sources/Domain/RemoteBootMarker.swift
@@ -13,14 +13,17 @@ import Foundation
 /// `GhosttyTerminalView.remoteCommand`'s cue to restore it instead — see the restore
 /// branch there.
 ///
-/// The probe reads Linux's per-boot UUID and falls back to macOS's `kern.boottime`. A
-/// host offering neither captures empty, which the reconnect treats as "unknown" and
-/// keeps the pre-marker behaviour; so does a session attached before the marker existed,
-/// whose file is simply absent until the next attach writes one.
+/// The probe reads Linux's per-boot UUID and falls back to macOS's
+/// `kern.bootsessionuuid` — a UUID minted per boot, not `kern.boottime`, which is
+/// derived from the clock and shifts when NTP steps it after a wake, faking a reboot
+/// that never happened. A host offering neither captures empty, which the reconnect
+/// treats as "unknown" and keeps the pre-marker behaviour; so does a session attached
+/// before the marker existed, whose file is simply absent until the next attach writes
+/// one.
 public enum RemoteBootMarker {
   /// Assigns the current boot's identity to `gc_boot`, or empty when unknowable.
   public static let captureFragment =
-    "gc_boot=$({ cat /proc/sys/kernel/random/boot_id || sysctl -n kern.boottime; } 2>/dev/null)"
+    "gc_boot=$({ cat /proc/sys/kernel/random/boot_id || sysctl -n kern.bootsessionuuid; } 2>/dev/null)"
 
   /// Where one session's marker lives, as `$HOME` shell text — the file is on the
   /// session's host, and only a shell there knows that home directory (the

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -650,7 +650,7 @@ public enum ZmxSessionLauncher {
     forNode node: LoopNode, sessionID: String, projectPath: String? = nil,
     settings: GraphcodeSettings = GraphcodeSettingsStore.load()
   ) -> [String]? {
-    guard node.backend == .claudeCode || node.backend == .copilotCLI else { return nil }
+    guard node.backend.supportsResume else { return nil }
     guard let executable = node.backend.executableName else { return nil }
     let remote = projectPath.flatMap { RemoteProjectLocation.parse(projectPath: $0) }
     let tier = node.effectiveModelTier(autoSelecting: settings.autoSelectsModel)
@@ -897,9 +897,23 @@ public enum ZmxSessionLauncher {
     else { return freshRun }
     let resume = remoteQuotedCommand(["zmx"] + resumeArgv)
     let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: node.id)
-    return "\(remoteResumeIDVariable)=$(cat \(idFile) 2>/dev/null); "
+    return resumeOrFreshScript(idFile: idFile, resume: resume, fresh: freshRun)
+  }
+
+  /// The consume-then-attempt shape both resumers share: read the banked ID, remove it
+  /// *before* the attempt, run `resume` with it in `remoteResumeIDVariable` — and
+  /// `fresh` when there was nothing banked. Removal-first is the invariant
+  /// `remoteCreateScript` documents (a dead ID must not starve the fresh branch), and it
+  /// lives here so the daemon's ensure and the app's reboot restore
+  /// (`GhosttyTerminalView`) cannot drift apart on it. `fresh` is optional because the
+  /// app's caller supplies its fresh launch as fall-through code after this fragment
+  /// rather than as an `else`.
+  public static func resumeOrFreshScript(
+    idFile: String, resume: String, fresh: String? = nil
+  ) -> String {
+    "\(remoteResumeIDVariable)=$(cat \(idFile) 2>/dev/null); "
       + "if [ -n \"$\(remoteResumeIDVariable)\" ]; then rm -f \(idFile); \(resume); "
-      + "else \(freshRun); fi"
+      + (fresh.map { "else \($0); " } ?? "") + "fi"
   }
 
   /// The files a remote session needs on its own disk, as one installer fragment

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
@@ -16,18 +16,9 @@ extension GhosttyTerminalView {
   /// by remote zmx under this very process — inherits it and expands the same
   /// `"$GRAPHCODE_TRIGGER_PROMPT"` reference the local path uses.
   ///
-  /// The loop's *reconnect* line is deliberately not the connect line again. For an
-  /// agent surface it reattaches a session that still exists; one that is gone is
-  /// either the loop finishing (or being killed) while disconnected — recreating it
-  /// then would re-export the prompt and launch a second agent pass behind the human's
-  /// back, so the pane closes with a notice — or the remote machine rebooting out from
-  /// under it, which only a boot comparison can tell apart (`RemoteBootMarker`). A
-  /// changed boot proves the session died with the machine, not that it finished, so
-  /// the reconnect restores it the way relaunching the app always has: resume the
-  /// backend session whose ID the `SessionStart` hook banked (the daemon's
-  /// `remoteCreateScript` arrangement), or start fresh when there is nothing to
-  /// resume. A plain shell has no such side effect, so its reconnect is the same
-  /// create-or-attach as its connect.
+  /// A plain shell's reconnect is the same create-or-attach as its connect — it has no
+  /// side effect to guard. An agent surface's reconnect is `remoteAgentScripts`'s
+  /// second script; see there for the session-gone split it makes.
   func remoteCommand(
     at location: RemoteProjectLocation, settings: GraphcodeSettings
   ) -> [String] {
@@ -36,33 +27,16 @@ extension GhosttyTerminalView {
     let delivery =
       ZmxSessionLauncher.remoteDeliveryScript(forNode: nil, at: location, settings: settings)
       .map { $0 + "; " } ?? ""
-    let briefingPath = remoteBriefingPath(settings: settings)
-    var script = delivery + "cd \(quoted(location.remotePath)) && "
-    let reconnectScript: String
-    let agentLaunch =
+    let agentScripts =
       launchesClaudeCode
-      ? agentCommand(
-        settings: settings, briefingPath: briefingPath,
-        remoteSettingsPath: backend == .claudeCode ? PresenceHooks.remotePathExpression : nil)
-      : nil
-    if let agentLaunch {
-      let markerWrite = RemoteBootMarker.writeFragment(forSessionName: sessionName)
-      let hooksWrite = backend == .claudeCode ? PresenceHooks.remoteWriteFragment() : nil
-      var promptExport = ""
-      if let prompt = sessionEnvironment(briefingPath: briefingPath)[Self.promptVariable] {
-        promptExport = "export \(Self.promptVariable)=\(quoted(prompt)) && "
-      }
-      script += markerWrite + " && "
-      if let hooksWrite { script += hooksWrite + " && " }
-      script += promptExport
-      script += ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName] + agentLaunch)
-      reconnectScript = agentReconnectScript(
-        delivery: delivery, promptExport: promptExport, agentLaunch: agentLaunch,
-        at: location, settings: settings)
-    } else {
-      script += ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])
-      reconnectScript = script
-    }
+      ? remoteAgentScripts(delivery: delivery, at: location, settings: settings) : nil
+    // A plain shell — and a backend graphcode can't launch — is create-or-attach both
+    // times: there is no agent pass to accidentally run twice.
+    let shell =
+      delivery + "cd \(quoted(location.remotePath)) && "
+      + ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])
+    let script = agentScripts?.connect ?? shell
+    let reconnectScript = agentScripts?.reconnect ?? shell
     let connect = location.sshCommandLine(
       remoteCommand: location.remoteLoginShellCommand(script), interactive: true)
     let reconnect = location.sshCommandLine(
@@ -70,69 +44,131 @@ extension GhosttyTerminalView {
     return ["/bin/sh", "-c", SSHReconnectLoop.script(connect: connect, reconnect: reconnect)]
   }
 
-  /// An agent surface's reconnect line, and the restore branch a proven reboot runs.
+  /// An agent surface's connect and reconnect scripts, built from fragments computed
+  /// once so the two dials cannot drift apart on preparation.
   ///
-  /// `zmx get` exits 0 for a live session and 1 for a missing one — the same existence
-  /// probe the daemon's ensure uses. Only that explicit 1 may even consider ending the
-  /// pane: any other failure (`command not found` while the remote host is still
-  /// booting, a broken login shell after wake) says nothing about the session, so it
-  /// exits 255 — the one code the outer loop retries — instead of letting a transient
-  /// error read as "the loop finished". A missing session then splits on the boot
-  /// marker: same boot (or no marker to compare) closes the pane as before; a changed
-  /// boot runs the restore. The get-then-attach race (session dying in between)
-  /// recreates a blank shell, accepted because the window is milliseconds.
+  /// The reconnect is deliberately not the connect again. `zmx get` exits 0 for a live
+  /// session and 1 for a missing one — the same existence probe the daemon's ensure
+  /// uses. A live session is reattached (refreshing the boot marker, so a survived
+  /// reboot cannot poison a later verdict). Any exit but the explicit 1 says nothing
+  /// about the session — `command not found` while the host boots, a broken login shell
+  /// after wake — so it exits 255, the one code the outer loop retries. A missing
+  /// session splits on the boot marker (`RemoteBootMarker`): the same boot (or nothing
+  /// to compare) means the loop finished while disconnected — recreating it would
+  /// launch a second agent pass behind the human's back, so the pane closes with a
+  /// notice, exactly as it always has. A changed boot proves the session died with the
+  /// machine instead, and what happens next depends on who restores this loop:
   ///
-  /// The restore is the connect dial's own preparation (delivery, cd, marker, hooks),
-  /// then resume-or-fresh. The resume ID is consumed before the attempt, exactly like
-  /// `ZmxSessionLauncher.remoteCreateScript` and for the same reason: a dead ID retried
-  /// forever would starve the fresh branch. The trailing `exit 255` catches a
-  /// preparation step failing (the repository directory not mounted yet, a hooks write
-  /// refused) — the host is mid-boot, so keep dialing rather than letting it read as
-  /// "the loop finished".
-  private func agentReconnectScript(
-    delivery: String, promptExport: String, agentLaunch: [String],
-    at location: RemoteProjectLocation, settings: GraphcodeSettings
-  ) -> String {
+  /// - An **unattended** loop (time- or goal-based) is `graphcoded`'s to restore: its
+  ///   liveness sweep already recreates the session with the banked resume ID, under
+  ///   `RemoteEnsureGate`. The pane joining in was measured to *race* that restore —
+  ///   both consumed the same ID file, and the loser's `cat` came back empty, so the
+  ///   loop restarted fresh instead of resuming. The pane therefore only announces the
+  ///   reboot and keeps dialing; the moment the sweep has the session back, the
+  ///   reattach branch picks it up. A loop the daemon will never restore — resolved,
+  ///   killed — leaves the pane at that banner until the human closes it: visibly
+  ///   waiting, never silently relaunching.
+  /// - A **turn-based** loop has no other restorer — the daemon deliberately never
+  ///   starts one — so the pane restores it itself: `restoreScript`.
+  ///
+  /// The get-then-attach race (session dying in between) recreates a blank shell,
+  /// accepted because the window is milliseconds.
+  private func remoteAgentScripts(
+    delivery: String, at location: RemoteProjectLocation, settings: GraphcodeSettings
+  ) -> (connect: String, reconnect: String)? {
     let quoted = RemoteProjectLocation.shellQuoted
+    let briefingPath = remoteBriefingPath(settings: settings)
+    guard
+      let agentLaunch = agentCommand(
+        settings: settings, briefingPath: briefingPath,
+        remoteSettingsPath: backend == .claudeCode ? PresenceHooks.remotePathExpression : nil)
+    else { return nil }
     let markerWrite = RemoteBootMarker.writeFragment(forSessionName: sessionName)
-    let hooksWrite = backend == .claudeCode ? PresenceHooks.remoteWriteFragment() : nil
-    var restore = delivery + "if cd \(quoted(location.remotePath)); then \(markerWrite)"
-    if let hooksWrite { restore += " && " + hooksWrite }
-    restore += " && { "
-    let nodeID = SurfaceRef.nodeID(fromZmxSessionName: sessionName)
-    let resumeLaunch = resumeCommand(
-      settings: settings,
-      remoteSettingsPath: backend == .claudeCode ? PresenceHooks.remotePathExpression : nil)
-    if let nodeID, let resumeLaunch {
-      let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: nodeID)
-      let idVariable = ZmxSessionLauncher.remoteResumeIDVariable
-      restore +=
-        "\(idVariable)=$(cat \(idFile) 2>/dev/null); "
-        + "if [ -n \"$\(idVariable)\" ]; then rm -f \(idFile); export \(idVariable); "
-        + "exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName] + resumeLaunch)); fi; "
+    let hooksWrite =
+      (backend == .claudeCode ? PresenceHooks.remoteWriteFragment() : nil)
+      .map { $0 + " && " } ?? ""
+    var promptExport = ""
+    if let prompt = sessionEnvironment(briefingPath: briefingPath)[Self.promptVariable] {
+      promptExport = "export \(Self.promptVariable)=\(quoted(prompt)) && "
     }
-    restore +=
-      promptExport
-      + "exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName] + agentLaunch)); }; fi"
+    let attachFresh = ZmxSessionLauncher.quotedCommand(
+      ["zmx", "attach", sessionName] + agentLaunch)
+    let connect =
+      delivery + "cd \(quoted(location.remotePath)) && "
+      + markerWrite + " && " + hooksWrite + promptExport + attachFresh
+    let rebootBranch: String
+    if loopType == .turnBased {
+      let preparation = delivery + "if cd \(quoted(location.remotePath)); then " + hooksWrite
+      rebootBranch =
+        #"printf '\033[1;33m── Remote machine rebooted; restoring the session. ──\033[0m\r\n'; "#
+        + restoreScript(
+          preparation: preparation, promptExport: promptExport, attachFresh: attachFresh,
+          settings: settings) + "; exit 255"
+    } else {
+      rebootBranch =
+        #"printf '\033[1;33m── Remote machine rebooted; waiting for the loop session "#
+        + #"to be restored. ──\033[0m\r\n'; exit 255"#
+    }
     let markerFile = RemoteBootMarker.markerExpression(forSessionName: sessionName)
-    return
+    let reconnect =
       "\(ZmxSessionLauncher.quotedCommand(["zmx", "get", sessionName])) >/dev/null 2>&1; "
       + "gc_rc=$?; if [ \"$gc_rc\" -eq 0 ]; then \(markerWrite); "
       + "exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])); fi; "
       + "[ \"$gc_rc\" -ne 1 ] && exit 255; "
       + "\(RemoteBootMarker.captureFragment); gc_last=$(cat \(markerFile) 2>/dev/null); "
       + "if [ -n \"$gc_boot\" ] && [ -n \"$gc_last\" ] && [ \"$gc_boot\" != \"$gc_last\" ]; then "
-      + #"printf '\033[1;33m── Remote machine rebooted; restoring the session. ──\033[0m\r\n'; "#
-      + restore + "; exit 255; fi; "
+      + rebootBranch + "; fi; "
       + #"printf '\033[2m── Remote session ended while disconnected. ──\033[0m\r\n'; exit 0"#
+    return (connect, reconnect)
   }
 
-  /// `agentCommand` for a session the remote machine's reboot killed: the same model and
-  /// permission arguments, but resuming the backend session whose ID the `SessionStart`
-  /// hook banked in `~/.graphcode/sessions` instead of starting a fresh one — what the
-  /// daemon's ensure does after a reboot (`ZmxSessionLauncher.remoteCreateScript`),
-  /// built here for the pane that is already dialing. `nil` when the backend cannot
-  /// resume (Codex), which sends the restore branch to the fresh launch instead.
+  /// The turn-based restore a proven reboot runs: the connect dial's own preparation
+  /// (already in `preparation` — delivery, cd, hooks), then resume-or-fresh.
+  ///
+  /// The resume ID is consumed before the attempt
+  /// (`ZmxSessionLauncher.resumeOrFreshScript` — the daemon's own fragment, shared so
+  /// the invariant cannot drift). A resume that dies within seconds is a dead ID —
+  /// `claude --resume` against a pruned transcript exits immediately — and only this
+  /// attached script can see that, so it measures: an attach that returned in under
+  /// five seconds falls through to the fresh launch instead of closing the pane with a
+  /// pass-through exit code. One that lived longer was a real session, and its exit is
+  /// the session ending, passed through as ever.
+  ///
+  /// The boot marker is deliberately *not* refreshed here: it updates only when an
+  /// attach finds a live session. A drop mid-restore therefore redials into this same
+  /// branch — with the marker already rewritten it would have read as "ended while
+  /// disconnected" and closed the pane on a reboot that was real.
+  ///
+  /// The trailing `exit 255` in the caller catches a preparation step failing (the
+  /// repository directory not mounted yet, a hooks write refused) — the host is
+  /// mid-boot, so keep dialing rather than letting it read as "the loop finished".
+  private func restoreScript(
+    preparation: String, promptExport: String, attachFresh: String, settings: GraphcodeSettings
+  ) -> String {
+    var script = preparation + "{ "
+    let nodeID = SurfaceRef.nodeID(fromZmxSessionName: sessionName)
+    let resumeLaunch = resumeCommand(
+      settings: settings,
+      remoteSettingsPath: backend == .claudeCode ? PresenceHooks.remotePathExpression : nil)
+    if let nodeID, let resumeLaunch {
+      let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: nodeID)
+      let attempt =
+        "export \(ZmxSessionLauncher.remoteResumeIDVariable); gc_t0=$(date +%s); "
+        + ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName] + resumeLaunch)
+        + "; gc_rc=$?; [ $(($(date +%s) - gc_t0)) -ge 5 ] && exit \"$gc_rc\"; "
+        + #"printf '\033[1;33m── Resume did not take; starting the session fresh. ──\033[0m\r\n'"#
+      script += ZmxSessionLauncher.resumeOrFreshScript(idFile: idFile, resume: attempt) + "; "
+    }
+    script += promptExport + "exec \(attachFresh); }; fi"
+    return script
+  }
+
+  /// `agentCommand` for a session the remote machine's reboot killed: the same launch
+  /// prefix (`launchPrefix` — executable, model, permissions), resuming the backend
+  /// session whose ID the `SessionStart` hook banked in `~/.graphcode/sessions` instead
+  /// of starting a fresh one. `nil` when the backend cannot resume
+  /// (`CLISessionBackendKind.supportsResume`), which sends the restore to the fresh
+  /// launch instead.
   ///
   /// The ID reaches the session as `"$GRAPHCODE_RESUME_ID"`, unexpanded inside this
   /// single-quoted script the same way the opening prompt does: the restore shell reads
@@ -143,19 +179,12 @@ extension GhosttyTerminalView {
   func resumeCommand(
     settings: GraphcodeSettings, remoteSettingsPath: String?
   ) -> [String]? {
-    guard backend == .claudeCode || backend == .copilotCLI,
-      let executable = backend.executableName
-    else { return nil }
-    let tier = ModelTier.resolved(
-      pinned: pinnedModelTier, for: loopType, autoSelecting: settings.autoSelectsModel)
-    let model = backend.modelArguments(for: tier).joined(separator: " ")
-    let permissions = backend.permissionArguments(settings).joined(separator: " ")
-    var parts = ["exec", executable]
-    if !model.isEmpty { parts.append(model) }
-    if !permissions.isEmpty { parts.append(permissions) }
+    guard backend.supportsResume, var parts = launchPrefix(settings: settings) else {
+      return nil
+    }
     if let remoteSettingsPath { parts.append("--settings \"\(remoteSettingsPath)\"") }
     parts.append("--resume \"$\(ZmxSessionLauncher.remoteResumeIDVariable)\"")
-    return ["/bin/zsh", "-i", "-l", "-c", parts.joined(separator: " ")]
+    return Self.interactiveLoginShell(parts)
   }
 
   /// The remote twin of `briefingFile`: the `~/`-relative path the briefing is

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -150,16 +150,8 @@ struct GhosttyTerminalView: NSViewRepresentable {
     settings: GraphcodeSettings = GraphcodeSettingsStore.load(), briefingPath: String? = nil,
     hooksFile: URL? = nil, remoteSettingsPath: String? = nil
   ) -> [String]? {
-    guard let executable = backend.executableName else { return nil }
-    let tier = ModelTier.resolved(
-      pinned: pinnedModelTier, for: loopType, autoSelecting: settings.autoSelectsModel)
-    let model = backend.modelArguments(for: tier).joined(separator: " ")
-    let permissions = backend.permissionArguments(settings).joined(separator: " ")
+    guard var parts = launchPrefix(settings: settings) else { return nil }
     let prompt = initialPrompt == nil ? "" : "\"$\(Self.promptVariable)\""
-
-    var parts = ["exec", executable]
-    if !model.isEmpty { parts.append(model) }
-    if !permissions.isEmpty { parts.append(permissions) }
     // Presence reporting, from the same place the daemon gets it (`PresenceHooks`). It
     // matters most here: a turn-based loop's session only ever starts from this view, so
     // without it the one loop type a human watches most closely would be the one that
@@ -200,7 +192,29 @@ struct GhosttyTerminalView: NSViewRepresentable {
       if backend == .copilotCLI { parts.append("--interactive") }
       parts.append(prompt)
     }
-    return ["/bin/zsh", "-i", "-l", "-c", parts.joined(separator: " ")]
+    return Self.interactiveLoginShell(parts)
+  }
+
+  /// The words every launch of this surface's agent starts from — executable, model,
+  /// permissions — shared by the fresh launch above and the reboot resume
+  /// (`resumeCommand`), so a flag every session needs cannot land in one and not the
+  /// other.
+  func launchPrefix(settings: GraphcodeSettings) -> [String]? {
+    guard let executable = backend.executableName else { return nil }
+    let tier = ModelTier.resolved(
+      pinned: pinnedModelTier, for: loopType, autoSelecting: settings.autoSelectsModel)
+    let model = backend.modelArguments(for: tier).joined(separator: " ")
+    let permissions = backend.permissionArguments(settings).joined(separator: " ")
+    var parts = ["exec", executable]
+    if !model.isEmpty { parts.append(model) }
+    if !permissions.isEmpty { parts.append(permissions) }
+    return parts
+  }
+
+  /// The `-i -l` wrapper `agentCommand`'s doc explains — one place, so the resume and
+  /// fresh launches cannot diverge on how the shell resolves the agent.
+  static func interactiveLoginShell(_ parts: [String]) -> [String] {
+    ["/bin/zsh", "-i", "-l", "-c", parts.joined(separator: " ")]
   }
 
   /// Where the graph briefing for this session landed, or `nil` when it shouldn't get

--- a/graphcode/Tests/RemoteLoopSurvivalTests.swift
+++ b/graphcode/Tests/RemoteLoopSurvivalTests.swift
@@ -178,12 +178,13 @@ struct RemoteLoopSurvivalTests {
   // MARK: - The reconnect line
 
   private func agentSurface(
-    nodeID: UUID = UUID(), backend: CLISessionBackendKind = .claudeCode
+    nodeID: UUID = UUID(), backend: CLISessionBackendKind = .claudeCode,
+    loopType: LoopType = .turnBased
   ) -> GhosttyTerminalView {
     GhosttyTerminalView(
       surfaceID: nodeID,
       sessionName: SurfaceRef(id: nodeID, launchesClaudeCode: true).zmxSessionName,
-      launchesClaudeCode: true, backend: backend,
+      launchesClaudeCode: true, backend: backend, loopType: loopType,
       initialPrompt: "fix the build", workingDirectory: location.projectPath,
       projectPath: location.projectPath, onProcessExited: { _ in })
   }
@@ -205,19 +206,20 @@ struct RemoteLoopSurvivalTests {
   // MARK: - Reboot restore
 
   @Test
-  func aProvenRebootRestoresTheSessionInsteadOfClosingThePane() throws {
+  func aProvenRebootRestoresATurnBasedSessionInsteadOfClosingThePane() throws {
     // A missing session used to close the pane unconditionally, which read a host
     // reboot as "the loop finished": the session died with the machine, the pane gave
-    // up, and only relaunching the app brought the loop back. The reconnect line now
-    // compares the boot it last attached under (`RemoteBootMarker`) and, when the boot
-    // changed, restores the session in place — resuming the backend session whose ID
-    // the remote hook banked, with the ID consumed first exactly like the daemon's
-    // ensure, so a dead one costs a single fresh launch rather than a trapped loop.
+    // up, and only relaunching the app brought the loop back. For a turn-based loop —
+    // the one kind the daemon never restores — the reconnect line now compares the boot
+    // it last attached under (`RemoteBootMarker`) and, when the boot changed, restores
+    // the session itself: resume from the banked ID, consumed first exactly like the
+    // daemon's ensure.
     let nodeID = UUID()
     let view = agentSurface(nodeID: nodeID)
     let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
     let loopBody = try #require(script.range(of: "while :; do").map { script[$0.upperBound...] })
     #expect(loopBody.contains("boot_id"))
+    #expect(loopBody.contains("kern.bootsessionuuid"))
     #expect(loopBody.contains(".graphcode/boots/graphcode-\(nodeID.uuidString)"))
     #expect(loopBody.contains(#"[ "$gc_boot" != "$gc_last" ]"#))
     #expect(loopBody.contains("\(nodeID.uuidString).id"))
@@ -226,6 +228,54 @@ struct RemoteLoopSurvivalTests {
     // Same boot — or no boot to compare — still closes with the notice: a session that
     // ended on its own must not be relaunched behind the human's back.
     #expect(loopBody.contains("ended while disconnected"))
+  }
+
+  @Test
+  func aDeadResumeIDFallsThroughToAFreshLaunchInsteadOfClosingThePane() throws {
+    // `claude --resume` against a pruned transcript exits immediately, and `zmx attach`
+    // passes that exit straight to ssh — a non-255 code the outer loop would close the
+    // pane on. Only this attached script can see how long the session lived, so the
+    // restore measures: an attach back in under five seconds is a dead ID and falls
+    // through to the fresh launch; one that lived was a real session whose exit passes
+    // through as ever.
+    let view = agentSurface()
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    let loopBody = try #require(script.range(of: "while :; do").map { script[$0.upperBound...] })
+    #expect(loopBody.contains("gc_t0=$(date +%s)"))
+    #expect(loopBody.contains("-ge 5"))
+    #expect(loopBody.contains("Resume did not take"))
+  }
+
+  @Test
+  func anUnattendedLoopDefersItsRestoreToTheDaemon() throws {
+    // The daemon's liveness sweep already restores an unattended loop's session, with
+    // the resume ID and the ensure gate. The pane joining in raced it: both consumed
+    // the same ID file, and the loser's read came back empty, so the loop restarted
+    // fresh instead of resuming (the bug observed in the field). After a proven reboot
+    // the pane only announces and keeps dialing; the reattach branch joins the session
+    // the moment the sweep has it back. No resume, no ID consumption, no prompt
+    // re-export — nothing for the daemon to race.
+    let view = agentSurface(loopType: .goalBased)
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    let loopBody = try #require(script.range(of: "while :; do").map { script[$0.upperBound...] })
+    #expect(loopBody.contains(#"[ "$gc_boot" != "$gc_last" ]"#))
+    #expect(loopBody.contains("waiting for the loop session"))
+    #expect(!loopBody.contains("--resume"))
+    #expect(!loopBody.contains("rm -f"))
+    #expect(!loopBody.contains("GRAPHCODE_TRIGGER_PROMPT"))
+    #expect(loopBody.contains("ended while disconnected"))
+  }
+
+  @Test
+  func theRestoreDoesNotRefreshTheMarkerUntilASessionIsLive() throws {
+    // The marker updates only when an attach finds a live session. Written during the
+    // restore, a drop mid-restore would make the next redial read "same boot" and
+    // close the pane as "ended while disconnected" on a reboot that was real.
+    let view = agentSurface()
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    let loopBody = try #require(script.range(of: "while :; do").map { script[$0.upperBound...] })
+    let rebootCheck = try #require(loopBody.range(of: #"[ "$gc_boot" != "$gc_last" ]"#))
+    #expect(!loopBody[rebootCheck.upperBound...].contains("mkdir -p \"$HOME/.graphcode/boots\""))
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #80, fixing a field-reported bug plus every confirmed finding from that PR's review.

## The reported bug: an unattended loop restarted fresh instead of resuming

After a remote reboot the loop came back with a brand-new agent pass rather than its conversation. Cause: PR #80 made the pane a **second restorer**. The pane's restore and `graphcoded`'s liveness sweep both ran consume-then-resume against the same `~/.graphcode/sessions/<node>.id` file; whichever read second found it already removed and fell through to the fresh, prompt-bearing launch.

Ownership is now explicit:

| Loop type | Who restores after a reboot |
|---|---|
| Time-based / goal-based (unattended) | **The daemon**, as always — its sweep resumes under `RemoteEnsureGate`. The pane announces the reboot and keeps dialing; its reattach branch joins the session as soon as the sweep has it back. |
| Turn-based | **The pane** — the daemon deliberately never starts one, so there is nobody to race. |

## Review findings addressed

- **Dead resume ID closed the pane** (confirmed). `claude --resume` on a pruned transcript exits instantly and zmx passes that code to ssh, which the retry loop treats as a real exit. The restore now times the attach: back in under five seconds means the ID was dead, so it falls through to the fresh launch instead of dying silently.
- **Marker written before the restore landed** (confirmed). It is now refreshed only when an attach finds a *live* session; a drop mid-restore used to make the next redial read "same boot" and close the pane on a real reboot.
- **Finished-loop-then-reboot relaunched the agent** (confirmed). Unattended loops no longer relaunch from the pane at all; the daemon's sweep already skips resolved nodes.
- **`kern.boottime` faked reboots** (plausible). macOS now reads `kern.bootsessionuuid`, a per-boot UUID that NTP clock steps do not move.
- **Pane consuming the daemon's ID / racing it** (plausible x2). Gone with the ownership split — the pane touches the ID file only for turn-based loops, which the daemon never restores.
- **Four cleanups** (confirmed). `resumeOrFreshScript`, `CLISessionBackendKind.supportsResume`, `launchPrefix`/`interactiveLoginShell`, and one preparation-fragment computation now each exist once and are shared by both callers.

## Testing

776 tests pass (3 new); swiftlint 80 = main's baseline; `swift format lint --strict` clean.

New tests: an unattended loop defers to the daemon (no `--resume`, no `rm -f`, no prompt re-export), a dead resume ID falls through to fresh, the marker is not refreshed during a restore, and the macOS probe is the boot-session UUID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y8PXuUFDWCRuNJsVdFuuJ