### PR TITLE
fix: suggested loop names are one or two precise words, and never a name in use

### DIFF
--- a/graphcode/Sources/Clients/LoopTitleDirectory.swift
+++ b/graphcode/Sources/Clients/LoopTitleDirectory.swift
@@ -1,0 +1,47 @@
+import Dependencies
+import Foundation
+import GraphcodeKit
+
+/// Every node title the app currently knows, across every open project — local
+/// folders, remote repositories, and the Graph — for the one consumer that needs the
+/// cross-project view: `TitleSuggestionClient`, whose generated names must not collide
+/// with anything already on any canvas.
+///
+/// Each project's reducer registers its graph on every `.graphChanged` broadcast, so
+/// the directory is only ever as current as the last broadcast — enough for naming,
+/// where a stale entry merely keeps a just-deleted name retired one beat longer.
+struct LoopTitleDirectory: Sendable {
+  var register: @Sendable (_ projectPath: String, _ graph: LoopGraph) -> Void
+  var allTitles: @Sendable () -> Set<String>
+}
+
+extension LoopTitleDirectory: DependencyKey {
+  static let liveValue: LoopTitleDirectory = {
+    let titles = LockIsolated<[String: Set<String>]>([:])
+    return LoopTitleDirectory(
+      register: { path, graph in
+        titles.withValue { $0[path] = collectTitles(in: graph) }
+      },
+      allTitles: {
+        titles.withValue { stored in stored.values.reduce(into: Set()) { $0.formUnion($1) } }
+      })
+  }()
+
+  /// Reducer tests exercise node creation without caring about names elsewhere.
+  static let testValue = LoopTitleDirectory(register: { _, _ in }, allTitles: { [] })
+
+  /// A composite's children live in its `subGraph`, and their names are just as taken.
+  static func collectTitles(in graph: LoopGraph) -> Set<String> {
+    graph.nodes.reduce(into: Set()) { titles, node in
+      titles.insert(node.title)
+      if let subGraph = node.subGraph { titles.formUnion(collectTitles(in: subGraph)) }
+    }
+  }
+}
+
+extension DependencyValues {
+  var loopTitleDirectory: LoopTitleDirectory {
+    get { self[LoopTitleDirectory.self] }
+    set { self[LoopTitleDirectory.self] = newValue }
+  }
+}

--- a/graphcode/Sources/Clients/TitleSuggestionClient.swift
+++ b/graphcode/Sources/Clients/TitleSuggestionClient.swift
@@ -2,16 +2,20 @@ import Dependencies
 import Foundation
 import GraphcodeKit
 
