### PR TITLE
Opening a local loop resumes its conversation instead of restarting the goal

### DIFF
--- a/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
+++ b/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
@@ -162,10 +162,17 @@ public enum PresenceHooks {
   /// machine's home directory, and only a shell there can expand it. A hook file carrying
   /// this Mac's `/Users/<me>/.graphcode` wrote nothing at all on a Codespace, where
   /// `/Users` doesn't exist and the agent user can't create it.
+  /// The pointer is overwritten every session start, and the `.history` line beside it
+  /// is what makes that recoverable: `<epoch> <session-id> <cwd>`, appended and never
+  /// rewritten. See `SessionIDStore.historyFile` for the failure that motivated it.
+  /// Written before the pointer so a history line can never be missing for an ID the
+  /// pointer already names.
   static func captureSessionID(sessionsDirectory: String) -> String {
     "if [ -n \"$ZMX_SESSION\" ] && [ -n \"$CLAUDE_CODE_SESSION_ID\" ]; then "
       + "node_id=\"${ZMX_SESSION#\(SurfaceRef.zmxSessionPrefix)}\"; "
       + "mkdir -p \(sessionsDirectory); "
+      + "printf '%s %s %s\\n' \"$(date +%s)\" \"$CLAUDE_CODE_SESSION_ID\" \"$PWD\" "
+      + ">> \(sessionsDirectory)/\"$node_id\".history 2>/dev/null; "
       + "printf '%s' \"$CLAUDE_CODE_SESSION_ID\" > \(sessionsDirectory)/\"$node_id\".id; "
       + "fi; exit 0"
   }

--- a/GraphcodeKit/Sources/Sessions/SessionIDStore.swift
+++ b/GraphcodeKit/Sources/Sessions/SessionIDStore.swift
@@ -17,8 +17,43 @@ public enum SessionIDStore {
     SupportDirectory.url.appendingPathComponent("sessions", isDirectory: true)
   }
 
-  static func file(forNodeID nodeID: UUID) -> URL {
+  /// Public because the app's own launch path reads this file too — see
+  /// `GhosttyTerminalView.localResumeOrFreshCommand`, which resumes rather than
+  /// re-prompting when a loop is opened with its session gone.
+  public static func file(forNodeID nodeID: UUID) -> URL {
     directory.appendingPathComponent("\(nodeID.uuidString).id")
+  }
+
+  /// Every ID this node has ever banked, appended one line per session start as
+  /// `<epoch> <session-id> <cwd>`.
+  ///
+  /// The pointer is last-writer-wins by design — a new session for a node *is* the
+  /// node's session now. What that cannot survive is a session started against a
+  /// conversation the node had already moved on from: the pointer swings to a transcript
+  /// with nothing in it, and the one that holds the work is unreachable, with nothing on
+  /// disk recording that it ever existed. Recovering a real case of this (2026-08-11)
+  /// meant reading transcript sizes and birth times out of `~/.claude/projects` and
+  /// guessing — forensics, not a supported operation.
+  ///
+  /// Append-only and never read by the launcher: this exists so a human (or a repair
+  /// command) can see what the pointer used to be. Truncation is deliberately absent —
+  /// a line per session start is a handful of bytes a week.
+  public static func historyFile(forNodeID nodeID: UUID) -> URL {
+    directory.appendingPathComponent("\(nodeID.uuidString).history")
+  }
+
+  /// The IDs banked for this node, newest last, as `(sessionID, cwd)`. Empty when the
+  /// node predates the history or nothing was ever recorded.
+  public static func history(forNodeID nodeID: UUID) -> [(
+    sessionID: String, workingDirectory: String
+  )] {
+    guard let text = try? String(contentsOf: historyFile(forNodeID: nodeID), encoding: .utf8)
+    else { return [] }
+    return text.split(separator: "\n").compactMap { line in
+      let fields = line.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: false)
+      guard fields.count >= 2 else { return nil }
+      return (String(fields[1]), fields.count > 2 ? String(fields[2]) : "")
+    }
   }
 
   public static func save(_ sessionID: String, forNodeID nodeID: UUID) {

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -1190,6 +1190,7 @@ public enum ZmxSessionLauncher {
         let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
         return CopilotSessionLog.directory(forSessionNamed: name)?.lastPathComponent
       }()
+    guard let runArgs = arguments(forNode: node, projectPath: projectPath) else { return }
     if let sessionID,
       let resumeArgs = resumeArguments(
         forNode: node, sessionID: sessionID, projectPath: projectPath)
@@ -1197,13 +1198,42 @@ public enum ZmxSessionLauncher {
       await atomicCheckOrRun(
         checkArguments: checkArgs, runArguments: resumeArgs,
         zmxPath: zmxPath, workingDirectory: wd)
-      return
+      // `zmx run -d` reports that the *session* exists, not that what it launched
+      // survived: `claude --resume` against a transcript its retention expired dies
+      // within a second, taking the session with it, and the ensure returns 0 having
+      // achieved nothing. Nothing else notices — the card keeps saying `running` while
+      // the loop is gone, and the next ensure retries the same dead ID, because
+      // (unlike the remote path) the local one never consumed it. So look again, and
+      // only if the session really failed to survive is the ID treated as dead: it is
+      // dropped and the fresh launch runs. A resume that took is left alone, and its
+      // `SessionStart` hook has already rebanked the same ID.
+      guard
+        await sessionDiedImmediately(
+          checkArguments: checkArgs, zmxPath: zmxPath, workingDirectory: wd)
+      else { return }
+      SessionIDStore.remove(forNodeID: node.id)
     }
-
-    guard let runArgs = arguments(forNode: node, projectPath: projectPath) else { return }
     await atomicCheckOrRun(
       checkArguments: checkArgs, runArguments: runArgs,
       zmxPath: zmxPath, workingDirectory: wd)
+  }
+
+  /// How long a resumed session has to still be there before its launch counts as taken.
+  /// Long enough that a dying `claude --resume` is already gone, short enough that a
+  /// genuinely dead ID costs one of these per ensure rather than a wasted minute.
+  /// Public because the app's launch path makes the same judgement with the same number
+  /// (`GhosttyTerminalView.localResumeOrFreshCommand`).
+  public static let resumeSettleSeconds: UInt64 = 5
+
+  private static func sessionDiedImmediately(
+    checkArguments: [String], zmxPath: String, workingDirectory: String?
+  ) async -> Bool {
+    try? await Task.sleep(for: .seconds(resumeSettleSeconds))
+    guard
+      let session = try? PTYProcessSession(
+        executable: zmxPath, arguments: checkArguments, workingDirectory: workingDirectory)
+    else { return false }
+    return await session.waitUntilFinished() == false
   }
 
   private static func atomicCheckOrRun(

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
@@ -1,3 +1,4 @@
+import Foundation
 import GraphcodeKit
 
 /// The remote half of `GhosttyTerminalView`: the ssh dial a surface runs when its
@@ -176,12 +177,23 @@ extension GhosttyTerminalView {
   /// under that very process — inherits it. No opening prompt and no briefing: a resumed
   /// conversation already had both. No `--name` for Copilot either — it is mutually
   /// exclusive with `--resume` (see `ZmxSessionLauncher.resumeArguments`).
+  ///
+  /// `hooksFile` is the local twin of `remoteSettingsPath` — the presence hooks this
+  /// machine wrote. A resumed local session needs them for the same reason a fresh one
+  /// does: without them the loop reports IDLE for as long as it runs.
   func resumeCommand(
-    settings: GraphcodeSettings, remoteSettingsPath: String?
+    settings: GraphcodeSettings, hooksFile: URL? = nil, remoteSettingsPath: String?
   ) -> [String]? {
     guard backend.supportsResume, var parts = launchPrefix(settings: settings) else {
       return nil
     }
+    let presence = backend.presenceArguments(
+      hooksFile: hooksFile, sessionName: nil,
+      zmxPath: ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil
+    )
+    .map(PresenceHooks.singleQuoted)
+    .joined(separator: " ")
+    if !presence.isEmpty { parts.append(presence) }
     if let remoteSettingsPath { parts.append("--settings \"\(remoteSettingsPath)\"") }
     parts.append("--resume \"$\(ZmxSessionLauncher.remoteResumeIDVariable)\"")
     return Self.interactiveLoginShell(parts)

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -289,7 +289,67 @@ struct GhosttyTerminalView: NSViewRepresentable {
     // `zmx attach <name>` with no trailing command spawns a login shell directly — no
     // wrapper needed for a plain-shell surface.
     var command = [ZmxLocator.binaryURL.path, "attach", sessionName]
-    if launchesClaudeCode { command += agentCommand }
+    guard launchesClaudeCode else { return command }
+    if let resuming = localResumeOrFreshCommand(agentLaunch: agentCommand) {
+      return resuming
+    }
+    command += agentCommand
     return command
+  }
+
+  /// Opening a loop whose session is gone used to start the agent **fresh**, prompt and
+  /// all, because this was the one launch path that could not resume — `agentCommand`
+  /// carries `sessionPrompt`, and only the daemon knew about `SessionIDStore`.
+  ///
+  /// That asymmetry cost a real conversation (2026-08-11). Something killed the zmx
+  /// server — an app update replaces the `zmx` binary and reloads the daemon — and with
+  /// no local liveness sweep nothing brought the sessions back. Opening the loops
+  /// created fresh sessions here, whose `SessionStart` hooks rebanked their IDs over the
+  /// ones holding days of work; the transcripts survived on disk with nothing pointing
+  /// at them. Every reboot afterwards faithfully resumed the near-empty replacements.
+  ///
+  /// So this path resumes too, and the two launchers now make the same choice from the
+  /// same banked ID. The check-then-launch is one `/bin/sh` script rather than an argv
+  /// because the decision has to be made *here*, on the machine, at the moment the pane
+  /// opens: whether a session exists, and whether the resume survived, are both facts
+  /// only the shell holding the terminal can see.
+  ///
+  /// Deliberately *not* consuming the ID up front, which is what the remote path does:
+  /// there, one restorer owns the loop, and here the daemon's ensure may be running the
+  /// same resume concurrently. Two consumers racing on one `rm` is how the loser falls
+  /// through to a fresh launch — the very failure this exists to end. It is dropped only
+  /// once a resume has been *seen* to fail, which is also the check the daemon makes.
+  ///
+  /// `nil` for a backend that cannot resume, or a node with nothing banked: both take
+  /// the ordinary fresh launch.
+  func localResumeOrFreshCommand(agentLaunch: [String]) -> [String]? {
+    let settings = GraphcodeSettingsStore.load()
+    guard let nodeID = SurfaceRef.nodeID(fromZmxSessionName: sessionName),
+      SessionIDStore.load(forNodeID: nodeID) != nil,
+      let resumeLaunch = resumeCommand(
+        settings: settings, hooksFile: presenceHooksFile(), remoteSettingsPath: nil)
+    else { return nil }
+    let zmx = ZmxLocator.binaryURL.path
+    let quoted = RemoteProjectLocation.shellQuoted
+    let idFile = quoted(SessionIDStore.file(forNodeID: nodeID).path)
+    let attach = ZmxSessionLauncher.quotedCommand([zmx, "attach", sessionName])
+    let resume = ZmxSessionLauncher.quotedCommand(
+      [zmx, "attach", sessionName] + resumeLaunch)
+    let fresh = ZmxSessionLauncher.quotedCommand([zmx, "attach", sessionName] + agentLaunch)
+    let exists = ZmxSessionLauncher.quotedCommand([zmx, "get", sessionName])
+    // A live session is joined as it always was — the resume argv would be ignored by
+    // `zmx attach` anyway, and building it costs a settings read nobody needs.
+    let idVariable = ZmxSessionLauncher.remoteResumeIDVariable
+    let settle = ZmxSessionLauncher.resumeSettleSeconds
+    let joined = "\(exists) >/dev/null 2>&1 && exec \(attach); "
+    let read = "\(idVariable)=$(cat \(idFile) 2>/dev/null); "
+    let attempt =
+      "if [ -n \"$\(idVariable)\" ]; then export \(idVariable); gc_t0=$(date +%s); "
+      + resume + "; gc_rc=$?; "
+    let verdict =
+      "[ $(($(date +%s) - gc_t0)) -ge \(settle) ] && exit \"$gc_rc\"; rm -f \(idFile); "
+      + #"printf '\033[1;33m── Resume did not take; starting fresh. ──\033[0m\r\n'; fi; "#
+    let script = joined + read + attempt + verdict + "exec \(fresh)"
+    return ["/bin/sh", "-c", script]
   }
 }

--- a/graphcode/Tests/LocalSessionResumeTests.swift
+++ b/graphcode/Tests/LocalSessionResumeTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+@testable import graphcode
+
+/// A *local* machine rebooting, and the asymmetry that cost a real conversation.
+///
+/// The daemon could always resume: `ensureUnattendedSessions` reads `SessionIDStore` and
+/// passes `--resume`. Opening a loop could not — `GhosttyTerminalView` built one argv,
+/// `zmx attach <name> <agent> <prompt>`, so a pane that found the session gone started
+/// the agent over from its goal. That is not a corner case: an app update replaces the
+/// `zmx` binary and reloads the daemon, every session dies with the old server, and
+/// locally there is no liveness sweep to bring them back. Opening the loops afterwards
+/// rebanked their IDs (the `SessionStart` hook writes the pointer) over the ones holding
+/// days of work, leaving those transcripts on disk with nothing naming them — and every
+/// reboot afterwards resumed the near-empty replacements. Observed 2026-08-11 on three
+/// loops at once.
+@Suite
+struct LocalSessionResumeTests {
+  private let projectPath = "/tmp/widget"
+
+  private func surface(
+    nodeID: UUID = UUID(), backend: CLISessionBackendKind = .claudeCode
+  ) -> GhosttyTerminalView {
+    GhosttyTerminalView(
+      surfaceID: nodeID,
+      sessionName: SurfaceRef(id: nodeID, launchesClaudeCode: true).zmxSessionName,
+      launchesClaudeCode: true, backend: backend, loopType: .goalBased,
+      initialPrompt: "Work toward this goal until it is met: ship it",
+      workingDirectory: projectPath, projectPath: projectPath, onProcessExited: { _ in })
+  }
+
+  /// The banked ID is real state on this disk, so these tests write one and clean up.
+  private func withBankedID<T>(
+    _ sessionID: String?, forNode nodeID: UUID, _ body: () throws -> T
+  ) rethrows -> T {
+    if let sessionID {
+      SessionIDStore.save(sessionID, forNodeID: nodeID)
+    } else {
+      SessionIDStore.remove(forNodeID: nodeID)
+    }
+    defer { SessionIDStore.remove(forNodeID: nodeID) }
+    return try body()
+  }
+
+  // MARK: - The pane resumes rather than re-prompting
+
+  @Test
+  func openingALoopWithABankedIDResumesInsteadOfReplayingTheGoal() throws {
+    let nodeID = UUID()
+    let view = surface(nodeID: nodeID)
+    let script = try withBankedID("abc-123", forNode: nodeID) {
+      try #require(view.localResumeOrFreshCommand(agentLaunch: ["claude", "the prompt"])?.last)
+    }
+    #expect(script.contains(#"--resume "$GRAPHCODE_RESUME_ID""#))
+    #expect(script.contains(SessionIDStore.file(forNodeID: nodeID).path))
+    // A live session is still just joined — the same reattach the pane always did.
+    #expect(script.contains("'get'"))
+    #expect(script.contains("'attach'"))
+  }
+
+  @Test
+  func aNodeWithNothingBankedStillLaunchesFresh() {
+    let nodeID = UUID()
+    let view = surface(nodeID: nodeID)
+    let command = withBankedID(nil, forNode: nodeID) {
+      view.localResumeOrFreshCommand(agentLaunch: ["claude", "the prompt"])
+    }
+    // Nothing to resume is the first launch, and the ordinary argv is what it gets.
+    #expect(command == nil)
+  }
+
+  @Test
+  func aBackendThatCannotResumeIsUnaffected() {
+    let nodeID = UUID()
+    let view = surface(nodeID: nodeID, backend: .codex)
+    let command = withBankedID("abc-123", forNode: nodeID) {
+      view.localResumeOrFreshCommand(agentLaunch: ["codex", "the prompt"])
+    }
+    #expect(command == nil)
+  }
+
+  // MARK: - A resume that does not take
+
+  @Test
+  func aDeadIDFallsThroughToAFreshLaunchRatherThanClosingThePane() throws {
+    // `claude --resume` against a transcript its retention expired dies at once, and
+    // `zmx attach` hands that exit straight to the pane, which reads as the loop having
+    // finished. Only this script can see how long the session lived, so it measures.
+    let nodeID = UUID()
+    let view = surface(nodeID: nodeID)
+    let script = try withBankedID("dead-id", forNode: nodeID) {
+      try #require(view.localResumeOrFreshCommand(agentLaunch: ["claude", "the prompt"])?.last)
+    }
+    #expect(script.contains("gc_t0=$(date +%s)"))
+    #expect(script.contains("-ge \(ZmxSessionLauncher.resumeSettleSeconds)"))
+    #expect(script.contains("Resume did not take"))
+    // The fresh launch is what follows, prompt and all.
+    let verdict = try #require(script.range(of: "Resume did not take"))
+    #expect(script[verdict.upperBound...].contains("the prompt"))
+  }
+
+  @Test
+  func theIDIsDroppedOnlyAfterAResumeIsSeenToFail() throws {
+    // Not consumed up front, unlike the remote path: there one restorer owns the loop,
+    // here the daemon's ensure may be running the same resume concurrently, and two
+    // consumers racing on one `rm` is how the loser falls through to a fresh launch —
+    // the very failure this exists to end.
+    let nodeID = UUID()
+    let view = surface(nodeID: nodeID)
+    let script = try withBankedID("abc-123", forNode: nodeID) {
+      try #require(view.localResumeOrFreshCommand(agentLaunch: ["claude", "the prompt"])?.last)
+    }
+    let removal = try #require(script.range(of: "rm -f"))
+    let attempt = try #require(script.range(of: #"--resume "$GRAPHCODE_RESUME_ID""#))
+    #expect(attempt.upperBound < removal.lowerBound)
+  }
+
+  @Test
+  func aResumedLocalSessionStillReportsItsPresence() throws {
+    // Without the hooks a resumed loop reads IDLE for as long as it runs — the fresh
+    // launch has always passed them, and a resume that dropped them would make every
+    // post-reboot card lie.
+    let nodeID = UUID()
+    let view = surface(nodeID: nodeID)
+    let resume = try #require(
+      view.resumeCommand(
+        settings: GraphcodeSettings(), hooksFile: URL(fileURLWithPath: "/tmp/hooks.json"),
+        remoteSettingsPath: nil)
+    ).joined(separator: " ")
+    #expect(resume.contains("--settings"))
+    #expect(resume.contains("/tmp/hooks.json"))
+    // No opening prompt: a resumed conversation already had one.
+    #expect(!resume.contains("GRAPHCODE_TRIGGER_PROMPT"))
+  }
+
+  // MARK: - The history beside the pointer
+
+  @Test
+  func everyBankedIDIsAppendedToAHistoryBesideThePointer() throws {
+    // The pointer is last-writer-wins by design; the history is what made the 2026-08-11
+    // recovery possible at all, and it was pure forensics — transcript sizes and birth
+    // times out of `~/.claude/projects`.
+    let json = try #require(
+      PresenceHooks.json(forBackend: .claudeCode, zmxPath: "/opt/zmx"))
+    let parsed = try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any] ?? [:]
+    let hooks = try #require(parsed["hooks"] as? [String: Any])
+    let matchers = try #require(hooks["SessionStart"] as? [[String: Any]])
+    let entries = try #require(matchers.first?["hooks"] as? [[String: Any]])
+    let capture = try #require(
+      entries.compactMap { $0["command"] as? String }
+        .first { $0.contains("CLAUDE_CODE_SESSION_ID") })
+
+    #expect(capture.contains(".history"))
+    #expect(capture.contains("$PWD"))
+    // Appended, never rewritten — and written before the pointer, so no ID the pointer
+    // names is ever missing from the history.
+    #expect(capture.contains(">>"))
+    let history = try #require(capture.range(of: ".history"))
+    let pointer = try #require(capture.range(of: ".id"))
+    #expect(history.upperBound < pointer.lowerBound)
+  }
+
+  @Test
+  func theHistoryReadsBackTheIDsAndWhereTheyRan() throws {
+    let nodeID = UUID()
+    let file = SessionIDStore.historyFile(forNodeID: nodeID)
+    try FileManager.default.createDirectory(
+      at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try "1786498552 aaa /Volumes/SCG/wd/widget\n1786499999 bbb /tmp/wt\n"
+      .write(to: file, atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(at: file) }
+
+    let history = SessionIDStore.history(forNodeID: nodeID)
+    #expect(history.map(\.sessionID) == ["aaa", "bbb"])
+    #expect(history.last?.workingDirectory == "/tmp/wt")
+  }
+}


