### PR TITLE
fix: loop naming prefers two precise words, one only when it alone fits

### DIFF
--- a/graphcode/Sources/Clients/TitleSuggestionClient.swift
+++ b/graphcode/Sources/Clients/TitleSuggestionClient.swift
@@ -44,12 +44,15 @@ extension TitleSuggestionClient: DependencyKey {
   /// every single one.
   private static let takenNamesListed = 100
 
-  /// One or two words, precise, and none of the names any canvas already shows — the
-  /// model is told, and `accept` enforces what telling cannot guarantee.
+  /// As precise as possible, preferring two words — a single word is allowed when it
+  /// alone names the task, never more than two — and none of the names any canvas
+  /// already shows. The model is told, and `accept` enforces what telling cannot
+  /// guarantee.
   static func instruction(for prompt: String, taken: Set<String>) -> String {
     var instruction = """
-      Reply with a precise name for this task — one or two words, no punctuation, \
-      no quotes — and nothing else.
+      Reply with the most precise name you can for this task. Prefer two words; use \
+      a single word only when it alone names the task precisely. Never more than two \
+      words, no punctuation, no quotes — and nothing else.
       """
     let listed = taken.sorted().prefix(takenNamesListed)
     if !listed.isEmpty {

--- a/graphcode/Tests/TitleSuggestionTests.swift
+++ b/graphcode/Tests/TitleSuggestionTests.swift
@@ -36,10 +36,12 @@ struct TitleSuggestionTests {
   }
 
   @Test
-  func theInstructionAsksForOneOrTwoWordsAndListsTakenNames() {
+  func theInstructionPrefersTwoPreciseWordsAndListsTakenNames() {
     let instruction = TitleSuggestionClient.instruction(
       for: "fix the build", taken: ["Deploy", "Research"])
-    #expect(instruction.contains("one or two words"))
+    #expect(instruction.contains("Prefer two words"))
+    #expect(instruction.contains("single word only when it alone names the task"))
+    #expect(instruction.contains("Never more than two words"))
     #expect(instruction.contains("Deploy, Research"))
     #expect(instruction.contains("fix the build"))
     let bare = TitleSuggestionClient.instruction(for: "fix the build", taken: [])


### PR DESCRIPTION
## Summary
Follow-up to #97: the instruction asked for "one or two words" with no preference. It now asks for the most precise name possible, **preferring two words** and allowing a single word only when it alone names the task. Hard bounds unchanged (max two words, `sanitize`-enforced; dedup against all open projects unchanged).

## Testing
TitleSuggestionTests — 5 tests pass; swift format lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls4npxddhrzQ6UL7qt8xai