-/// Asks a loop's own backend for a one-word title when the human left the form's title
-/// blank — `claude -p` / `copilot -p` / `codex exec`, the headless print-mode shape of
-/// each CLI, so nothing here opens a session or touches the loop's actual work.
+/// Asks a loop's own backend for a one-or-two-word title when the human left the form's
+/// title blank — `claude -p` / `copilot -p` / `codex exec`, the headless print-mode
+/// shape of each CLI, so nothing here opens a session or touches the loop's actual work.
 ///
 /// Fire-and-forget by design: the node is already created as "New Loop" by the time this
 /// runs, and a `renameNode` follows only if an answer arrives. A backend that is slow,
 /// missing, or confused costs nothing but the fallback name staying.
 struct TitleSuggestionClient: Sendable {
-  /// A short title for `prompt`, or `nil` when the backend can't produce one.
-  var suggest: @Sendable (_ backend: CLISessionBackendKind, _ prompt: String) async -> String?
+  /// A short title for `prompt` that is not in `taken` — every node name the app knows
+  /// across every open project (`LoopTitleDirectory`) — or `nil` when the backend can't
+  /// produce one.
+  var suggest:
+    @Sendable (_ backend: CLISessionBackendKind, _ prompt: String, _ taken: Set<String>)
+      async -> String?
 }
 
 extension TitleSuggestionClient: DependencyKey {
@@ -25,18 +29,45 @@ extension TitleSuggestionClient: DependencyKey {
   /// prompt containing quotes, `$`, or backticks can't break out of the command.
   private static let promptVariable = "GRAPHCODE_TITLE_PROMPT"
 
-  static let liveValue = TitleSuggestionClient { backend, prompt in
+  static let liveValue = TitleSuggestionClient { backend, prompt, taken in
     guard let invocation = invocation(for: backend) else { return nil }
-    let instruction = """
-      Reply with a single word (no punctuation, no quotes) that names this task, \
-      and nothing else: \(prompt)
-      """
-    let output = await run(invocation, environment: [promptVariable: instruction])
-    return output.flatMap(sanitize)
+    let output = await run(
+      invocation, environment: [promptVariable: instruction(for: prompt, taken: taken)])
+    return output.flatMap { accept($0, taken: taken) }
   }
 
   /// Reducer tests have no CLI to call and should not discover that by hanging.
-  static let testValue = TitleSuggestionClient { _, _ in nil }
+  static let testValue = TitleSuggestionClient { _, _, _ in nil }
+
+  /// Bounds how many taken names ride into the instruction. Any graph that outgrows it
+  /// still gets the hard guarantee from `accept`; the instruction just stops naming
+  /// every single one.
+  private static let takenNamesListed = 100
+
+  /// One or two words, precise, and none of the names any canvas already shows — the
+  /// model is told, and `accept` enforces what telling cannot guarantee.
+  static func instruction(for prompt: String, taken: Set<String>) -> String {
+    var instruction = """
+      Reply with a precise name for this task — one or two words, no punctuation, \
+      no quotes — and nothing else.
+      """
+    let listed = taken.sorted().prefix(takenNamesListed)
+    if !listed.isEmpty {
+      instruction += " These names are already taken; do not reuse any of them: "
+      instruction += listed.joined(separator: ", ") + "."
+    }
+    return instruction + " The task: \(prompt)"
+  }
+
+  /// `sanitize`, then the guarantee the instruction alone cannot make: a name some
+  /// canvas already shows is refused outright — case-insensitively, since two loops
+  /// named "Deploy" and "deploy" are the same collision to a human — and the fallback
+  /// name stays.
+  static func accept(_ output: String, taken: Set<String>) -> String? {
+    guard let name = sanitize(output) else { return nil }
+    let collides = taken.contains { $0.caseInsensitiveCompare(name) == .orderedSame }
+    return collides ? nil : name
+  }
 
   /// The headless print-mode invocation for each backend — the shape that answers on
   /// stdout and exits, as opposed to the interactive sessions loops actually run in
@@ -102,19 +133,23 @@ extension TitleSuggestionClient: DependencyKey {
     return String(data: data, encoding: .utf8)
   }
 
-  /// One clean word out of whatever the model printed. `codex exec` wraps its answer in
-  /// log lines, and any model can get chatty — the *last* non-empty line is the answer
-  /// far more reliably than the first, and one token of it is all that was asked for.
-  private static func sanitize(_ output: String) -> String? {
+  /// One clean name — at most two words — out of whatever the model printed. `codex
+  /// exec` wraps its answer in log lines, and any model can get chatty — the *last*
+  /// non-empty line is the answer far more reliably than the first, and two tokens of
+  /// it are all that was asked for.
+  static func sanitize(_ output: String) -> String? {
     let lastLine =
       output
       .components(separatedBy: .newlines)
       .map { $0.trimmingCharacters(in: .whitespaces) }
       .last { !$0.isEmpty }
-    guard let word = lastLine?.split(separator: " ").first else { return nil }
-    let cleaned = word.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-    guard !cleaned.isEmpty, cleaned.count <= 30 else { return nil }
-    return cleaned
+    let words = (lastLine ?? "").split(separator: " ").prefix(2)
+      .map { $0.trimmingCharacters(in: CharacterSet.alphanumerics.inverted) }
+      .filter { !$0.isEmpty }
+    guard !words.isEmpty else { return nil }
+    let name = words.joined(separator: " ")
+    guard name.count <= 30 else { return nil }
+    return name
   }
 }
 

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -207,6 +207,9 @@ struct ProjectFeature {
   @Dependency(\.gitClient) var gitClient
   /// Names an untitled loop after creation — see `createNodeConfirmed`.
   @Dependency(\.titleSuggestionClient) var titleSuggestionClient
+  /// Where every project's node names are registered, so a suggested name can be
+  /// checked against all of them — not just this project's.
+  @Dependency(\.loopTitleDirectory) var loopTitleDirectory
 
   @Dependency(\.orchestratorClient) var orchestratorClient
 
@@ -221,6 +224,7 @@ struct ProjectFeature {
         switch event {
         case .graphChanged(let newGraph):
           state.connectionError = nil
+          loopTitleDirectory.register(newGraph.project.path, newGraph)
           // Every card placed again from the graph that just arrived, rather than only the
           // ones that are new. Slots handed out at arrival time made the canvas a record of
           // the order loops turned up in: a hand-off drawn between two cards the layout had
@@ -336,7 +340,8 @@ struct ProjectFeature {
             let basis = [draft.checkDescription, draft.triggerPrompt, draft.goal?.summary]
               .compactMap({ $0 })
               .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }),
-            let title = await titleSuggestionClient.suggest(draft.effectiveBackend, basis)
+            let title = await titleSuggestionClient.suggest(
+              draft.effectiveBackend, basis, loopTitleDirectory.allTitles())
           else { return }
           try? await orchestratorClient.send(
             .graphCommand(

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -46,7 +46,7 @@ struct ProjectFeatureTests {
     } withDependencies: {
       $0.gitClient.listWorktrees = { _ in [] }
       $0.orchestratorClient.send = { command in await sent.append(command) }
-      $0.titleSuggestionClient.suggest = { backend, basis in
+      $0.titleSuggestionClient.suggest = { backend, basis, _ in
         #expect(backend == .claudeCode)
         #expect(basis == "Say hello")
         return "Research"
@@ -87,7 +87,7 @@ struct ProjectFeatureTests {
     } withDependencies: {
       $0.gitClient.listWorktrees = { _ in [] }
       $0.orchestratorClient.send = { command in await sent.append(command) }
-      $0.titleSuggestionClient.suggest = { _, _ in
+      $0.titleSuggestionClient.suggest = { _, _, _ in
         #expect(Bool(false), "no suggestion should be requested for a typed title")
         return nil
       }

--- a/graphcode/Tests/TitleSuggestionTests.swift
+++ b/graphcode/Tests/TitleSuggestionTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+@testable import graphcode
+
+/// The naming rules for backend-suggested loop titles: at most two precise words, and
+/// never a name any open project — local folder, remote repository, or the Graph —
+/// already shows.
+@Suite
+struct TitleSuggestionTests {
+  @Test
+  func aNameIsAtMostTwoCleanWords() {
+    #expect(TitleSuggestionClient.sanitize("Research") == "Research")
+    #expect(TitleSuggestionClient.sanitize("Database Migration") == "Database Migration")
+    #expect(TitleSuggestionClient.sanitize("Fix flaky login tests") == "Fix flaky")
+    #expect(TitleSuggestionClient.sanitize("\"Deploy!\"") == "Deploy")
+    #expect(TitleSuggestionClient.sanitize("") == nil)
+    #expect(TitleSuggestionClient.sanitize("   \n  ") == nil)
+  }
+
+  @Test
+  func theAnswerIsTheLastNonEmptyLine() {
+    // `codex exec` wraps its answer in log lines; any model can get chatty.
+    #expect(
+      TitleSuggestionClient.sanitize("[2026-08-12] model: gpt\nthinking...\nRefactor\n")
+        == "Refactor")
+  }
+
+  @Test
+  func aTakenNameIsRefusedWhateverItsCase() {
+    #expect(TitleSuggestionClient.accept("Deploy", taken: ["deploy"]) == nil)
+    #expect(TitleSuggestionClient.accept("Deploy", taken: ["Research"]) == "Deploy")
+    #expect(
+      TitleSuggestionClient.accept("Database Migration", taken: ["database migration"]) == nil)
+  }
+
+  @Test
+  func theInstructionAsksForOneOrTwoWordsAndListsTakenNames() {
+    let instruction = TitleSuggestionClient.instruction(
+      for: "fix the build", taken: ["Deploy", "Research"])
+    #expect(instruction.contains("one or two words"))
+    #expect(instruction.contains("Deploy, Research"))
+    #expect(instruction.contains("fix the build"))
+    let bare = TitleSuggestionClient.instruction(for: "fix the build", taken: [])
+    #expect(!bare.contains("already taken"))
+  }
+
+  @Test
+  func theDirectoryCollectsTitlesAcrossProjectsAndSubgraphs() {
+    let child = LoopNode(title: "Child")
+    let composite = LoopNode(
+      title: "Composite",
+      subGraph: LoopGraph(
+        project: ProjectRef(path: "/tmp/sub", name: "sub"), nodes: [child]))
+    let local = LoopGraph(project: ProjectRef(path: "/tmp/a", name: "a"), nodes: [composite])
+    let remote = LoopGraph(
+      project: ProjectRef(path: "ssh://dev@host/w", name: "w"),
+      nodes: [LoopNode(title: "Deploy")])
+    let directory = LoopTitleDirectory.liveValue
+    directory.register(local.project.path, local)
+    directory.register(remote.project.path, remote)
+    let titles = directory.allTitles()
+    #expect(titles.isSuperset(of: ["Composite", "Child", "Deploy"]))
+  }
+}


### PR DESCRIPTION
## Summary
- New `LoopTitleDirectory` dependency: every node title across every open project (local folders, remote repositories, and the Graph; composite subgraphs included), registered by each project's reducer on every `graphChanged` broadcast.
- The title-suggestion instruction now asks for a **precise one-or-two-word** name and lists the taken names (bounded at 100).
- `accept` enforces the guarantee the instruction alone can't: a suggested name colliding with any known title (case-insensitive) is refused, and the "New Loop" fallback stays.
- `sanitize` keeps up to two words (was one), still from the last non-empty line, still ≤30 chars.

## Testing
- New TitleSuggestionTests (5 tests: two-word sanitize, chatty-output last line, case-insensitive collision refusal, instruction contents, cross-project + subgraph directory collection).
- NodeDraftTests, ProjectFeatureTests, TitleSuggestionTests — 34 tests, all pass; swiftlint + swift format lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls4npxddhrzQ6UL7qt8xai