### PR TITLE
fix: remote Copilot loops resume after a host reboot, banked from the outside

### DIFF
--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -247,6 +247,36 @@ public enum CopilotSessionLog {
 
   // MARK: - Remote
 
+  /// Banks a live remote Copilot session's resume ID into
+  /// `~/.graphcode/sessions/<node>.id` — the file every restorer already reads — from
+  /// the outside, because Copilot has no hooks to bank it itself the way Claude's
+  /// `SessionStart` does. Without this, a remote host reboot found nothing banked and
+  /// every Copilot loop restarted its goal from scratch (observed 2026-08-13, the
+  /// first dial-logged incident).
+  ///
+  /// The ID is the session-state directory's basename, found by the `--name` graphcode
+  /// launched the session with — the same directory walk `remotePresenceInvocation`
+  /// does, done here in the ensure's *alive* branch. The `[ -s ]` guard keeps the walk
+  /// off the healthy tick once banked: it runs once per session lifetime. History line
+  /// before pointer, same order and format as `PresenceHooks.captureSessionID`, and
+  /// the whole fragment is silenced and `|| true`d so a banking failure can never turn
+  /// an alive tick into the create branch.
+  public static func remoteIDBankFragment(forNodeID nodeID: UUID) -> String {
+    let name = SurfaceRef(id: nodeID, launchesClaudeCode: true).zmxSessionName
+    let sessions = PresenceHooks.remoteSessionsExpression
+    let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: nodeID)
+    let historyFile = "\(sessions)/\"\(nodeID.uuidString).history\""
+    let logged = DialLog.fragment(session: name, dial: "bank", event: "copilot-id")
+    return "{ [ -s \(idFile) ] || { gc_sid=''; "
+      + "for gc_d in $(ls -t \"$HOME/.copilot/session-state/\" 2>/dev/null); do "
+      + "if grep -qx 'name: \(name)' "
+      + "\"$HOME/.copilot/session-state/$gc_d/workspace.yaml\" 2>/dev/null; then "
+      + "gc_sid=\"$gc_d\"; break; fi; done; "
+      + "if [ -n \"$gc_sid\" ]; then mkdir -p \(sessions); "
+      + "printf '%s %s %s\\n' \"$(date +%s)\" \"$gc_sid\" \"$PWD\" >> \(historyFile); "
+      + "printf '%s' \"$gc_sid\" > \(idFile); \(logged); fi; }; } 2>/dev/null || true"
+  }
+
   static func remotePresenceInvocation(
     forNode node: LoopNode, at location: RemoteProjectLocation
   ) -> [String] {

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -820,10 +820,17 @@ public enum ZmxSessionLauncher {
     // running. This used to run per ensure, which was once at load and once per node
     // created; the liveness sweep dials every minute, and a `python3` per loop per
     // minute to rewrite files nothing will re-read is pure cost.
+    // Copilot has no hooks to bank its own resume ID, so the ensure banks it from the
+    // session-state directory while the session is alive — the `&& { … } || { … }` is
+    // safe only because the bank fragment always exits 0 (`remoteIDBankFragment`); a
+    // fragment that could fail would send an alive tick into the create branch.
+    let bank =
+      node.backend == .copilotCLI
+      ? " && { " + CopilotSessionLog.remoteIDBankFragment(forNodeID: node.id) + "; }" : ""
     let script =
       "cd \(RemoteProjectLocation.shellQuoted(location.remotePath)) && { "
       + deliveryFragment(delivery, ifSessionMissing: check)
-      + "\(check) >/dev/null 2>&1 || { " + trustSeed + hooksWrite
+      + "\(check) >/dev/null 2>&1\(bank) || { " + trustSeed + hooksWrite
       + "\(create); }; }"
     return location.sshInvocation(remoteCommand: location.remoteLoginShellCommand(script))
   }

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
@@ -116,9 +116,18 @@ extension GhosttyTerminalView {
     let log = { (dial: String, event: String) in
       DialLog.fragment(session: self.sessionName, dial: dial, event: event) + "; "
     }
+    // Copilot has no hooks, so joining a live session is also the moment its resume ID
+    // gets banked — the daemon's ensure does the same for unattended loops, but a
+    // turn-based loop's only dial is this one. `[ -s ]`-guarded, so it walks the
+    // session-state directory once per session lifetime.
+    let bank =
+      backend == .copilotCLI
+      ? SurfaceRef.nodeID(fromZmxSessionName: sessionName).map {
+        CopilotSessionLog.remoteIDBankFragment(forNodeID: $0) + "; "
+      } ?? "" : ""
     let reattachOrRetry = { (dial: String) in
       "\(ZmxSessionLauncher.quotedCommand(["zmx", "get", sessionName])) >/dev/null 2>&1; "
-        + "gc_rc=$?; if [ \"$gc_rc\" -eq 0 ]; then \(log(dial, "attach-live"))\(markerWrite); "
+        + "gc_rc=$?; if [ \"$gc_rc\" -eq 0 ]; then \(log(dial, "attach-live"))\(bank)\(markerWrite); "
         + "exec \(ZmxSessionLauncher.quotedCommand(["zmx", "attach", sessionName])); fi; "
         + "[ \"$gc_rc\" -ne 1 ] && exit 255; "
     }

--- a/graphcode/Tests/RemoteLoopSurvivalTests.swift
+++ b/graphcode/Tests/RemoteLoopSurvivalTests.swift
@@ -369,6 +369,20 @@ struct RemoteLoopSurvivalTests {
   }
 
   @Test
+  func aCopilotPaneBanksTheResumeIDOnEveryLiveJoin() throws {
+    // A turn-based Copilot loop never gets an ensure dial, so the pane's attach-live
+    // branch is its one chance to bank — same fragment, same `[ -s ]` guard.
+    let view = agentSurface(backend: .copilotCLI)
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    #expect(script.contains("session-state"))
+    #expect(script.contains("bank copilot-id"))
+    let claude = agentSurface()
+    let claudeScript = try #require(
+      claude.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    #expect(!claudeScript.contains("session-state"))
+  }
+
+  @Test
   func copilotRestoreResumesWithoutANameAndCodexCannotResume() {
     // Copilot's `--name` and `--resume` are mutually exclusive; Codex has no resume at
     // all, so its restore goes straight to the fresh launch.

--- a/graphcode/Tests/RemoteSessionResumeTests.swift
+++ b/graphcode/Tests/RemoteSessionResumeTests.swift
@@ -289,6 +289,40 @@ struct RemoteSessionResumeTests {
   }
 
   @Test
+  func aCopilotEnsureBanksTheLiveSessionsResumeID() throws {
+    // Copilot has no hooks, so nothing banked its resume ID on the remote host and a
+    // host reboot restarted every Copilot loop's goal from scratch (the first
+    // dial-logged incident, 2026-08-13: three `reboot wait-daemon` → `ensure fresh`).
+    // The ensure now banks the ID from the session-state directory while the session
+    // is alive, and the whole existing resume machinery takes over on the next reboot.
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(forNode: goalNode(.copilotCLI), at: location))
+    let remoteCommand = try #require(invocation.last)
+    #expect(remoteCommand.contains("session-state"))
+    #expect(remoteCommand.contains("workspace.yaml"))
+    #expect(remoteCommand.contains(".history"))
+    #expect(remoteCommand.contains("[ -s"))
+    #expect(remoteCommand.contains("bank copilot-id"))
+    // The bank rides the alive branch: behind the existence check, before the create —
+    // and it must always exit 0, or an alive tick would fall into the create branch.
+    let check = try #require(remoteCommand.range(of: "'get'"))
+    let bank = try #require(remoteCommand.range(of: "session-state"))
+    let run = try #require(remoteCommand.range(of: "'run'"))
+    #expect(check.upperBound <= bank.lowerBound)
+    #expect(bank.upperBound <= run.lowerBound)
+    #expect(remoteCommand.contains("|| true"))
+  }
+
+  @Test
+  func aClaudeEnsureNeverWalksCopilotState() throws {
+    // Claude banks through its own SessionStart hook; scanning Copilot's directory for
+    // it would be a wasted walk on every claude create.
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(forNode: goalNode(), at: location))
+    #expect(!(try #require(invocation.last)).contains("session-state"))
+  }
+
+  @Test
   func aCodexNodeHasNoResumeToOffer() {
     // Codex has no `--resume` graphcode has spiked, so the remote ensure keeps the
     // single fresh-launch branch rather than inventing a flag.


### PR DESCRIPTION
## Summary
The first dial-logged incident showed the reboot machinery working (`reboot wait-daemon` ×3) and still losing conversations (`ensure fresh` ×3): Copilot has no hooks, so nothing ever banked its session ID on the remote host.

- `CopilotSessionLog.remoteIDBankFragment`: finds the live session's `~/.copilot/session-state/<id>/` by the `--name` we launched it with (the same walk the presence probe uses) and banks `<id>` into the standard `~/.graphcode/sessions/<node>.id` + `.history` (same format as Claude's `SessionStart` hook), logging `bank copilot-id`.
- The daemon's ensure banks on its **alive** tick (unattended loops); the pane's **attach-live** branch banks on join (turn-based loops' only dial). Both `[ -s ]`-guarded — the walk runs once per session lifetime — and the fragment always exits 0 so an alive tick can never fall into the create branch.
- Downstream unchanged: the next reboot's resume-or-fresh finds a banked ID and `copilot --resume` continues the conversation. Codex remains fresh-only (no resume flag exists).

## Testing
64 tests in 4 suites pass; 3 new: ensure banks behind the alive branch (ordering asserted), claude never walks copilot state, pane banks on live join. Repo lint gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls4npxddhrzQ6UL7qt8xai