### PR TITLE
feat: a bounded dial log records every launch decision where it was made

### DIFF
--- a/GraphcodeKit/Sources/Domain/DialLog.swift
+++ b/GraphcodeKit/Sources/Domain/DialLog.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// One line per launch decision, written on the machine that made it — the record that
+/// turns "my loop restarted from scratch" into a diagnosis instead of a forensic
+/// reconstruction from transcript birth times.
+///
+/// Every dial that can create, resume, or refuse to touch a session appends
+/// `<utc-time> <session> <dial> <branch>` to `~/.graphcode/dials.log` on the host the
+/// session lives on: a remote loop's pane scripts and the daemon's remote ensure log on
+/// the remote host, right beside the banked session IDs they consume; the daemon's
+/// local launches and the local pane log here. The pane banners announce the same
+/// decisions, but they die with the scrollback.
+///
+/// Bounded before every append: past `maxBytes` the file is trimmed to its last
+/// `keptLines` lines (~5000 lines is roughly 400 KB of these), so a reconnect loop
+/// that waits all night cannot eat a disk.
+public enum DialLog {
+  public static let maxBytes = 1_048_576
+  public static let keptLines = 5000
+  static let logExpression = "\"$HOME/.graphcode/dials.log\""
+
+  /// The append as a shell fragment, safe anywhere in an `&&` chain: braced, silenced,
+  /// and `|| true`d — a full disk or a read-only home must never break the dial it
+  /// rides on. `session`, `dial`, and `event` are interpolated into the `printf`
+  /// format, which is fine for the values this codebase passes (session names are
+  /// `graphcode-<uuid>`, the rest are literals here) and would not be for user text.
+  public static func fragment(session: String, dial: String, event: String) -> String {
+    let log = logExpression
+    return "{ mkdir -p \"$HOME/.graphcode\"; "
+      + "gc_dl=$(wc -c < \(log) 2>/dev/null || echo 0); "
+      + "[ \"${gc_dl:-0}\" -gt \(maxBytes) ] "
+      + "&& { tail -n \(keptLines) \(log) > \(log).tmp && mv \(log).tmp \(log); }; "
+      + "printf '%s \(session) \(dial) \(event)\\n' \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" "
+      + ">> \(log); } 2>/dev/null || true"
+  }
+
+  /// The same line from Swift, for the launches the daemon decides locally rather than
+  /// in a remote shell. Best-effort by the same rule: failure to log must never fail a
+  /// launch.
+  public static func record(
+    session: String, dial: String, event: String,
+    home: URL = FileManager.default.homeDirectoryForCurrentUser
+  ) {
+    let fileManager = FileManager.default
+    let directory = home.appendingPathComponent(".graphcode", isDirectory: true)
+    let log = directory.appendingPathComponent("dials.log")
+    try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    let stamp = ISO8601DateFormatter().string(from: Date())
+    let line = "\(stamp) \(session) \(dial) \(event)\n"
+    let size = (try? fileManager.attributesOfItem(atPath: log.path))?[.size] as? Int ?? 0
+    if size > maxBytes, let contents = try? String(contentsOf: log, encoding: .utf8) {
+      let kept = contents.split(separator: "\n").suffix(keptLines).joined(separator: "\n")
+      try? (kept + "\n" + line).write(to: log, atomically: true, encoding: .utf8)
+      return
+    }
+    if let handle = try? FileHandle(forWritingTo: log) {
+      _ = try? handle.seekToEnd()
+      try? handle.write(contentsOf: Data(line.utf8))
+      try? handle.close()
+    } else {
+      try? line.write(to: log, atomically: true, encoding: .utf8)
+    }
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -890,14 +890,19 @@ public enum ZmxSessionLauncher {
     forNode node: LoopNode, freshRun: String, at location: RemoteProjectLocation,
     settings: GraphcodeSettings
   ) -> String {
+    let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
+    let log = { (event: String) in
+      DialLog.fragment(session: name, dial: "ensure", event: event) + "; "
+    }
     guard
       let resumeArgv = resumeArguments(
         forNode: node, sessionID: remoteResumeIDPlaceholder,
         projectPath: location.projectPath, settings: settings)
-    else { return freshRun }
+    else { return log("fresh") + freshRun }
     let resume = remoteQuotedCommand(["zmx"] + resumeArgv)
     let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: node.id)
-    return resumeOrFreshScript(idFile: idFile, resume: resume, fresh: freshRun)
+    return resumeOrFreshScript(
+      idFile: idFile, resume: log("resume") + resume, fresh: log("fresh") + freshRun)
   }
 
   /// The consume-then-attempt shape both resumers share: read the banked ID, remove it
@@ -1191,13 +1196,15 @@ public enum ZmxSessionLauncher {
         return CopilotSessionLog.directory(forSessionNamed: name)?.lastPathComponent
       }()
     guard let runArgs = arguments(forNode: node, projectPath: projectPath) else { return }
+    let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
     if let sessionID,
       let resumeArgs = resumeArguments(
         forNode: node, sessionID: sessionID, projectPath: projectPath)
     {
       await atomicCheckOrRun(
         checkArguments: checkArgs, runArguments: resumeArgs,
-        zmxPath: zmxPath, workingDirectory: wd)
+        zmxPath: zmxPath, workingDirectory: wd,
+        logFragment: DialLog.fragment(session: name, dial: "ensure", event: "resume"))
       // `zmx run -d` reports that the *session* exists, not that what it launched
       // survived: `claude --resume` against a transcript its retention expired dies
       // within a second, taking the session with it, and the ensure returns 0 having
@@ -1211,11 +1218,13 @@ public enum ZmxSessionLauncher {
         await sessionDiedImmediately(
           checkArguments: checkArgs, zmxPath: zmxPath, workingDirectory: wd)
       else { return }
+      DialLog.record(session: name, dial: "ensure", event: "resume-dead")
       SessionIDStore.remove(forNodeID: node.id)
     }
     await atomicCheckOrRun(
       checkArguments: checkArgs, runArguments: runArgs,
-      zmxPath: zmxPath, workingDirectory: wd)
+      zmxPath: zmxPath, workingDirectory: wd,
+      logFragment: DialLog.fragment(session: name, dial: "ensure", event: "fresh"))
   }
 
   /// How long a resumed session has to still be there before its launch counts as taken.
