### PR TITLE
Project canvas matches the Graph view's layout; briefing teaches node = loop

### DIFF
--- a/GraphcodeKit/Sources/Domain/SessionBriefing.swift
+++ b/GraphcodeKit/Sources/Domain/SessionBriefing.swift
@@ -63,6 +63,12 @@ public enum SessionBriefing {
       graphcode node create \(projectPath) --title <title> --type goal --goal <what done looks like>
       ```
 
+      A **node is a loop** — the cards on graphcode's canvas are loops, and the CLI calls
+      them nodes. A request to create a "child node", "child loop", "sub-loop", "subagent
+      loop", or a "node" of any kind is a request for this command, whatever the word.
+      Run from inside your session, the CLI already attributes the new loop to you as its
+      creator, so making a child needs nothing beyond the create itself.
+
       ## Choosing the loop type
 
       Choose by **what decides the loop is finished**. This matters more than it looks:

--- a/graphcode/Sources/Features/App/QuickChatsCanvasView.swift
+++ b/graphcode/Sources/Features/App/QuickChatsCanvasView.swift
@@ -37,10 +37,8 @@ struct QuickChatsCanvasView: View {
   @State private var pinchBaseScale: CGFloat?
   @State private var viewport: CGSize = .zero
 
-  /// One chat and where its card goes. Derived rather than stored, and laid out with the
-  /// same grid a folder's freshly synced nodes get (`ProjectFeature.gridPosition`), so a
-  /// chat card lands on the same rhythm as a loop card — this is a viewer, not a second
-  /// canvas you arrange by hand.
+  /// One chat and where its card goes. Derived rather than stored — this is a viewer, not
+  /// a second canvas you arrange by hand.
   private struct Placement: Identifiable {
     let chat: QuickChat
     let position: CGPoint
@@ -50,8 +48,20 @@ struct QuickChatsCanvasView: View {
 
   private var placements: [Placement] {
     store.quickChats.enumerated().map { index, chat in
-      Placement(chat: chat, position: ProjectFeature.gridPosition(index))
+      Placement(chat: chat, position: Self.gridPosition(index))
     }
+  }
+
+  /// Rows of three, on the same origin and pitch a folder's cards use (`LaneLayout`), so a
+  /// chat card lands on the rhythm of a loop card. A plain grid rather than that layout
+  /// itself because chats have no edges at all — there is no chain to run rightward and no
+  /// beginning to stack down the left, so laying them out by structure would produce one
+  /// very long column saying nothing.
+  private static func gridPosition(_ index: Int) -> CGPoint {
+    let columns = 3
+    return CGPoint(
+      x: LaneLayout.Metrics.origin.x + CGFloat(index % columns) * LaneLayout.Metrics.columnWidth,
+      y: LaneLayout.Metrics.origin.y + CGFloat(index / columns) * LaneLayout.Metrics.rowHeight)
   }
 
   var body: some View {

--- a/graphcode/Sources/Features/Canvas/LaneLayout.swift
+++ b/graphcode/Sources/Features/Canvas/LaneLayout.swift
@@ -1,0 +1,175 @@
+import CoreGraphics
+import Foundation
+import GraphcodeKit
+
+/// Where one graph's cards go: the column says how far a loop sits from a beginning, the
+/// row says which chain it belongs to.
+///
+/// Lifted out of the Graph view's lane layout so a folder's own canvas can be placed by the
+/// same rules. The two used to disagree about what a graph looks like — the Graph view read
+/// the edges and laid chains out left-to-right off a column of beginnings, while a project's
+/// canvas handed out grid slots in whatever order nodes arrived from the daemon and never
+/// looked at an edge at all. The same three loops therefore read as a chain in one view and
+/// as a scatter in the other, with the hand-offs between them running behind the cards.
+/// There is one answer to "where does this card go" now, and both canvases ask it.
+///
+/// Positions are *derived*, never accumulated. Recomputing from the graph is cheaper than
+/// reconciling a stored table against the next broadcast, and it is the whole point: a new
+/// edge has to re-flow the cards it now relates, which a table of slots handed out at
+/// arrival time can never do.
+struct LaneLayout: Equatable {
+  /// One card's place in the lane, before it becomes a point.
+  struct Slot: Hashable {
+    let column: Int
+    let row: Int
+  }
+
+  enum Metrics {
+    static let card = LoopCardView.Metrics.size
+    static let columnGap: CGFloat = 40
+    static let rowGap: CGFloat = 24
+    /// How far right a chain runs before it folds back into the last column. A lane that
+    /// grew without bound would push whatever is below it off the canvas, and four
+    /// hand-offs is already deeper than a real graph goes.
+    static let columns = 4
+
+    static let columnWidth = card.width + columnGap
+    static let rowHeight = card.height + rowGap
+    /// Where a lane's band begins. On the Graph view that leaves the start node its own
+    /// 60pt column plus a gap; a project's canvas has no start node, but it keeps the
+    /// margin so a band drawn around its cards lands exactly where a lane's band does.
+    static let bandX: CGFloat = 80
+    /// Clear of the attention rail, which floats over both canvases' top-left corner.
+    static let laneTop: CGFloat = 62
+    static let bandWidth =
+      CanvasBand.padding * 2 + CanvasBand.originLane + CGFloat(columns) * card.width
+      + CGFloat(columns - 1) * columnGap
+    /// The first card's centre, inside the band and clear of the origin lane.
+    static let firstLoopX =
+      bandX + CanvasBand.padding + CanvasBand.originLane + card.width / 2
+    static let firstRowInset = CanvasBand.captionHeight + CanvasBand.padding + card.height / 2
+    /// The first card's centre on a canvas showing exactly one graph. The Graph view
+    /// stacks several, so it offsets each lane's own top instead — see `GraphOverview`.
+    static let origin = CGPoint(x: firstLoopX, y: laneTop + firstRowInset)
+  }
+
+  /// Which column and row each node landed in.
+  private(set) var slots: [UUID: Slot] = [:]
+  /// Each node's card centre, in canvas coordinates.
+  private(set) var positions: [UUID: CGPoint] = [:]
+  /// How many rows the lane used — never zero, so a band around an empty graph is still
+  /// one row tall rather than a caption-height sliver.
+  private(set) var rowCount = 1
+
+  /// - Parameters:
+  ///   - roles: passed in rather than resolved here because both callers already have
+  ///     them for their cards, and `CardEntryRole.roles(in:)` walks the whole edge list.
+  ///   - rowHeight: the Graph view's pitch unless the caller needs a taller one — see
+  ///     `rowHeight(for:)`.
+  init(
+    graph: LoopGraph, roles: [UUID: CardEntryRole], origin: CGPoint = Metrics.origin,
+    rowHeight: CGFloat = Metrics.rowHeight
+  ) {
+    // Everything nothing hands off to goes in column 0, one per row, and each chain flows
+    // right along its own row.
+    //
+    // Filling rows left-to-right put all four rootless cards of a real graph side by side,
+    // which hid the origin's fan behind them — cards draw over the lines, so the connectors
+    // showed only in the gaps and read as one card chained to the next. A column of
+    // beginnings is also how the graph reads: down the left is where work starts, across is
+    // where it goes.
+    let hangsOffOrigin: (LoopNode) -> Bool = {
+      roles[$0.id] == .entry || roles[$0.id] == .unwired
+    }
+    let starts = Array(graph.nodes).filter(hangsOffOrigin)
+    let depths = Self.depths(in: graph, from: starts.map(\.id))
+
+    var placed: [UUID: Slot] = [:]
+    var takenRows: Set<Int> = []
+    var occupied: Set<Slot> = []
+
+    func place(_ node: LoopNode, preferring row: Int) {
+      guard placed[node.id] == nil else { return }
+      let column = min(depths[node.id] ?? 0, Metrics.columns - 1)
+      var candidate = row
+      while occupied.contains(Slot(column: column, row: candidate)) { candidate += 1 }
+      let slot = Slot(column: column, row: candidate)
+      placed[node.id] = slot
+      occupied.insert(slot)
+      takenRows.insert(candidate)
+      // Walk this chain onward on the same row, so a hand-off reads as one line of work.
+      for edge in graph.edges where edge.from == node.id {
+        guard let next = graph.nodes[id: edge.to] else { continue }
+        place(next, preferring: candidate)
+      }
+    }
+
+    var nextRow = 0
+    for node in starts {
+      while takenRows.contains(nextRow) { nextRow += 1 }
+      place(node, preferring: nextRow)
+    }
+    // Whatever a walk from a beginning never reached: a closed cycle, which has none.
+    for node in graph.nodes where placed[node.id] == nil {
+      while takenRows.contains(nextRow) { nextRow += 1 }
+      place(node, preferring: nextRow)
+    }
+
+    slots = placed
+    positions = placed.mapValues { slot in
+      CGPoint(
+        x: origin.x + CGFloat(slot.column) * Metrics.columnWidth,
+        y: origin.y + CGFloat(slot.row) * rowHeight)
+    }
+    rowCount = max((placed.values.map(\.row).max() ?? 0) + 1, 1)
+  }
+
+  /// Every card one canvas can show: this graph's own loops, plus the insides of every
+  /// composite on it.
+  ///
+  /// Drilling into a composite swaps the canvas over to its sub-graph (see
+  /// `ProjectFeature.State.canvasGraph`), and those loops need somewhere to be too — a
+  /// missing position draws every card of a drilled-in canvas at the same unplaced point.
+  /// Node ids are unique across the whole tree, so one flat table serves every level; the
+  /// levels are laid out over each other on purpose, since exactly one of them is ever on
+  /// screen.
+  static func positions(forCanvas graph: LoopGraph) -> [UUID: CGPoint] {
+    var placed = LaneLayout(
+      graph: graph, roles: CardEntryRole.roles(in: graph), rowHeight: rowHeight(for: graph)
+    ).positions
+    for node in graph.nodes {
+      guard let subGraph = node.subGraph else { continue }
+      placed.merge(positions(forCanvas: subGraph)) { current, _ in current }
+    }
+    return placed
+  }
+
+  /// The row pitch a canvas needs: the Graph view's own, unless a composite here is drawn
+  /// open. A folder's canvas hangs a composite's insides below its card (`SubGraphLayout`),
+  /// and those chips need more room under a card than the Graph view — which expands
+  /// nothing — leaves between rows. Taller uniformly rather than only under the composites,
+  /// because rows of two different heights is exactly the raggedness this layout is for.
+  static func rowHeight(for graph: LoopGraph) -> CGFloat {
+    let expandsSomething = graph.nodes.contains { $0.subGraph?.nodes.isEmpty == false }
+    return expandsSomething ? max(Metrics.rowHeight, SubGraphLayout.rowPitch) : Metrics.rowHeight
+  }
+
+  /// How many hand-offs from a beginning each loop sits — its column.
+  ///
+  /// Capped by the walk itself rather than by a visited set: a cycle would otherwise raise
+  /// its own depth forever, and the column is clamped to the lane's width anyway.
+  private static func depths(in graph: LoopGraph, from starts: [UUID]) -> [UUID: Int] {
+    var depths = Dictionary(uniqueKeysWithValues: starts.map { ($0, 0) })
+    var frontier = starts
+    while let current = frontier.popLast() {
+      let next = (depths[current] ?? 0) + 1
+      guard next < Metrics.columns else { continue }
+      for edge in graph.edges where edge.from == current {
+        guard (depths[edge.to] ?? -1) < next else { continue }
+        depths[edge.to] = next
+        frontier.append(edge.to)
+      }
+    }
+    return depths
+  }
+}

--- a/graphcode/Sources/Features/Canvas/SubGraphLayout.swift
+++ b/graphcode/Sources/Features/Canvas/SubGraphLayout.swift
@@ -49,15 +49,32 @@ struct SubGraphLayout: Equatable {
   var isEmpty: Bool { placements.isEmpty }
 
   private enum Metrics {
-    /// Clear of the parent card's bottom edge (cards are ~90pt tall, centred).
-    static let firstOffset: CGFloat = 56
+    /// Clear of the parent card's bottom edge — a card reaches half its height below its
+    /// own centre.
+    static let firstOffset = LaneLayout.Metrics.card.height / 2 + 3
     static let step: CGFloat = 28
     /// Each level of nesting steps right, so depth reads off the left edge.
     static let indent: CGFloat = 14
-    /// The grid's row pitch is 200pt and a card reaches ~45pt below its centre, so this
-    /// many chips is what fits before the next row's card. Past it, `Overflow`.
+    /// How many chips a composite draws before it says `+N more` instead. Not a fit
+    /// against some other view's row pitch anymore — see `SubGraphLayout.rowPitch`, which
+    /// is how the canvas finds out how much room these need.
     static let maxVisible = 4
+    /// A chip is its caption plus 3pt of padding either side, and the deepest one has to
+    /// clear the next row's card by more than nothing.
+    static let chipHeight: CGFloat = 20
+    static let gutter: CGFloat = 10
   }
+
+  /// The row pitch a canvas needs for a composite drawn open under one of its cards.
+  ///
+  /// The dependency used to run the other way: the chips were tuned to fit a 200pt grid,
+  /// with a comment saying so, so the canvas moving to the Graph view's tighter rows would
+  /// have quietly dropped every chip onto the row below. The chips state their own room
+  /// instead, and `LaneLayout.rowHeight(for:)` asks — the deepest slot a chip or a `+N
+  /// more` can take, plus what a card occupies above its own centre.
+  static let rowPitch =
+    Metrics.firstOffset + CGFloat(Metrics.maxVisible - 1) * Metrics.step + Metrics.chipHeight / 2
+    + Metrics.gutter + LaneLayout.Metrics.card.height / 2
 
   init() {}
 

--- a/graphcode/Sources/Features/Overview/GraphOverview.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverview.swift
@@ -96,28 +96,21 @@ struct GraphOverview: Equatable {
 
   // MARK: - Layout
 
+  /// The lane's own furniture. Everything about where a *card* goes lives in `LaneLayout`
+  /// instead, which is what a folder's canvas lays itself out with too.
   enum Metrics {
-    static let card = LoopCardView.Metrics.size
+    static let card = LaneLayout.Metrics.card
     static let startNodeLane: CGFloat = 60
     /// Every band starts at the same x and is the same width, however few loops are in
     /// it. Ragged lanes read as a collage; aligned ones read as a table of projects.
-    static let bandX: CGFloat = startNodeLane + 20
-    /// Clear of the attention rail, which floats over the canvas's top-left corner.
-    static let laneTop: CGFloat = 62
+    static let bandX = LaneLayout.Metrics.bandX
+    static let laneTop = LaneLayout.Metrics.laneTop
     static let laneGap: CGFloat = 24
-    static let columnGap: CGFloat = 40
-    static let rowGap: CGFloat = 24
-    static let columns = 4
-
-    static let columnWidth = card.width + columnGap
-    static let rowHeight = card.height + rowGap
-    static let bandWidth =
-      CanvasBand.padding * 2 + CanvasBand.originLane + CGFloat(columns) * card.width
-      + CGFloat(columns - 1) * columnGap
+    static let rowGap = LaneLayout.Metrics.rowGap
+    static let bandWidth = LaneLayout.Metrics.bandWidth
     /// The first card's centre, inside the band and below the caption.
-    static let firstLoopX =
-      bandX + CanvasBand.padding + CanvasBand.originLane + card.width / 2
-    static let firstRowInset = CanvasBand.captionHeight + CanvasBand.padding + card.height / 2
+    static let firstLoopX = LaneLayout.Metrics.firstLoopX
+    static let firstRowInset = LaneLayout.Metrics.firstRowInset
   }
 
   init() {}
@@ -159,96 +152,26 @@ struct GraphOverview: Equatable {
     let links: [Link]
   }
 
-  /// How many hand-offs from a beginning each loop sits — its column.
-  ///
-  /// Capped by the walk itself rather than by a visited set: a cycle would otherwise
-  /// raise its own depth forever, and the column is clamped to the lane's width anyway.
-  private static func depths(in graph: LoopGraph, from starts: [UUID]) -> [UUID: Int] {
-    var depths = Dictionary(uniqueKeysWithValues: starts.map { ($0, 0) })
-    var frontier = starts
-    while let current = frontier.popLast() {
-      let next = (depths[current] ?? 0) + 1
-      guard next < Metrics.columns else { continue }
-      for edge in graph.edges where edge.from == current {
-        guard (depths[edge.to] ?? -1) < next else { continue }
-        depths[edge.to] = next
-        frontier.append(edge.to)
-      }
-    }
-    return depths
-  }
-
   private static func layOutLane(_ graph: LoopGraph, top: CGFloat) -> Lane {
     let path = graph.project.path
     let roles = CardEntryRole.roles(in: graph)
     var loops: [Loop] = []
     var links: [Link] = []
-    var positions: [UUID: CGPoint] = [:]
 
-    // Entry points first, then everything else, each group keeping its own order.
-    //
-    // Position is what makes the rail mean anything: a rail down the lane's leading edge
-    // with a 12pt stub to each port only reaches cards in the first column, and an entry
-    // sitting three columns right would need a connector long enough to read as an edge —
-    // which is exactly what a rail must not imply. Laying the roots out first also makes
-    // the lane read left-to-right in the direction work actually travels.
-    // Laid out by *depth from a beginning* rather than in graph order: everything
-    // nothing hands off to goes in column 0, one per row, and each chain flows right
-    // along its own row.
-    //
-    // Filling rows left-to-right put all four rootless cards of a real graph side by
-    // side, which hid the origin's fan behind them — cards draw over the lines, so the
-    // connectors showed only in the gaps and read as one card chained to the next. A
-    // column of beginnings is also how the graph reads: down the left is where work
-    // starts, across is where it goes.
-    let hangsOffOrigin: (LoopNode) -> Bool = {
-      roles[$0.id] == .entry || roles[$0.id] == .unwired
-    }
-    let starts = Array(graph.nodes).filter(hangsOffOrigin)
-    let depths = Self.depths(in: graph, from: starts.map(\.id))
-
-    var slots: [UUID: (column: Int, row: Int)] = [:]
-    var takenRows: Set<Int> = []
-    var occupied: Set<String> = []
-
-    func place(_ node: LoopNode, preferring row: Int) {
-      guard slots[node.id] == nil else { return }
-      let column = min(depths[node.id] ?? 0, Metrics.columns - 1)
-      var candidate = row
-      while occupied.contains("\(column)-\(candidate)") { candidate += 1 }
-      slots[node.id] = (column, candidate)
-      occupied.insert("\(column)-\(candidate)")
-      takenRows.insert(candidate)
-      // Walk this chain onward on the same row, so a hand-off reads as one line of work.
-      for edge in graph.edges where edge.from == node.id {
-        guard let next = graph.nodes[id: edge.to] else { continue }
-        place(next, preferring: candidate)
-      }
-    }
-
-    var nextRow = 0
-    for node in starts {
-      while takenRows.contains(nextRow) { nextRow += 1 }
-      place(node, preferring: nextRow)
-    }
-    // Whatever a walk from a beginning never reached: a closed cycle, which has none.
-    for node in graph.nodes where slots[node.id] == nil {
-      while takenRows.contains(nextRow) { nextRow += 1 }
-      place(node, preferring: nextRow)
-    }
+    // The shared layout, offset to this lane's own top — the same placement a folder's
+    // own canvas gets, so the two views can't drift on what a graph looks like.
+    let layout = LaneLayout(
+      graph: graph, roles: roles,
+      origin: CGPoint(x: Metrics.firstLoopX, y: top + Metrics.firstRowInset))
+    let positions = layout.positions
 
     for node in graph.nodes {
-      guard let slot = slots[node.id] else { continue }
-      let position = CGPoint(
-        x: Metrics.firstLoopX + CGFloat(slot.column) * Metrics.columnWidth,
-        y: top + Metrics.firstRowInset + CGFloat(slot.row) * Metrics.rowHeight)
-      positions[node.id] = position
+      guard let position = positions[node.id] else { continue }
       loops.append(
         Loop(
           node: node, projectPath: path, position: position,
           entryRole: roles[node.id] ?? .interior))
     }
-    let rowCount = max((slots.values.map(\.row).max() ?? 0) + 1, 1)
 
     for edge in graph.edges {
       guard let from = positions[edge.from], let to = positions[edge.to] else { continue }
@@ -261,7 +184,7 @@ struct GraphOverview: Equatable {
     // An empty folder still gets a band one row tall — that is how the overview says
     // "this folder has no loops yet", and collapsing it to its caption would leave a
     // sliver jammed against the lane below.
-    let rows = graph.nodes.isEmpty ? 1 : rowCount
+    let rows = graph.nodes.isEmpty ? 1 : layout.rowCount
     let height =
       CanvasBand.captionHeight + CanvasBand.padding * 2 + CGFloat(rows) * Metrics.card.height
       + CGFloat(rows - 1) * Metrics.rowGap
@@ -299,17 +222,5 @@ struct GraphOverview: Equatable {
     // The kind-independent reading of the word: a lane is speaking about a folder, and a
     // folder has no loop type for `idle` to mean "scheduled" against.
     return "\(loops) · \(matching) \(state.displayWord(for: .goalBased).lowercased())"
-  }
-}
-
-extension Array {
-  /// Fixed-width rows for the lane layout. `chunked(into:)` isn't in the standard
-  /// library and the alternative — index arithmetic inline in the layout — is where
-  /// off-by-one row bugs live.
-  fileprivate func chunked(into size: Int) -> [[Element]] {
-    guard size > 0 else { return isEmpty ? [] : [self] }
-    return stride(from: 0, to: count, by: size).map {
-      Array(self[$0..<Swift.min($0 + size, count)])
-    }
   }
 }

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -134,14 +134,7 @@ struct ProjectFeature {
 
     init(graph: LoopGraph) {
       self.graph = graph
-      var positions: [UUID: CGPoint] = [:]
-      var taken = Set<CGPoint>()
-      for node in graph.nodes {
-        let position = ProjectFeature.nextFreePosition(avoiding: taken)
-        positions[node.id] = position
-        taken.insert(position)
-      }
-      self.nodePositions = positions
+      self.nodePositions = LaneLayout.positions(forCanvas: graph)
       self.sidebarNodeOrder = graph.nodes.map(\.id)
     }
   }
@@ -228,20 +221,12 @@ struct ProjectFeature {
         switch event {
         case .graphChanged(let newGraph):
           state.connectionError = nil
-          // Slots are taken by what's *there*, not by how many there are. Indexing by
-          // count meant deleting a loop freed its position but shifted the counter back,
-          // so the next node landed exactly on top of an existing card — four loops
-          // rendering as one, with the rest hidden underneath.
-          var taken = Set(state.nodePositions.values)
-          // Composites' contents get slots too, or a drilled-in canvas draws every card
-          // at the same unplaced point. Positions are keyed by node id and ids are unique
-          // across the whole tree, so one flat table serves every level.
-          for node in newGraph.nodes.flatMap({ [$0] + ($0.subGraph?.nodes ?? []) })
-          where state.nodePositions[node.id] == nil {
-            let position = Self.nextFreePosition(avoiding: taken)
-            taken.insert(position)
-            state.nodePositions[node.id] = position
-          }
+          // Every card placed again from the graph that just arrived, rather than only the
+          // ones that are new. Slots handed out at arrival time made the canvas a record of
+          // the order loops turned up in: a hand-off drawn between two cards the layout had
+          // no reason to put near each other ran behind whatever sat between them, and
+          // wiring a graph up changed nothing about how it looked. See `LaneLayout`.
+          state.nodePositions = LaneLayout.positions(forCanvas: newGraph)
           state.graph = newGraph
           // An offer only makes sense while its loop exists, stays resolved, and still
           // points at the worktree — a restarted or deleted loop takes it with it.
@@ -444,10 +429,9 @@ struct ProjectFeature {
       case .deleteNodeConfirmed:
         guard let nodeID = state.nodePendingDeletion else { return .none }
         state.nodePendingDeletion = nil
-        // Local canvas layout is this feature's own, so it's cleaned up here rather
-        // than waiting for the daemon's broadcast — otherwise a recreated node could
-        // inherit the dead one's position.
-        state.nodePositions[nodeID] = nil
+        // The card keeps its place until the broadcast lands, at which point the whole
+        // canvas is laid out again without it. Dropping the position here instead would
+        // teleport a card that is still on screen to the canvas origin for a frame.
         let projectPath = state.graph.project.path
         return .run { _ in
           try? await orchestratorClient.send(
@@ -581,31 +565,4 @@ extension ProjectFeature {
     }
   }
 
-  /// Simple grid layout for freshly synced nodes — real layout (force-directed,
-  /// draggable repositioning) is future work; this just needs nodes to not overlap.
-  /// The first grid slot nothing is sitting on.
-  ///
-  /// Deliberately not "the nth slot for the nth node": positions are removed when a loop
-  /// is deleted, so a counter drifts out of step with the grid and starts handing out
-  /// slots that are already occupied. Cards stacked pixel-perfectly on top of each other
-  /// don't look like a layout bug — they look like the graph lost its nodes.
-  ///
-  /// Terminates because the grid is unbounded and `taken` is finite.
-  static func nextFreePosition(avoiding taken: Set<CGPoint>) -> CGPoint {
-    var index = 0
-    while true {
-      let candidate = gridPosition(index)
-      if !taken.contains(candidate) { return candidate }
-      index += 1
-    }
-  }
-
-  /// Simple grid layout for freshly synced nodes — real layout (force-directed,
-  /// draggable repositioning) is future work; this just needs nodes to not overlap.
-  static func gridPosition(_ index: Int) -> CGPoint {
-    let columns = 3
-    let column = index % columns
-    let row = index / columns
-    return CGPoint(x: 160 + CGFloat(column) * 260, y: 140 + CGFloat(row) * 200)
-  }
 }

--- a/graphcode/Tests/NodePositionTests.swift
+++ b/graphcode/Tests/NodePositionTests.swift
@@ -1,53 +1,214 @@
 import ComposableArchitecture
 import Foundation
 import GraphcodeKit
+import IdentifiedCollections
 import Testing
 
 @testable import graphcode
 
-/// Where a freshly synced loop lands on the canvas.
+/// Where a folder canvas's loops land.
 ///
-/// The bug this pins is nastier than it sounds: two cards at the *same* point don't look
-/// like a layout problem, they look like the graph lost its nodes. A project with four
+/// The bug this started from is nastier than it sounds: two cards at the *same* point don't
+/// look like a layout problem, they look like the graph lost its nodes. A project with four
 /// loops rendered as one visible card with three hidden exactly underneath it.
+///
+/// What the canvas does now is the Graph view's own layout (`LaneLayout`), so the rest of
+/// these are about the thing that made the two views disagree: the old grid handed out
+/// slots in arrival order and never read an edge, so a wired-up graph looked exactly like a
+/// scatter of unrelated loops.
 @Suite
 struct NodePositionTests {
+  private static let project = ProjectRef(path: "/tmp/p", name: "p")
+
   private func node(_ title: String) -> LoopNode {
     LoopNode(title: title, loopType: .goalBased, goal: GoalSpec(summary: "go"))
   }
 
+  private func graph(nodes: [LoopNode], edges: [LoopEdge] = []) -> LoopGraph {
+    LoopGraph(
+      project: Self.project, nodes: IdentifiedArrayOf(uniqueElements: nodes),
+      edges: IdentifiedArrayOf(uniqueElements: edges))
+  }
+
   @Test
-  func everyLoopGetsASlotOfItsOwn() {
-    var taken: Set<CGPoint> = []
-    for _ in 0..<7 {
-      let position = ProjectFeature.nextFreePosition(avoiding: taken)
-      #expect(!taken.contains(position))
-      taken.insert(position)
+  func everyLoopGetsAPointOfItsOwn() {
+    let nodes = (0..<7).map { node("loop-\($0)") }
+    let placed = LaneLayout.positions(
+      forCanvas: graph(
+        nodes: nodes,
+        edges: [
+          LoopEdge(from: nodes[0].id, to: nodes[1].id),
+          LoopEdge(from: nodes[1].id, to: nodes[2].id),
+        ]))
+
+    #expect(placed.count == nodes.count)
+    #expect(Set(placed.values).count == nodes.count)
+  }
+
+  /// The reported bug, stated as an equality: a folder's own canvas has to place that
+  /// folder's loops exactly where the Graph view places them.
+  ///
+  /// Not "similarly" — the same points. A project canvas is one lane of the Graph view
+  /// with the other folders and the start node taken away, so the first lane's origin *is*
+  /// the project canvas's origin, and any difference at all is the two views having two
+  /// opinions about what the graph looks like.
+  @Test
+  func aFoldersCanvasPlacesCardsExactlyWhereTheGraphViewDoes() {
+    let root = node("root")
+    let middle = node("middle")
+    let leaf = node("leaf")
+    let secondRoot = node("second root")
+    let loose = node("loose")
+    let spun = node("spun")
+    let counterSpun = node("counter-spun")
+    let wired = graph(
+      nodes: [leaf, loose, root, spun, middle, counterSpun, secondRoot],
+      edges: [
+        LoopEdge(from: root.id, to: middle.id),
+        LoopEdge(from: middle.id, to: leaf.id),
+        LoopEdge(from: secondRoot.id, to: leaf.id),
+        // A closed cycle too: it has no beginning, so it is placed last, and "last" has to
+        // mean the same thing on both canvases.
+        LoopEdge(from: spun.id, to: counterSpun.id),
+        LoopEdge(from: counterSpun.id, to: spun.id),
+      ])
+
+    let overview = GraphOverview(graphs: [wired])
+    let lane = Dictionary(uniqueKeysWithValues: overview.loops.map { ($0.id, $0.position) })
+    let canvas = ProjectFeature.State(graph: wired).nodePositions
+
+    #expect(!lane.isEmpty)
+    #expect(canvas == lane)
+  }
+
+  @Test
+  func anOpenCompositeBuysTallerRowsAndNothingElse() {
+    // The one deliberate departure: a composite drawn open hangs chips below its card, and
+    // the Graph view — which expands nothing — leaves no room for them between rows. The
+    // canvas takes a taller pitch for that, and only that: same columns, same rows, same
+    // order. Anything else would be the two views disagreeing again.
+    let inner = node("inner")
+    let composite = LoopNode(
+      title: "pipeline", loopType: .composite,
+      subGraph: LoopGraph(project: Self.project, nodes: [inner]))
+    let downstream = node("downstream")
+    let wired = graph(
+      nodes: [composite, downstream],
+      edges: [LoopEdge(from: composite.id, to: downstream.id)])
+
+    let slots = LaneLayout(graph: wired, roles: CardEntryRole.roles(in: wired)).slots
+    let canvas = ProjectFeature.State(graph: wired).nodePositions
+    let pitch = LaneLayout.rowHeight(for: wired)
+    #expect(pitch > LaneLayout.Metrics.rowHeight)
+
+    for (id, slot) in slots {
+      #expect(
+        canvas[id]
+          == CGPoint(
+            x: LaneLayout.Metrics.origin.x + CGFloat(slot.column) * LaneLayout.Metrics.columnWidth,
+            y: LaneLayout.Metrics.origin.y + CGFloat(slot.row) * pitch))
     }
-    #expect(taken.count == 7)
   }
 
   @Test
-  func aFreedSlotIsReusedRatherThanCollidedWith() {
-    // Deleting a loop frees its position. The next node should take *that* slot back,
-    // not land on one still in use.
-    let first = ProjectFeature.gridPosition(0)
-    let second = ProjectFeature.gridPosition(1)
-    let third = ProjectFeature.gridPosition(2)
+  func aChainRunsLeftToRightAlongOneRow() {
+    // The reported difference between the two views: on the Graph view A → B → C is a line
+    // of work; on a folder's canvas it was three cards in whatever order they synced, with
+    // the hand-offs drawn behind them.
+    let first = node("first")
+    let second = node("second")
+    let third = node("third")
+    let placed = LaneLayout.positions(
+      forCanvas: graph(
+        nodes: [third, first, second],
+        edges: [
+          LoopEdge(from: first.id, to: second.id), LoopEdge(from: second.id, to: third.id),
+        ]))
 
-    // Everything except the middle one is occupied.
-    let reused = ProjectFeature.nextFreePosition(avoiding: [first, third])
-    #expect(reused == second)
+    #expect(placed[first.id]?.y == placed[second.id]?.y)
+    #expect(placed[second.id]?.y == placed[third.id]?.y)
+    #expect((placed[second.id]?.x ?? 0) > (placed[first.id]?.x ?? 0))
+    #expect((placed[third.id]?.x ?? 0) > (placed[second.id]?.x ?? 0))
   }
 
   @Test
+  func beginningsStackDownTheFirstColumn() {
+    let root = node("root")
+    let downstream = node("downstream")
+    let loose = node("loose")
+    let placed = LaneLayout.positions(
+      forCanvas: graph(
+        nodes: [root, downstream, loose],
+        edges: [LoopEdge(from: root.id, to: downstream.id)]))
+
+    // Both beginnings in the column the band's origin dot reaches, on rows of their own.
+    #expect(placed[root.id]?.x == LaneLayout.Metrics.origin.x)
+    #expect(placed[loose.id]?.x == LaneLayout.Metrics.origin.x)
+    #expect(placed[root.id]?.y != placed[loose.id]?.y)
+    #expect((placed[downstream.id]?.x ?? 0) > (placed[root.id]?.x ?? 0))
+  }
+
+  @Test
+  @MainActor
+  func wiringTwoLoopsTogetherReflowsTheCanvas() async throws {
+    // The point of deriving positions rather than storing them: drawing an edge has to
+    // change what the canvas looks like, or the graph is a picture of the order things
+    // arrived in.
+    let upstream = node("upstream")
+    let downstream = node("downstream")
+    let loose = graph(nodes: [upstream, downstream])
+    let store = TestStore(initialState: ProjectFeature.State(graph: loose)) {
+      ProjectFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.daemonEvent(.graphChanged(loose)))
+    // Two loose loops: both beginnings, stacked down the first column.
+    #expect(
+      store.state.nodePositions[upstream.id]?.x == store.state.nodePositions[downstream.id]?.x)
+
+    let wired = graph(
+      nodes: [upstream, downstream],
+      edges: [LoopEdge(from: upstream.id, to: downstream.id)])
+    await store.send(.daemonEvent(.graphChanged(wired)))
+
+    let from = try #require(store.state.nodePositions[upstream.id])
+    let to = try #require(store.state.nodePositions[downstream.id])
+    #expect(to.x > from.x)
+    #expect(to.y == from.y)
+  }
+
+  @Test
+  @MainActor
+  func aCompositesInsidesArePlacedForTheCanvasThatDrillsIntoThem() async {
+    // Opening a composite swaps the canvas over to its sub-graph, so those loops need
+    // positions of their own — without them every card of a drilled-in canvas draws at the
+    // same unplaced point.
+    let inner = node("inner")
+    let composite = LoopNode(
+      title: "pipeline", loopType: .composite,
+      subGraph: LoopGraph(project: Self.project, nodes: [inner]))
+    let store = TestStore(
+      initialState: ProjectFeature.State(graph: graph(nodes: [composite]))
+    ) {
+      ProjectFeature()
+    }
+    store.exhaustivity = .off
+
+    #expect(store.state.nodePositions[inner.id] != nil)
+
+    await store.send(.daemonEvent(.graphChanged(graph(nodes: [composite]))))
+    #expect(store.state.nodePositions[inner.id] != nil)
+  }
+
+  @Test
+  @MainActor
   func deletingThenAddingDoesNotStackCardsOnTopOfEachOther() async {
     // The reported failure, end to end: create three loops, delete one, create another,
     // and every card must still be somewhere different. Indexing by `count` put the new
     // one exactly on an existing card.
-    let project = ProjectRef(path: "/tmp/p", name: "p")
-    let store = await TestStore(
-      initialState: ProjectFeature.State(graph: LoopGraph(project: project))
+    let store = TestStore(
+      initialState: ProjectFeature.State(graph: LoopGraph(project: Self.project))
     ) {
       ProjectFeature()
     } withDependencies: {
@@ -60,20 +221,19 @@ struct NodePositionTests {
     let loopA = node("Greeter 1")
     let loopB = node("Greeter 2")
     let loopC = node("Greeter 3")
-    await store.send(
-      .daemonEvent(.graphChanged(LoopGraph(project: project, nodes: [loopA, loopB, loopC]))))
+    await store.send(.daemonEvent(.graphChanged(graph(nodes: [loopA, loopB, loopC]))))
     // `b` is deleted, and the daemon broadcasts the smaller graph.
     await store.send(.deleteNodeRequested(loopB.id))
     await store.send(.deleteNodeConfirmed)
-    await store.send(
-      .daemonEvent(.graphChanged(LoopGraph(project: project, nodes: [loopA, loopC]))))
+    await store.send(.daemonEvent(.graphChanged(graph(nodes: [loopA, loopC]))))
     // A fourth loop arrives — the moment the old code collided.
     let loopD = node("Greeter 4")
-    await store.send(
-      .daemonEvent(.graphChanged(LoopGraph(project: project, nodes: [loopA, loopC, loopD]))))
+    await store.send(.daemonEvent(.graphChanged(graph(nodes: [loopA, loopC, loopD]))))
 
     let positions = [loopA, loopC, loopD].compactMap { store.state.nodePositions[$0.id] }
     #expect(positions.count == 3)
     #expect(Set(positions).count == 3)
+    // And the loop that went away takes its point with it.
+    #expect(store.state.nodePositions[loopB.id] == nil)
   }
 }

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -160,7 +160,8 @@ struct ProjectFeatureTests {
 
     await store.send(.daemonEvent(.graphChanged(graph))) {
       $0.graph = graph
-      $0.nodePositions[node.id] = ProjectFeature.gridPosition(0)
+      // One loop, wired to nothing: the first slot of the lane — see `LaneLayout`.
+      $0.nodePositions[node.id] = LaneLayout.Metrics.origin
       $0.sidebarNodeOrder = [node.id]
     }
   }

--- a/graphcode/Tests/SessionBriefingTests.swift
+++ b/graphcode/Tests/SessionBriefingTests.swift
@@ -57,6 +57,16 @@ struct SessionBriefingTests {
   }
 
   @Test
+  func theBriefingSaysANodeIsALoop() throws {
+    // Issue #91: a Copilot session asked to create a child "node" did nothing, while
+    // "child loop" worked — the briefing taught the command only under the word "loop".
+    // The vocabulary bridge is the fix, so its absence has to fail a test.
+    let briefing = try #require(SessionBriefing.text(projectPath: Self.project))
+    #expect(briefing.contains("node is a loop"))
+    #expect(briefing.contains("child node"))
+  }
+
+  @Test
   func theBriefingLeadsWithGoalBasedAndWarnsThatTurnBasedDoesNotStart() throws {
     // Not a style preference — a defect this pins. `LoopNode.runsUnattended` is false for
     // turn-based, so a turn-based loop an agent creates launches no process at all: five

--- a/graphcode/Tests/SubGraphLayoutTests.swift
+++ b/graphcode/Tests/SubGraphLayoutTests.swift
@@ -83,9 +83,36 @@ struct SubGraphLayoutTests {
   }
 
   @Test
+  func aCompositesChipsStayInTheRowTheyHangIn() {
+    // The chips say how much room they need and the canvas gives it to them
+    // (`LaneLayout.rowHeight(for:)`); this is the other half of that deal — a full stack
+    // plus its overflow chip has to finish above the next row's card, or the layout has
+    // quietly gone back to drawing loops on top of each other.
+    let many = (0..<12).map { LoopNode(title: "loop-\($0)", checkDescription: "?") }
+    let parent = composite("fan-out", holding: many)
+    let layout = SubGraphLayout(
+      nodes: [parent], positions: [parent.id: Self.cardPosition])
+
+    let lowest = max(
+      layout.placements.map(\.position.y).max() ?? 0,
+      layout.overflows.map(\.position.y).max() ?? 0)
+    let nextRowCardTop =
+      Self.cardPosition.y + SubGraphLayout.rowPitch - LaneLayout.Metrics.card.height / 2
+    #expect(lowest < nextRowCardTop)
+
+    // And the pitch a canvas with a composite on it actually uses is at least that much.
+    let graph = LoopGraph(project: Self.project, nodes: [parent])
+    #expect(LaneLayout.rowHeight(for: graph) >= SubGraphLayout.rowPitch)
+    // A canvas with nothing to expand keeps the Graph view's own rows.
+    let plain = LoopGraph(
+      project: Self.project, nodes: [LoopNode(title: "review", checkDescription: "?")])
+    #expect(LaneLayout.rowHeight(for: plain) == LaneLayout.Metrics.rowHeight)
+  }
+
+  @Test
   func aCompositeTooBigForTheSpaceUnderItsCardSaysWhatItIsHiding() {
-    // The grid's row pitch is fixed, so the room under a card is finite. Drawing all
-    // twelve would collide with the row below; dropping them silently would be worse.
+    // The room under a card is finite whatever the row pitch is. Drawing all twelve would
+    // collide with the row below; dropping them silently would be worse.
     let many = (0..<12).map { LoopNode(title: "loop-\($0)", checkDescription: "?") }
     let parent = composite("fan-out", holding: many)
     let layout = SubGraphLayout(


### PR DESCRIPTION
Two bug fixes for 0.1.35-beta2:

**Fixes #90** — the per-project canvas now derives card positions from the same lane layout the Graph view uses (`LaneLayout`, extracted from `GraphOverview.layOutLane`). Chains run left-to-right on one row, beginnings stack down the first column, positions re-flow when edges are wired, and a test pins exact position equality between the two views for the same graph. Composite chips now state their own row-pitch needs instead of being tuned to the old 200pt grid.

**Fixes #91** — the session briefing teaches that a node **is** a loop, so a Copilot session asked to create a "child node" (or sub-loop) maps it to `graphcode node create`; creator attribution already records parentage. Applies to local and remote (SSH) briefings alike.

Regression review: full diff reviewed; 791/791 tests pass including 4 new regression tests; swiftlint 0 serious; swift-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls4npxddhrzQ6UL7qt8xai