### PR TITLE
fix: probe before the remote connect dial may create a session

### DIFF
--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
@@ -7,9 +7,10 @@ import GraphcodeKit
 extension GhosttyTerminalView {
   /// The argv for a surface whose project is remote: a local `/bin/sh` reconnect loop
   /// (`SSHReconnectLoop`) around the `ssh -t … zmx attach` dial — both kinds: an agent
-  /// surface attaches (or creates) the loop's session on the remote host, and a plain
-  /// shell opens a remote shell in the repository, which is the shell a remote project's
-  /// extra tabs should give you.
+  /// surface joins (or, when it owns the launch, creates) the loop's session on the
+  /// remote host — see `remoteAgentScripts` for who owns what — and a plain shell opens
+  /// a remote shell in the repository, which is the shell a remote project's extra tabs
+  /// should give you.
   ///
   /// The opening prompt cannot ride in through the local environment the way it does
   /// locally: sshd does not accept arbitrary client env. It is assigned inside the
@@ -48,29 +49,44 @@ extension GhosttyTerminalView {
   /// An agent surface's connect and reconnect scripts, built from fragments computed
   /// once so the two dials cannot drift apart on preparation.
   ///
-  /// The reconnect is deliberately not the connect again. `zmx get` exits 0 for a live
+  /// Both dials open the same way (`reattachOrRetry`): `zmx get` exits 0 for a live
   /// session and 1 for a missing one — the same existence probe the daemon's ensure
   /// uses. A live session is reattached (refreshing the boot marker, so a survived
   /// reboot cannot poison a later verdict). Any exit but the explicit 1 says nothing
   /// about the session — `command not found` while the host boots, a broken login shell
-  /// after wake — so it exits 255, the one code the outer loop retries. A missing
-  /// session splits on the boot marker (`RemoteBootMarker`): the same boot (or nothing
-  /// to compare) means the loop finished while disconnected — recreating it would
-  /// launch a second agent pass behind the human's back, so the pane closes with a
-  /// notice, exactly as it always has. A changed boot proves the session died with the
-  /// machine instead, and what happens next depends on who restores this loop:
+  /// after wake — so it exits 255, the one code the outer loop retries.
   ///
-  /// - An **unattended** loop (time- or goal-based) is `graphcoded`'s to restore: its
-  ///   liveness sweep already recreates the session with the banked resume ID, under
-  ///   `RemoteEnsureGate`. The pane joining in was measured to *race* that restore —
-  ///   both consumed the same ID file, and the loser's `cat` came back empty, so the
-  ///   loop restarted fresh instead of resuming. The pane therefore only announces the
-  ///   reboot and keeps dialing; the moment the sweep has the session back, the
-  ///   reattach branch picks it up. A loop the daemon will never restore — resolved,
-  ///   killed — leaves the pane at that banner until the human closes it: visibly
-  ///   waiting, never silently relaunching.
+  /// The connect used to be a bare create-or-attach carrying the goal prompt, which
+  /// held only while one surface process survived a whole outage: surfaces are
+  /// LRU-retained (`SurfaceRetentionPolicy`) and every rebuild — a screen switch, an
+  /// app relaunch, reopening the loop — dialed connect again. Rebuilt while the remote
+  /// host's reboot had the session down, that dial re-ran the goal from scratch and
+  /// its `SessionStart` hook rebanked the fresh ID over the one holding the work,
+  /// racing the very restore `graphcoded` was making. So a missing session now takes
+  /// the same ownership split on *both* dials:
+  ///
+  /// - An **unattended** loop (time- or goal-based) is `graphcoded`'s to (re)start: its
+  ///   ensure runs at node creation, at graph load, and every liveness sweep, with the
+  ///   banked resume ID under `RemoteEnsureGate`. The pane only announces and keeps
+  ///   dialing; the moment the daemon has the session, the reattach branch picks it up.
+  ///   A loop the daemon will never restore — resolved, killed — leaves the pane at
+  ///   that banner until the human closes it: visibly waiting, never silently
+  ///   relaunching.
   /// - A **turn-based** loop has no other restorer — the daemon deliberately never
-  ///   starts one — so the pane restores it itself: `restoreScript`.
+  ///   starts one — so the pane restores it itself: `restoreScript`, whose fresh
+  ///   fall-through is also the legitimate first launch of a loop nothing has banked
+  ///   an ID for. Only the connect writes the boot marker on that create
+  ///   (`freshPrefix`); the reconnect's restore runs behind a *proven* reboot and
+  ///   deliberately leaves the marker alone — see `restoreScript`.
+  ///
+  /// The reconnect additionally splits a missing session on the boot marker
+  /// (`RemoteBootMarker`): the same boot (or nothing to compare) means the loop
+  /// finished while disconnected — recreating it would launch a second agent pass
+  /// behind the human's back, so the pane closes with a notice, exactly as it always
+  /// has. A changed boot proves the session died with the machine and enters the split
+  /// above. The connect has no such verdict to make: it is the first dial, so a missing
+  /// session is either not started yet or died while no pane was watching — both roads
+  /// lead to the same owner.
   ///
   /// The get-then-attach race (session dying in between) recreates a blank shell,
   /// accepted because the window is milliseconds.
@@ -94,17 +110,32 @@ extension GhosttyTerminalView {
     }
     let attachFresh = ZmxSessionLauncher.quotedCommand(
       ["zmx", "attach", sessionName] + agentLaunch)
-    let connect =
-      delivery + "cd \(quoted(location.remotePath)) && "
-      + markerWrite + " && " + hooksWrite + promptExport + attachFresh
+    let reattachOrRetry =
+      "\(ZmxSessionLauncher.quotedCommand(["zmx", "get", sessionName])) >/dev/null 2>&1; "
+      + "gc_rc=$?; if [ \"$gc_rc\" -eq 0 ]; then \(markerWrite); "
+      + "exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])); fi; "
+      + "[ \"$gc_rc\" -ne 1 ] && exit 255; "
+    let restorePreparation = "if cd \(quoted(location.remotePath)); then " + hooksWrite
+    let connectMissing: String
+    if loopType == .turnBased {
+      connectMissing =
+        restoreScript(
+          preparation: restorePreparation, promptExport: promptExport,
+          attachFresh: attachFresh, freshPrefix: markerWrite + "; ", settings: settings)
+        + "; exit 255"
+    } else {
+      connectMissing =
+        #"printf '\033[1;33m── Loop session is not running; waiting for graphcoded "#
+        + #"to start it. ──\033[0m\r\n'; exit 255"#
+    }
+    let connect = delivery + reattachOrRetry + connectMissing
     let rebootBranch: String
     if loopType == .turnBased {
-      let preparation = delivery + "if cd \(quoted(location.remotePath)); then " + hooksWrite
       rebootBranch =
         #"printf '\033[1;33m── Remote machine rebooted; restoring the session. ──\033[0m\r\n'; "#
         + restoreScript(
-          preparation: preparation, promptExport: promptExport, attachFresh: attachFresh,
-          settings: settings) + "; exit 255"
+          preparation: delivery + restorePreparation, promptExport: promptExport,
+          attachFresh: attachFresh, settings: settings) + "; exit 255"
     } else {
       rebootBranch =
         #"printf '\033[1;33m── Remote machine rebooted; waiting for the loop session "#
@@ -112,10 +143,7 @@ extension GhosttyTerminalView {
     }
     let markerFile = RemoteBootMarker.markerExpression(forSessionName: sessionName)
     let reconnect =
-      "\(ZmxSessionLauncher.quotedCommand(["zmx", "get", sessionName])) >/dev/null 2>&1; "
-      + "gc_rc=$?; if [ \"$gc_rc\" -eq 0 ]; then \(markerWrite); "
-      + "exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])); fi; "
-      + "[ \"$gc_rc\" -ne 1 ] && exit 255; "
+      reattachOrRetry
       + "\(RemoteBootMarker.captureFragment); gc_last=$(cat \(markerFile) 2>/dev/null); "
       + "if [ -n \"$gc_boot\" ] && [ -n \"$gc_last\" ] && [ \"$gc_boot\" != \"$gc_last\" ]; then "
       + rebootBranch + "; fi; "
@@ -123,8 +151,9 @@ extension GhosttyTerminalView {
     return (connect, reconnect)
   }
 
-  /// The turn-based restore a proven reboot runs: the connect dial's own preparation
-  /// (already in `preparation` — delivery, cd, hooks), then resume-or-fresh.
+  /// The turn-based restore a missing session sends both dials into: the preparation
+  /// the caller assembled (cd, hooks — the connect's delivery already ran), then
+  /// resume-or-fresh.
   ///
   /// The resume ID is consumed before the attempt
   /// (`ZmxSessionLauncher.resumeOrFreshScript` — the daemon's own fragment, shared so
@@ -135,16 +164,19 @@ extension GhosttyTerminalView {
   /// pass-through exit code. One that lived longer was a real session, and its exit is
   /// the session ending, passed through as ever.
   ///
-  /// The boot marker is deliberately *not* refreshed here: it updates only when an
-  /// attach finds a live session. A drop mid-restore therefore redials into this same
-  /// branch — with the marker already rewritten it would have read as "ended while
-  /// disconnected" and closed the pane on a reboot that was real.
+  /// `freshPrefix` runs just before the fresh launch. The connect passes the boot
+  /// marker write there — the create is an attach, and a first launch that recorded no
+  /// boot would read as "ended while disconnected" on its first real reboot. The
+  /// reconnect passes nothing: its restore runs behind a proven reboot, and a marker
+  /// rewritten before the session is back would make a drop mid-restore redial into
+  /// "same boot" and close the pane on a reboot that was real.
   ///
   /// The trailing `exit 255` in the caller catches a preparation step failing (the
   /// repository directory not mounted yet, a hooks write refused) — the host is
   /// mid-boot, so keep dialing rather than letting it read as "the loop finished".
   private func restoreScript(
-    preparation: String, promptExport: String, attachFresh: String, settings: GraphcodeSettings
+    preparation: String, promptExport: String, attachFresh: String, freshPrefix: String = "",
+    settings: GraphcodeSettings
   ) -> String {
     var script = preparation + "{ "
     let nodeID = SurfaceRef.nodeID(fromZmxSessionName: sessionName)
@@ -160,7 +192,7 @@ extension GhosttyTerminalView {
         + #"printf '\033[1;33m── Resume did not take; starting the session fresh. ──\033[0m\r\n'"#
       script += ZmxSessionLauncher.resumeOrFreshScript(idFile: idFile, resume: attempt) + "; "
     }
-    script += promptExport + "exec \(attachFresh); }; fi"
+    script += promptExport + freshPrefix + "exec \(attachFresh); }; fi"
     return script
   }
 

--- a/graphcode/Tests/RemoteLoopSurvivalTests.swift
+++ b/graphcode/Tests/RemoteLoopSurvivalTests.swift
@@ -296,6 +296,78 @@ struct RemoteLoopSurvivalTests {
     #expect(successBranch[..<branchEnd.lowerBound].contains(".graphcode/boots"))
   }
 
+  // MARK: - The connect dial
+
+  @Test
+  func theConnectProbesBeforeItWillCreateAnything() throws {
+    // The connect used to be a bare create-or-attach carrying the goal prompt, which
+    // held only while one surface process survived a whole outage: surfaces are
+    // LRU-retained, and one rebuilt while a remote reboot had the session down — a
+    // screen switch, an app relaunch, reopening the loop — re-ran the goal from
+    // scratch and rebanked a fresh session ID over the one holding the work. Both
+    // dials now open with the same probe.
+    let view = agentSurface()
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    let connectLine = try #require(script.range(of: "while :; do").map { script[..<$0.lowerBound] })
+    #expect(connectLine.contains("'get'"))
+    #expect(connectLine.contains(#"-ne 1"#))
+    #expect(connectLine.contains("exit 255"))
+  }
+
+  @Test
+  func aLiveSessionIsJoinedWithoutTheAgentCommand() throws {
+    // A live session means someone already launched the agent — the daemon's ensure or
+    // an earlier pane. Attaching with the launch argv would be harmless today only
+    // because zmx ignores it; joining plainly makes that not depend on zmx's mercy.
+    let view = agentSurface()
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    let connectLine = try #require(script.range(of: "while :; do").map { script[..<$0.lowerBound] })
+    let live = try #require(connectLine.range(of: "-eq 0"))
+    let branchEnd = try #require(connectLine[live.upperBound...].range(of: "fi;"))
+    let branch = connectLine[live.upperBound..<branchEnd.lowerBound]
+    #expect(branch.contains("exec"))
+    #expect(branch.contains(".graphcode/boots"))
+    #expect(!branch.contains("claude"))
+    #expect(!branch.contains("GRAPHCODE_TRIGGER_PROMPT"))
+  }
+
+  @Test
+  func anUnattendedConnectNeverCarriesThePromptAndWaitsForTheDaemon() throws {
+    // An unattended loop's session is graphcoded's to start — at node creation, at
+    // graph load, and every liveness sweep, under the ensure gate. The pane creating
+    // it here raced that ensure: whichever launched second either re-ran the goal or
+    // typed a launch command into the other's session. The pane now announces and
+    // keeps dialing until the daemon has it.
+    let view = agentSurface(loopType: .goalBased)
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    #expect(!script.contains("GRAPHCODE_TRIGGER_PROMPT"))
+    #expect(!script.contains("--append-system-prompt"))
+    #expect(!script.contains("--resume"))
+    let connectLine = try #require(script.range(of: "while :; do").map { script[..<$0.lowerBound] })
+    #expect(connectLine.contains("waiting for graphcoded"))
+    #expect(connectLine.contains("exit 255"))
+  }
+
+  @Test
+  func aTurnBasedConnectResumesTheBankedConversation() throws {
+    // Opening a remote turn-based loop whose session was gone used to restart the
+    // goal fresh — the resume-on-open the local pane got never reached the remote
+    // dial. The connect's missing branch now runs the same consume-first restore as
+    // the reconnect's proven-reboot branch; only a loop nothing ever banked an ID for
+    // falls through to the prompt-bearing first launch, which records the boot it
+    // was created under.
+    let nodeID = UUID()
+    let view = agentSurface(nodeID: nodeID)
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    let connectLine = try #require(script.range(of: "while :; do").map { script[..<$0.lowerBound] })
+    #expect(connectLine.contains("\(nodeID.uuidString).id"))
+    #expect(connectLine.contains(#"--resume "$GRAPHCODE_RESUME_ID""#))
+    #expect(connectLine.contains("rm -f"))
+    #expect(connectLine.contains("GRAPHCODE_TRIGGER_PROMPT"))
+    let fresh = try #require(connectLine.range(of: "Resume did not take"))
+    #expect(connectLine[fresh.upperBound...].contains(".graphcode/boots"))
+  }
+
   @Test
   func copilotRestoreResumesWithoutANameAndCodexCannotResume() {
     // Copilot's `--name` and `--resume` are mutually exclusive; Codex has no resume at


### PR DESCRIPTION
## Summary
Closes the remaining duplicated-loop path after a **remote host reboot**: the pane's first (connect) dial was still a prompt-bearing create-or-attach. Since surfaces are LRU-retained, any surface rebuild during the outage window (screen switch, app relaunch, reopening the loop) re-ran the goal from scratch, rebanked a fresh session ID over the one holding the work, and raced graphcoded's gated restore.

- Both dials now open with the same `zmx get` probe: live → boot-marker refresh + plain attach; non-1 exit → retry (255).
- A proven-missing session takes the reconnect's ownership split on **both** dials:
  - **Unattended** loops: the pane never creates — it announces and keeps dialing until the daemon's ensure has the session back.
  - **Turn-based** loops: consume-first resume from the banked ID (same `restoreScript`), falling through to the prompt-bearing fresh launch only when nothing was ever banked — which also gives remote turn-based loops resume-on-open (parity with 0.1.34's local fix).
- The boot marker is written at live attach and at the fresh create, no longer unconditionally before every connect (which destroyed the reboot evidence the reconnect verdict depends on).

## Testing
- 83 tests across RemoteLoopSurvivalTests (+4 new: probe-first, plain live attach, unattended never carries the prompt, turn-based connect resumes), RemoteRepositoryTests, RemoteSessionResumeTests, RemoteSessionLaunchTests, LocalSessionResumeTests — all pass.
- swiftlint + swift format lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls4npxddhrzQ6UL7qt8xai