@@ -1236,13 +1245,17 @@ public enum ZmxSessionLauncher {
     return await session.waitUntilFinished() == false
   }
 
+  /// `logFragment` rides inside the run branch, so an ensure whose check found the
+  /// session alive records nothing — the dial log holds decisions, not ticks.
   private static func atomicCheckOrRun(
     checkArguments: [String], runArguments: [String],
-    zmxPath: String, workingDirectory: String?
+    zmxPath: String, workingDirectory: String?, logFragment: String? = nil
   ) async {
     let check = quotedCommand([zmxPath] + checkArguments)
     let run = quotedCommand([zmxPath] + runArguments)
-    let script = "\(check) >/dev/null 2>&1 || \(run)"
+    let script =
+      logFragment.map { "\(check) >/dev/null 2>&1 || { \($0); \(run); }" }
+      ?? "\(check) >/dev/null 2>&1 || \(run)"
     guard
       let session = try? PTYProcessSession(
         executable: "/bin/zsh", arguments: ["-c", script],

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
@@ -110,43 +110,54 @@ extension GhosttyTerminalView {
     }
     let attachFresh = ZmxSessionLauncher.quotedCommand(
       ["zmx", "attach", sessionName] + agentLaunch)
-    let reattachOrRetry =
+    // Every branch below records itself in the remote host's dial log
+    // (`DialLog.fragment`) before it acts — the banners announce the same decisions,
+    // but they die with the scrollback.
+    let log = { (dial: String, event: String) in
+      DialLog.fragment(session: self.sessionName, dial: dial, event: event) + "; "
+    }
+    let reattachOrRetry = { (dial: String) in
       "\(ZmxSessionLauncher.quotedCommand(["zmx", "get", sessionName])) >/dev/null 2>&1; "
-      + "gc_rc=$?; if [ \"$gc_rc\" -eq 0 ]; then \(markerWrite); "
-      + "exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])); fi; "
-      + "[ \"$gc_rc\" -ne 1 ] && exit 255; "
+        + "gc_rc=$?; if [ \"$gc_rc\" -eq 0 ]; then \(log(dial, "attach-live"))\(markerWrite); "
+        + "exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])); fi; "
+        + "[ \"$gc_rc\" -ne 1 ] && exit 255; "
+    }
     let restorePreparation = "if cd \(quoted(location.remotePath)); then " + hooksWrite
     let connectMissing: String
     if loopType == .turnBased {
       connectMissing =
         restoreScript(
           preparation: restorePreparation, promptExport: promptExport,
-          attachFresh: attachFresh, freshPrefix: markerWrite + "; ", settings: settings)
+          attachFresh: attachFresh, freshPrefix: markerWrite + "; ", dial: "connect",
+          settings: settings)
         + "; exit 255"
     } else {
       connectMissing =
-        #"printf '\033[1;33m── Loop session is not running; waiting for graphcoded "#
+        log("connect", "wait-daemon")
+        + #"printf '\033[1;33m── Loop session is not running; waiting for graphcoded "#
         + #"to start it. ──\033[0m\r\n'; exit 255"#
     }
-    let connect = delivery + reattachOrRetry + connectMissing
+    let connect = delivery + reattachOrRetry("connect") + connectMissing
     let rebootBranch: String
     if loopType == .turnBased {
       rebootBranch =
         #"printf '\033[1;33m── Remote machine rebooted; restoring the session. ──\033[0m\r\n'; "#
         + restoreScript(
           preparation: delivery + restorePreparation, promptExport: promptExport,
-          attachFresh: attachFresh, settings: settings) + "; exit 255"
+          attachFresh: attachFresh, dial: "reboot", settings: settings) + "; exit 255"
     } else {
       rebootBranch =
-        #"printf '\033[1;33m── Remote machine rebooted; waiting for the loop session "#
+        log("reboot", "wait-daemon")
+        + #"printf '\033[1;33m── Remote machine rebooted; waiting for the loop session "#
         + #"to be restored. ──\033[0m\r\n'; exit 255"#
     }
     let markerFile = RemoteBootMarker.markerExpression(forSessionName: sessionName)
     let reconnect =