### PR DESCRIPTION
Fixes the defect behind three loops losing days of work across a reboot (investigated in-session on 2026-08-11), plus the two guards around it.

## Root cause

The reboot was not where the damage happened. The app's own launch path was the only one that could not resume: `GhosttyTerminalView` built `zmx attach <name> <agent> <prompt>`, so a pane that found the session gone started the agent over from its goal. Only `graphcoded` read `SessionIDStore`.

That asymmetry is harmless while sessions survive, and locally they don't — an app update replaces the `zmx` binary and reloads the daemon, every session dies with the old server, and there is no local liveness sweep. Opening the loops afterwards created fresh sessions whose `SessionStart` hooks rebanked their IDs over the ones holding the work. Every reboot after that faithfully resumed the near-empty replacements.

Evidence: the stubs' first message is the goal prompt *with the WAKE.md pointer* — graphcode's fresh-launch shape — and they were born 14 minutes after the real sessions, which kept running until the reboot.

## Changes

- **The pane resumes.** Both launchers now make the same choice from the same banked ID, so no duplicate fresh session can be created while a resumable conversation exists — and nothing can clobber the pointer with a stub.
- **A resume that does not take falls through to fresh.** `zmx run -d` reports that the session exists, not that what it launched survived; a `claude --resume` against an expired transcript left the card claiming `running` over nothing, and the local path never consumed the ID, so the next ensure retried the same dead one forever.
- **The ID is dropped only after a resume is seen to fail.** Never up front: the remote path consumes first because one restorer owns the loop, but here the daemon's ensure may be running the same resume concurrently.
- **`.history` beside the pointer.** Every banked ID, with its working directory. The pointer is last-writer-wins by design; this is what makes a wrong one recoverable — reconstructing this incident meant reading transcript sizes and birth times and guessing.

## Testing

784 tests pass (8 new in `LocalSessionResumeTests`); `make check` clean.

Covered: opening a loop with a banked ID resumes rather than replaying the goal; nothing banked still launches fresh; a non-resumable backend is unaffected; a dead ID falls through to fresh rather than closing the pane; the ID is dropped only after the attempt; a resumed session still carries its presence hooks; the history is appended before the pointer and reads back.

## Not covered here

Two known gaps remain, both confirmed but out of scope: a resumed goal-based loop is never nudged to continue (it restores context and waits for input, while reporting `busy`), and the daemon loads no project graphs until the app asks, so loops in projects absent from `open-projects.json` are never restored at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y8PXuUFDWCRuNJsVdFuuJ