-      reattachOrRetry
+      reattachOrRetry("reconnect")
       + "\(RemoteBootMarker.captureFragment); gc_last=$(cat \(markerFile) 2>/dev/null); "
       + "if [ -n \"$gc_boot\" ] && [ -n \"$gc_last\" ] && [ \"$gc_boot\" != \"$gc_last\" ]; then "
       + rebootBranch + "; fi; "
+      + log("reconnect", "session-ended")
       + #"printf '\033[2m── Remote session ended while disconnected. ──\033[0m\r\n'; exit 0"#
     return (connect, reconnect)
   }
@@ -176,8 +187,11 @@ extension GhosttyTerminalView {
   /// mid-boot, so keep dialing rather than letting it read as "the loop finished".
   private func restoreScript(
     preparation: String, promptExport: String, attachFresh: String, freshPrefix: String = "",
-    settings: GraphcodeSettings
+    dial: String, settings: GraphcodeSettings
   ) -> String {
+    let log = { (event: String) in
+      DialLog.fragment(session: self.sessionName, dial: dial, event: event) + "; "
+    }
     var script = preparation + "{ "
     let nodeID = SurfaceRef.nodeID(fromZmxSessionName: sessionName)
     let resumeLaunch = resumeCommand(
@@ -186,13 +200,15 @@ extension GhosttyTerminalView {
     if let nodeID, let resumeLaunch {
       let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: nodeID)
       let attempt =
-        "export \(ZmxSessionLauncher.remoteResumeIDVariable); gc_t0=$(date +%s); "
+        log("resume")
+        + "export \(ZmxSessionLauncher.remoteResumeIDVariable); gc_t0=$(date +%s); "
         + ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName] + resumeLaunch)
         + "; gc_rc=$?; [ $(($(date +%s) - gc_t0)) -ge 5 ] && exit \"$gc_rc\"; "
+        + log("resume-dead")
         + #"printf '\033[1;33m── Resume did not take; starting the session fresh. ──\033[0m\r\n'"#
       script += ZmxSessionLauncher.resumeOrFreshScript(idFile: idFile, resume: attempt) + "; "
     }
-    script += promptExport + freshPrefix + "exec \(attachFresh); }; fi"
+    script += promptExport + freshPrefix + log("fresh") + "exec \(attachFresh); }; fi"
     return script
   }
 

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -341,15 +341,20 @@ struct GhosttyTerminalView: NSViewRepresentable {
     // `zmx attach` anyway, and building it costs a settings read nobody needs.
     let idVariable = ZmxSessionLauncher.remoteResumeIDVariable
     let settle = ZmxSessionLauncher.resumeSettleSeconds
-    let joined = "\(exists) >/dev/null 2>&1 && exec \(attach); "
+    let log = { (event: String) in
+      DialLog.fragment(session: self.sessionName, dial: "open", event: event) + "; "
+    }
+    let joined = "\(exists) >/dev/null 2>&1 && { \(log("attach-live"))exec \(attach); }; "
     let read = "\(idVariable)=$(cat \(idFile) 2>/dev/null); "
     let attempt =
-      "if [ -n \"$\(idVariable)\" ]; then export \(idVariable); gc_t0=$(date +%s); "
+      "if [ -n \"$\(idVariable)\" ]; then export \(idVariable); \(log("resume"))"
+      + "gc_t0=$(date +%s); "
       + resume + "; gc_rc=$?; "
     let verdict =
       "[ $(($(date +%s) - gc_t0)) -ge \(settle) ] && exit \"$gc_rc\"; rm -f \(idFile); "
+      + log("resume-dead")
       + #"printf '\033[1;33m── Resume did not take; starting fresh. ──\033[0m\r\n'; fi; "#
-    let script = joined + read + attempt + verdict + "exec \(fresh)"
+    let script = joined + read + attempt + verdict + log("fresh") + "exec \(fresh)"
     return ["/bin/sh", "-c", script]
   }
 }

--- a/graphcode/Tests/DialLogTests.swift
+++ b/graphcode/Tests/DialLogTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+@testable import graphcode
+
+/// The dial log: one bounded line per launch decision, on the machine that made it, so
+/// the next "my loop restarted from scratch" report is a diagnosis, not a forensic
+/// reconstruction.
+@Suite
+struct DialLogTests {
+  private let location = RemoteProjectLocation(
+    user: "dev", host: "build-box", port: 2222, remotePath: "/home/dev/widget")
+
+  private func agentSurface(loopType: LoopType = .turnBased) -> GhosttyTerminalView {
+    let nodeID = UUID()
+    return GhosttyTerminalView(
+      surfaceID: nodeID,
+      sessionName: SurfaceRef(id: nodeID, launchesClaudeCode: true).zmxSessionName,
+      launchesClaudeCode: true, loopType: loopType,
+      initialPrompt: "fix the build", workingDirectory: location.projectPath,
+      projectPath: location.projectPath, onProcessExited: { _ in })
+  }
+
+  @Test
+  func theFragmentIsBoundedAndCanNeverFailItsDial() {
+    let fragment = DialLog.fragment(session: "graphcode-x", dial: "connect", event: "attach-live")
+    #expect(fragment.contains("dials.log"))
+    #expect(fragment.contains("graphcode-x connect attach-live"))
+    // Trimmed past the cap before every append, so a night of redials can't eat a disk.
+    #expect(fragment.contains("-gt \(DialLog.maxBytes)"))
+    #expect(fragment.contains("tail -n \(DialLog.keptLines)"))
+    // A full disk or read-only home must never break the launch the log rides on.
+    #expect(fragment.hasSuffix("|| true"))
+    #expect(fragment.contains("2>/dev/null"))
+  }
+
+  @Test
+  func recordAppendsAndTrimsPastTheCap() throws {
+    let home = FileManager.default.temporaryDirectory
+      .appendingPathComponent("dial-log-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: home) }
+    DialLog.record(session: "graphcode-y", dial: "ensure", event: "fresh", home: home)
+    let log = home.appendingPathComponent(".graphcode/dials.log")
+    let first = try String(contentsOf: log, encoding: .utf8)
+    #expect(first.contains("graphcode-y ensure fresh"))
+
+    let filler = String(repeating: "old line\n", count: 1)
+    try String(repeating: filler, count: DialLog.maxBytes / 8).write(
+      to: log, atomically: true, encoding: .utf8)
+    DialLog.record(session: "graphcode-y", dial: "ensure", event: "resume", home: home)
+    let trimmed = try String(contentsOf: log, encoding: .utf8)
+    #expect(trimmed.count < DialLog.maxBytes)
+    #expect(trimmed.contains("graphcode-y ensure resume"))
+  }
+
+  @Test
+  func everyRemoteDialBranchAnnouncesItself() throws {
+    let view = agentSurface()
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    let splitAt = try #require(script.range(of: "while :; do"))
+    let connectLine = script[..<splitAt.lowerBound]
+    let loopBody = script[splitAt.upperBound...]
+    #expect(connectLine.contains("connect attach-live"))
+    #expect(connectLine.contains("connect resume"))
+    #expect(connectLine.contains("connect fresh"))
+    #expect(loopBody.contains("reconnect attach-live"))
+    #expect(loopBody.contains("reboot resume"))
+    #expect(loopBody.contains("reboot fresh"))
+    #expect(loopBody.contains("reconnect session-ended"))
+  }
+
+  @Test
+  func anUnattendedDialLogsTheWaitInsteadOfAnyLaunch() throws {
+    let view = agentSurface(loopType: .goalBased)
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    #expect(script.contains("connect wait-daemon"))
+    #expect(script.contains("reboot wait-daemon"))
+    #expect(!script.contains("connect fresh"))
+    #expect(!script.contains("connect resume"))
+  }
+
+  @Test
+  func theEnsureLogsOnlyWhenItActuallyLaunches() throws {
+    let node = LoopNode(
+      title: "Fix", loopType: .goalBased, goal: GoalSpec(summary: "tests pass"),
+      state: .running)
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location))
+    let remoteCommand = try #require(invocation.last)
+    #expect(remoteCommand.contains("ensure resume"))
+    #expect(remoteCommand.contains("ensure fresh"))
+    // Both live behind the existence check: a healthy sweep tick logs nothing.
+    let check = try #require(remoteCommand.range(of: "'get'"))
+    let resume = try #require(remoteCommand.range(of: "ensure resume"))
+    #expect(check.upperBound <= resume.lowerBound)
+  }
+
+  @Test
+  func theLocalOpenLogsItsChoice() throws {
+    let nodeID = UUID()
+    let name = SurfaceRef(id: nodeID, launchesClaudeCode: true).zmxSessionName
+    SessionIDStore.save("abc-123", forNodeID: nodeID)
+    defer { SessionIDStore.remove(forNodeID: nodeID) }
+    let view = GhosttyTerminalView(
+      surfaceID: nodeID, sessionName: name, launchesClaudeCode: true,
+      initialPrompt: nil, workingDirectory: "/tmp", projectPath: "/tmp",
+      onProcessExited: { _ in })
+    let script = try #require(
+      view.localResumeOrFreshCommand(agentLaunch: ["claude"])?.last)
+    #expect(script.contains("open attach-live"))
+    #expect(script.contains("open resume"))
+    #expect(script.contains("open resume-dead"))
+    #expect(script.contains("open fresh"))
+  }
+}


### PR DESCRIPTION
## Summary
Field reports of "my loop restarted from scratch" die unreproduced because the launch decisions happen in shell scripts whose only trace is a pane banner. Every dial that can create, resume, or refuse to touch a session now appends `<utc-time> <session> <dial> <branch>` to `~/.graphcode/dials.log` **on the machine that made the decision** — remote pane scripts and the daemon's remote ensure log on the remote host (beside the banked IDs they consume); the local pane and local ensure log locally.

Events: `connect|reconnect attach-live`, `connect|reboot wait-daemon`, `connect|reboot|open resume / resume-dead / fresh`, `reconnect session-ended`, `ensure resume / resume-dead / fresh`. Healthy ticks log nothing — the ensure fragments ride inside the run branch.

**Disk-bounded**: before every append, past 1 MB the file is trimmed to its last 5000 lines (~400 KB), both shell-side (`wc`/`tail`) and Swift-side. Fragments are braced, silenced, and `|| true`d so logging can never break a launch.

## Testing
89 tests in 6 suites pass (6 new DialLogTests: fragment bounds, Swift trim behavior, every remote branch announces itself, unattended logs the wait and no launch, ensure logs only when launching, local open logs its choice). Repo-level swiftlint + swift format gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls4npxddhrzQ6UL7qt8xai