### PR TITLE
Summary rails: a loop's narration, read off its own transcript

### DIFF
--- a/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
+++ b/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
@@ -246,6 +246,36 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
   /// is a trade worth offering and not worth imposing.
   public var showsActivityStrip: Bool
 
+  /// Whether graphcode narrates what loops are doing — the summary rail's *producer*.
+  ///
+  /// **Off by default, and experimental.** Off, nothing reads a session's transcript, no
+  /// node carries a `summary`, the rail shows no section and the card's live line falls
+  /// back to what the loop was handed, exactly as it did before this existed. On, each
+  /// working loop's transcript tail is read once per poll and folded into
+  /// `LoopNode.summary`.
+  ///
+  /// Deliberately distinct from hiding the rail. Hiding is a view, and this is the
+  /// reading: the design's own division, kept because the two would otherwise be one
+  /// switch that quietly does two things. It is a setting at all — rather than always-on —
+  /// because a beat is a claim about what an agent is *trying* to do, and a wrong one is
+  /// worse than the scrollback it replaces. It stays behind a switch until it has been
+  /// watched on real loops.
+  public var summarisesLoops: Bool
+
+  /// Whether a small model may rewrite the current beat, on top of the free reading.
+  ///
+  /// **Off by default, and meaningless with `summarisesLoops` off.** The rail works
+  /// without this: the beat is the agent's own sentence, taken off its transcript for
+  /// nothing. What a model buys is the last edit — the design's plain past tense, ten
+  /// words, tools turned back into intent — and it is the one part of the feature that
+  /// costs money, so it is the one part behind its own switch.
+  ///
+  /// One `claude -p` / `copilot -p` / `codex exec` per *changed* beat of a *working* loop,
+  /// at the fast tier, over one sentence and one line of evidence. It is its own process,
+  /// so its tokens never land on the loop's own budget line, and every failure path leaves
+  /// the derived beat exactly as it was — see `SummaryModelWriter`.
+  public var summaryUsesModel: Bool
+
   // There is deliberately no window-opacity setting here any more. graphcode used to own
   // one and apply it as `NSWindow.alphaValue`, which fades the whole window — terminal
   // text included — rather than only the background behind it. Ghostty already has
@@ -261,6 +291,8 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     briefsSessionsAboutTheGraph: Bool = true,
     autoSelectsModel: Bool = false,
     showsActivityStrip: Bool = false,
+    summarisesLoops: Bool = false,
+    summaryUsesModel: Bool = false,
     worktreePolicies: [String: WorktreeHygienePolicy] = [:]
   ) {
     self.defaultBackend = defaultBackend.isSpiked ? defaultBackend : .claudeCode
@@ -270,6 +302,8 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     self.briefsSessionsAboutTheGraph = briefsSessionsAboutTheGraph
     self.autoSelectsModel = autoSelectsModel
     self.showsActivityStrip = showsActivityStrip
+    self.summarisesLoops = summarisesLoops
+    self.summaryUsesModel = summaryUsesModel
     self.worktreePolicies = worktreePolicies
   }
 
@@ -299,6 +333,14 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(Bool.self, forKey: .autoSelectsModel) ?? false
     showsActivityStrip =
       try container.decodeIfPresent(Bool.self, forKey: .showsActivityStrip) ?? false
+    // Absent in every file written before the rail existed, which is the same thing as an
+    // experiment nobody has opted into yet.
+    summarisesLoops =
+      try container.decodeIfPresent(Bool.self, forKey: .summarisesLoops) ?? false
+    // Never inferred from `summarisesLoops`: turning the rail on must not start spending
+    // money on a machine whose owner only asked to see what their loops were doing.
+    summaryUsesModel =
+      try container.decodeIfPresent(Bool.self, forKey: .summaryUsesModel) ?? false
     worktreePolicies =
       try container.decodeIfPresent(
         [String: WorktreeHygienePolicy].self, forKey: .worktreePolicies) ?? [:]

--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -75,6 +75,17 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
   /// line then says what the loop was *handed* instead. That fallback is honest and is
   /// what shipped before this field existed.
   public var activity: String?
+  /// The loop's narration — what it has been trying to do, in beats, bounded.
+  ///
+  /// `activity` is one phrase about one tool call and is replaced every time the call
+  /// changes; this is the story around it, and the two are read off different halves of
+  /// the same session. Kept on the node rather than in a side store because it is exactly
+  /// as small as `metricHistory` (three beats and three pass lines, by construction — see
+  /// `LoopSummary`) and every surface that wants it already has a node.
+  ///
+  /// `nil` until the summary producer is switched on in Settings, which is where it stays
+  /// for anyone who never turns the experiment on.
+  public var summary: LoopSummary?
   /// What the session is doing right now, as last read off its own label store
   /// (`PresenceHooks` writes it, `ZmxSessionLauncher.presence` reads it).
   ///
@@ -123,6 +134,7 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     pilotState: PilotState = .notPiloted,
     usage: UsageSample? = nil,
     activity: String? = nil,
+    summary: LoopSummary? = nil,
     presence: PresenceReading? = nil,
     metricHistory: [MetricSample] = [],
     createdBy: UUID? = nil,
@@ -144,6 +156,7 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     self.pilotState = pilotState
     self.usage = usage
     self.activity = activity
+    self.summary = summary
     self.presence = presence
     self.metricHistory = metricHistory
     self.createdBy = createdBy
@@ -273,6 +286,7 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     case id, title, loopType, checkDescription, triggerPrompt, goal, backend, modelTier
     case worktreeBinding, subGraph, pilotState, usage, metricHistory, createdBy
     case state, createdAt, activity, presence, firstInstruction, pausesBeforeWritesOnly
+    case summary
   }
 
   /// Hand-written for the same reason `LoopEdge`'s is: `ProjectPersistence.loadGraph`
@@ -299,6 +313,10 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     pilotState = try container.decodeIfPresent(PilotState.self, forKey: .pilotState) ?? .notPiloted
     usage = try container.decodeIfPresent(UsageSample.self, forKey: .usage)
     activity = try container.decodeIfPresent(String.self, forKey: .activity)
+    // Unlike `presence` and `activity`, this survives a reload: pass summaries are the
+    // account of a run, and a resolved loop's is the thing worth reading after the fact.
+    // It is bounded by construction, so a graph file cannot grow on it.
+    summary = try container.decodeIfPresent(LoopSummary.self, forKey: .summary)
     presence = try container.decodeIfPresent(PresenceReading.self, forKey: .presence)
     metricHistory =
       try container.decodeIfPresent([MetricSample].self, forKey: .metricHistory) ?? []

--- a/GraphcodeKit/Sources/Domain/LoopSummary.swift
+++ b/GraphcodeKit/Sources/Domain/LoopSummary.swift
@@ -260,7 +260,11 @@ public struct LoopSummary: Codable, Equatable, Sendable {
     if passes.count > Self.maxPassSummaries {
       passes.removeFirst(passes.count - Self.maxPassSummaries)
     }
-    let newestPass = reading.beats.map(\.pass).max()
+    // A reading with rollups but no beats leaves the ones on screen alone. No reader
+    // produces one — a finished pass implies the beats it was summarised from — but the
+    // alternative reading of "nothing" here is an empty rail, and the whole contract of
+    // this method is that a reader cannot erase more than it can see.
+    guard let newestPass = reading.beats.map(\.pass).max() else { return }
     beats =
       reading.beats
       .filter { $0.pass == newestPass }

--- a/GraphcodeKit/Sources/Domain/LoopSummary.swift
+++ b/GraphcodeKit/Sources/Domain/LoopSummary.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+/// What a beat is about, in six words the rail colours rather than prints twice.
+///
+/// The shape of a pass — a long read, a short edit, a run, a finding — is meant to be
+/// legible from the dots alone, before a word is read. `asking` and `done` are never
+/// produced by a reader: they are what the rail shows when the node's own presence says a
+/// human is wanted and when the node has resolved, so attention keeps one source of truth
+/// (`AttentionRollup`) rather than gaining a second one inside the summary.
+public enum BeatKind: String, Codable, Sendable, CaseIterable {
+  case reading
+  case editing
+  case running
+  case thinking
+  case found
+  case asking
+  case done
+
+  /// The tool phrase every backend reader already speaks — `"editing Foo.swift"`,
+  /// `"running make check"` — mapped to the kind it belongs to. Unrecognised phrases are
+  /// `thinking` rather than dropped: a beat with no tool calls under it is a session
+  /// working something out, which is exactly what the word says.
+  public static func inferred(fromPhrase phrase: String) -> BeatKind {
+    let verb = phrase.split(separator: " ").first.map(String.init) ?? ""
+    switch verb {
+    case "editing", "writing": return .editing
+    case "reading", "searching", "looking": return .reading
+    case "running", "delegating", "using", "planning": return .running
+    default: return .thinking
+    }
+  }
+}
+
+/// One shift in what a loop is trying to do.
+///
+/// Not one per tool call and not one per tick: twenty greps in a row are one beat. What
+/// makes a new one is the agent saying, in its own words, that it has moved on — the
+/// narration every backend writes into its own transcript before the calls it is about to
+/// make. That is why nothing here is generated: `text` is the agent's sentence, `evidence`
+/// names the file or command the beat came from, and a beat that can cite neither is not
+/// emitted.
+public struct SummaryBeat: Codable, Equatable, Sendable, Identifiable {
+  /// Stable across polls so the rail doesn't re-animate a beat it is already showing, and
+  /// so `seenBeatID` can name one. Derived from the transcript position rather than
+  /// random — the same beat read twice is the same beat.
+  public let id: String
+  public let at: Date
+  /// Which pass this belongs to, counted from the session's own user turns. A loop's
+  /// wake-up is a user turn whether a human typed it or `/loop` did.
+  public let pass: Int
+  public let kind: BeatKind
+  /// Under ten words. The rail's content width is 188pt and a beat needing three lines is
+  /// two beats, or it is describing tools instead of intent.
+  public let text: String
+  /// `"UsageProbe.swift · 3 files read"` — where the beat came from, one line, mono.
+  public let evidence: String?
+
+  public init(
+    id: String, at: Date, pass: Int, kind: BeatKind, text: String, evidence: String? = nil
+  ) {
+    self.id = id
+    self.at = at
+    self.pass = pass
+    self.kind = kind
+    self.text = text
+    self.evidence = evidence
+  }
+}
+
+/// A finished pass, in one line. What the pass ended up doing, plus where the metric got
+/// to — the only number the section carries.
+public struct PassSummary: Codable, Equatable, Sendable, Identifiable {
+  public let pass: Int
+  public let text: String
+  public let delta: String?
+
+  public var id: Int { pass }
+
+  public init(pass: Int, text: String, delta: String? = nil) {
+    self.pass = pass
+    self.text = text
+    self.delta = delta
+  }
+}
+
+/// What a reader took off one session this poll, before any of it is folded into the
+/// node's own bounded store.
+///
+/// Deliberately separate from `LoopSummary`: a reader sees only as far back as the tail it
+/// read, so it can report the current pass in full and the last pass or two in summary,
+/// and it must not be able to erase what the store already knows about passes that have
+/// scrolled out of that window.
+public struct SummaryReading: Equatable, Sendable {
+  public var beats: [SummaryBeat]
+  public var finishedPasses: [PassSummary]
+
+  public init(beats: [SummaryBeat], finishedPasses: [PassSummary] = []) {
+    self.beats = beats
+    self.finishedPasses = finishedPasses
+  }
+
+  public var isEmpty: Bool { beats.isEmpty && finishedPasses.isEmpty }
+}
+
+/// A loop's narration, bounded by construction: the current beat, the two before it, one
+/// line per finished pass down to the last few, and a count for everything older.
+///
+/// A six-hour loop and a six-minute one are the same height, and the same number of bytes
+/// in the graph file. Nothing accumulates — that is the difference between this and the
+/// terminal it exists to save you reading.
+public struct LoopSummary: Codable, Equatable, Sendable {
+  /// Newest last. Three is the design's now-block plus two receding rows.
+  public static let maxBeats = 3
+  /// How many finished passes keep a line of their own before they become a count.
+  public static let maxPassSummaries = 3
+
+  public var beats: [SummaryBeat]
+  public var passes: [PassSummary]
+  /// Passes older than the ones `passes` still names. Kept as a number so `5 earlier
+  /// passes` can be said without keeping five of anything.
+  public var earlierPasses: Int
+
+  public init(
+    beats: [SummaryBeat] = [], passes: [PassSummary] = [], earlierPasses: Int = 0
+  ) {
+    self.beats = beats
+    self.passes = passes
+    self.earlierPasses = earlierPasses
+  }
+
+  public var isEmpty: Bool { beats.isEmpty && passes.isEmpty && earlierPasses == 0 }
+
+  /// The beat the rail shows at full size, and the card shows in one line.
+  public var current: SummaryBeat? { beats.last }
+
+  /// The beats behind the current one, newest first — the receding rows.
+  public var receding: [SummaryBeat] { beats.dropLast().reversed() }
+
+  /// How many beats have landed since `seenBeatID` was the newest one.
+  ///
+  /// The watermark is **not** stored here, and that is deliberate: "since you looked" is a
+  /// fact about a person at a window, not about the loop. Two windows showing the same
+  /// loop have different answers, and the daemon has none at all. `LoopWorkspaceFeature`
+  /// owns it; this only knows how to count against it.
+  ///
+  /// A watermark naming a beat that has since rolled out of the store counts as nothing
+  /// unseen rather than everything — the alternative marks a whole section new every time
+  /// a pass rolls up, which is when the marker means least.
+  public func unseenCount(since seenBeatID: String?) -> Int {
+    guard let seenBeatID else { return 0 }
+    guard let index = beats.firstIndex(where: { $0.id == seenBeatID }) else { return 0 }
+    return beats.count - 1 - index
+  }
+
+  /// Folds a reader's view of a session into the store.
+  ///
+  /// Three rules, and they are the whole of the bounding:
+  ///
+  /// 1. **Beats of the newest pass only.** A beat belonging to an older pass has already
+  ///    been rolled up, or is about to be; keeping it would make the section grow with the
+  ///    run.
+  /// 2. **A pass rolls up once.** A finished pass the store has never seen becomes one
+  ///    `PassSummary` and the rest of its beats are dropped. A pass it already holds is
+  ///    left alone — a reader whose tail window has moved on must not be able to rewrite
+  ///    history it can no longer see.
+  /// 3. **Everything past the cap becomes a number.** Oldest summaries go first, and
+  ///    `earlierPasses` counts what went.
+  public mutating func merge(_ reading: SummaryReading) {
+    for summary in reading.finishedPasses.sorted(by: { $0.pass < $1.pass }) {
+      guard !passes.contains(where: { $0.pass == summary.pass }) else { continue }
+      guard summary.pass > (passes.last?.pass ?? 0) || passes.isEmpty else { continue }
+      passes.append(summary)
+    }
+    if passes.count > Self.maxPassSummaries {
+      let dropped = passes.count - Self.maxPassSummaries
+      passes.removeFirst(dropped)
+      earlierPasses += dropped
+    }
+    let newestPass = reading.beats.map(\.pass).max()
+    beats =
+      Array(
+        reading.beats
+          .filter { $0.pass == newestPass }
+          .suffix(Self.maxBeats))
+  }
+
+  /// Same fold, without mutating — what a reader's output becomes when a node has no
+  /// summary yet.
+  public func merging(_ reading: SummaryReading) -> LoopSummary {
+    var copy = self
+    copy.merge(reading)
+    return copy
+  }
+}

--- a/GraphcodeKit/Sources/Domain/LoopSummary.swift
+++ b/GraphcodeKit/Sources/Domain/LoopSummary.swift
@@ -109,10 +109,15 @@ public struct SummaryReading: Equatable, Sendable {
 /// in the graph file. Nothing accumulates — that is the difference between this and the
 /// terminal it exists to save you reading.
 public struct LoopSummary: Codable, Equatable, Sendable {
-  /// Newest last. Three is the design's now-block plus two receding rows.
-  public static let maxBeats = 3
+  /// Newest last.
+  ///
+  /// Three — the now block plus two receding rows — was the fixed-height design's answer,
+  /// and it stopped being the right one when the section became scrollable: a rail you can
+  /// scroll has nothing to scroll to at three. Twelve is what a person can page back
+  /// through and still be a fixed cost per node (a beat is a short line and two dates).
+  public static let maxBeats = 12
   /// How many finished passes keep a line of their own before they become a count.
-  public static let maxPassSummaries = 3
+  public static let maxPassSummaries = 6
 
   public var beats: [SummaryBeat]
   public var passes: [PassSummary]
@@ -133,8 +138,12 @@ public struct LoopSummary: Codable, Equatable, Sendable {
   /// The beat the rail shows at full size, and the card shows in one line.
   public var current: SummaryBeat? { beats.last }
 
-  /// The beats behind the current one, newest first — the receding rows.
-  public var receding: [SummaryBeat] { beats.dropLast().reversed() }
+  /// The beats behind the current one, **oldest first** — the rows above it.
+  ///
+  /// Chronological, not newest-first. The rail sits beside a terminal that reads top to
+  /// bottom with the newest line at the foot of it, and a panel that ran the other way
+  /// meant reading the same run in two directions on one screen.
+  public var receding: [SummaryBeat] { Array(beats.dropLast()) }
 
   /// How many beats have landed since `seenBeatID` was the newest one.
   ///

--- a/GraphcodeKit/Sources/Domain/LoopSummary.swift
+++ b/GraphcodeKit/Sources/Domain/LoopSummary.swift
@@ -104,19 +104,22 @@ public struct SummaryReading: Equatable, Sendable {
   /// is newer than the last one it counted, which is what makes a pass number survive the
   /// tail window sliding past the turn that opened it.
   public var turns: [Date]
-  /// Where the metric got to, by **absolute** pass — the store's numbering, not this
-  /// reading's, since it is read off `metricHistory` rather than off the transcript.
-  /// Applied when a pass rolls up.
-  public var deltas: [Int: String]
+  /// When each finished pass's last beat landed, by this reading's own pass number. What
+  /// the metric's movement is attributed with — see `LoopSummary.merge`.
+  public var passEndedAt: [Int: Date]
+  /// The loop's metric series, unchanged. The store matches samples to passes by *when*
+  /// they were taken, so nothing here has to know how the passes are numbered.
+  public var metricSamples: [MetricSample]
 
   public init(
     beats: [SummaryBeat], finishedPasses: [PassSummary] = [], turns: [Date] = [],
-    deltas: [Int: String] = [:]
+    passEndedAt: [Int: Date] = [:], metricSamples: [MetricSample] = []
   ) {
     self.beats = beats
     self.finishedPasses = finishedPasses
     self.turns = turns
-    self.deltas = deltas
+    self.passEndedAt = passEndedAt
+    self.metricSamples = metricSamples
   }
 
   public var isEmpty: Bool { beats.isEmpty && finishedPasses.isEmpty }
@@ -249,7 +252,10 @@ public struct LoopSummary: Codable, Equatable, Sendable {
     for summary in reading.finishedPasses.sorted(by: { $0.pass < $1.pass }) {
       let pass = summary.pass + shift
       guard pass > (passes.last?.pass ?? 0) else { continue }
-      passes.append(PassSummary(pass: pass, text: summary.text, delta: reading.deltas[pass]))
+      passes.append(
+        PassSummary(
+          pass: pass, text: summary.text, delta: Self.delta(of: summary.pass, in: reading))
+      )
     }
     if passes.count > Self.maxPassSummaries {
       passes.removeFirst(passes.count - Self.maxPassSummaries)
@@ -264,6 +270,23 @@ public struct LoopSummary: Codable, Equatable, Sendable {
           id: $0.id, at: $0.at, pass: $0.pass + shift, kind: $0.kind, text: $0.text,
           evidence: $0.evidence)
       }
+  }
+
+  /// Where the metric got to over one pass, or nothing — which is most passes.
+  ///
+  /// **Matched by when the samples were taken, not by counting.** The first version keyed
+  /// the series by position, on the assumption that sample *n* belongs to pass *n* — true
+  /// of a `/loop` waking on a timer, and false the moment a human types twice in one pass
+  /// or once between two. It printed the movement of a pass that was not the pass it was
+  /// printed under, which is the one thing the section's only number must not do. A pass
+  /// with no sample inside it, or a metric that did not move, says nothing.
+  static func delta(of pass: Int, in reading: SummaryReading) -> String? {
+    guard let ended = reading.passEndedAt[pass] else { return nil }
+    let previous = reading.passEndedAt[pass - 1]
+    let before = reading.metricSamples.last { $0.recordedAt <= (previous ?? .distantPast) }
+    let after = reading.metricSamples.last { $0.recordedAt <= ended }
+    guard let after, let before, before.value != after.value else { return nil }
+    return "\(LoopSummaryDeltas.number(before.value)) → \(LoopSummaryDeltas.number(after.value))"
   }
 
   /// Same fold, without mutating — what a reader's output becomes when a node has no

--- a/GraphcodeKit/Sources/Domain/LoopSummary.swift
+++ b/GraphcodeKit/Sources/Domain/LoopSummary.swift
@@ -90,13 +90,33 @@ public struct PassSummary: Codable, Equatable, Sendable, Identifiable {
 /// read, so it can report the current pass in full and the last pass or two in summary,
 /// and it must not be able to erase what the store already knows about passes that have
 /// scrolled out of that window.
+///
+/// **Its pass numbers are window-relative and mean nothing on their own.** A transcript on
+/// this machine reaches a hundred megabytes and the tail read is half of one, so a session
+/// on its forty-first turn shows ten of them — measured, not supposed. The store turns
+/// these into the numbers a person reads; see `LoopSummary.merge`, and `turns` for what it
+/// counts with.
 public struct SummaryReading: Equatable, Sendable {
   public var beats: [SummaryBeat]
   public var finishedPasses: [PassSummary]
+  /// When each user turn the window saw happened, oldest first. The only thing in a
+  /// reading that carries across polls: the store counts a pass when a turn arrives that
+  /// is newer than the last one it counted, which is what makes a pass number survive the
+  /// tail window sliding past the turn that opened it.
+  public var turns: [Date]
+  /// Where the metric got to, by **absolute** pass — the store's numbering, not this
+  /// reading's, since it is read off `metricHistory` rather than off the transcript.
+  /// Applied when a pass rolls up.
+  public var deltas: [Int: String]
 
-  public init(beats: [SummaryBeat], finishedPasses: [PassSummary] = []) {
+  public init(
+    beats: [SummaryBeat], finishedPasses: [PassSummary] = [], turns: [Date] = [],
+    deltas: [Int: String] = [:]
+  ) {
     self.beats = beats
     self.finishedPasses = finishedPasses
+    self.turns = turns
+    self.deltas = deltas
   }
 
   public var isEmpty: Bool { beats.isEmpty && finishedPasses.isEmpty }
@@ -121,19 +141,58 @@ public struct LoopSummary: Codable, Equatable, Sendable {
 
   public var beats: [SummaryBeat]
   public var passes: [PassSummary]
-  /// Passes older than the ones `passes` still names. Kept as a number so `5 earlier
-  /// passes` can be said without keeping five of anything.
-  public var earlierPasses: Int
+  /// Which pass the newest beats belong to, counted from the loop's own start rather than
+  /// from the start of whatever the last tail read happened to reach.
+  ///
+  /// This is the number `PASS 7` prints, and it is here rather than on a beat because it
+  /// is the one fact about a run that a reader cannot see: the transcript it reads half a
+  /// megabyte of has a hundred megabytes behind it. The store counts a pass when
+  /// `merge` is handed a user turn newer than `lastTurnAt`, so a pass that has scrolled
+  /// out of the window is still counted, once.
+  ///
+  /// `0` means nothing has been merged yet. The first merge takes the window's own count,
+  /// which is a floor: a loop graphcode started watching mid-run is on *at least* that
+  /// many passes, and no reading can say more than that.
+  public var currentPass: Int
+  /// The newest user turn already counted into `currentPass`. What keeps a turn seen in
+  /// six consecutive polls from counting six times.
+  public var lastTurnAt: Date?
 
   public init(
-    beats: [SummaryBeat] = [], passes: [PassSummary] = [], earlierPasses: Int = 0
+    beats: [SummaryBeat] = [], passes: [PassSummary] = [], currentPass: Int = 0,
+    lastTurnAt: Date? = nil
   ) {
     self.beats = beats
     self.passes = passes
-    self.earlierPasses = earlierPasses
+    self.currentPass = currentPass
+    self.lastTurnAt = lastTurnAt
   }
 
-  public var isEmpty: Bool { beats.isEmpty && passes.isEmpty && earlierPasses == 0 }
+  /// Hand-written for the reason `LoopNode`'s is: a graph file that fails to decode is a
+  /// graph the app reports as having no loops in it. Every field is optional on the way
+  /// in, so a summary written by a build before this one — or after the next one — still
+  /// loads.
+  private enum CodingKeys: String, CodingKey {
+    case beats, passes, currentPass, lastTurnAt
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    beats = try container.decodeIfPresent([SummaryBeat].self, forKey: .beats) ?? []
+    passes = try container.decodeIfPresent([PassSummary].self, forKey: .passes) ?? []
+    currentPass = try container.decodeIfPresent(Int.self, forKey: .currentPass) ?? 0
+    lastTurnAt = try container.decodeIfPresent(Date.self, forKey: .lastTurnAt)
+  }
+
+  /// Finished passes with no line of their own, so `5 earlier passes` can be said without
+  /// keeping five of anything.
+  ///
+  /// Derived rather than accumulated, now that `currentPass` is absolute: a loop adopted
+  /// on its tenth pass has nine passes behind it whether or not graphcode ever saw them,
+  /// and a counter that only knew about the rows it had dropped would have said none.
+  public var earlierPasses: Int { max(0, currentPass - 1 - passes.count) }
+
+  public var isEmpty: Bool { beats.isEmpty && passes.isEmpty }
 
   /// The beat the rail shows at full size, and the card shows in one line.
   public var current: SummaryBeat? { beats.last }
@@ -163,34 +222,48 @@ public struct LoopSummary: Codable, Equatable, Sendable {
 
   /// Folds a reader's view of a session into the store.
   ///
-  /// Three rules, and they are the whole of the bounding:
+  /// Four rules, and they are the whole of the bounding:
   ///
-  /// 1. **Beats of the newest pass only.** A beat belonging to an older pass has already
+  /// 1. **The store numbers the passes.** A reading's are relative to a window that slides
+  ///    as the transcript grows, so taking them at face value made `PASS 7` count
+  ///    backwards as a session got long. Only a turn newer than `lastTurnAt` advances the
+  ///    count, and everything in the reading is shifted onto that numbering.
+  /// 2. **Beats of the newest pass only.** A beat belonging to an older pass has already
   ///    been rolled up, or is about to be; keeping it would make the section grow with the
   ///    run.
-  /// 2. **A pass rolls up once.** A finished pass the store has never seen becomes one
+  /// 3. **A pass rolls up once.** A finished pass the store has never seen becomes one
   ///    `PassSummary` and the rest of its beats are dropped. A pass it already holds is
   ///    left alone — a reader whose tail window has moved on must not be able to rewrite
   ///    history it can no longer see.
-  /// 3. **Everything past the cap becomes a number.** Oldest summaries go first, and
-  ///    `earlierPasses` counts what went.
+  /// 4. **Everything past the cap becomes a number.** Oldest summaries go first, and
+  ///    `earlierPasses` says how many are no longer named.
   public mutating func merge(_ reading: SummaryReading) {
+    let relativeNewest = max(
+      reading.beats.map(\.pass).max() ?? 0, reading.finishedPasses.map(\.pass).max() ?? 0)
+    guard relativeNewest > 0 else { return }
+    let newTurns = reading.turns.filter { $0 > (lastTurnAt ?? .distantPast) }
+    currentPass = currentPass == 0 ? relativeNewest : currentPass + newTurns.count
+    if let newest = newTurns.last { lastTurnAt = newest }
+    let shift = currentPass - relativeNewest
+
     for summary in reading.finishedPasses.sorted(by: { $0.pass < $1.pass }) {
-      guard !passes.contains(where: { $0.pass == summary.pass }) else { continue }
-      guard summary.pass > (passes.last?.pass ?? 0) || passes.isEmpty else { continue }
-      passes.append(summary)
+      let pass = summary.pass + shift
+      guard pass > (passes.last?.pass ?? 0) else { continue }
+      passes.append(PassSummary(pass: pass, text: summary.text, delta: reading.deltas[pass]))
     }
     if passes.count > Self.maxPassSummaries {
-      let dropped = passes.count - Self.maxPassSummaries
-      passes.removeFirst(dropped)
-      earlierPasses += dropped
+      passes.removeFirst(passes.count - Self.maxPassSummaries)
     }
     let newestPass = reading.beats.map(\.pass).max()
     beats =
-      Array(
-        reading.beats
-          .filter { $0.pass == newestPass }
-          .suffix(Self.maxBeats))
+      reading.beats
+      .filter { $0.pass == newestPass }
+      .suffix(Self.maxBeats)
+      .map {
+        SummaryBeat(
+          id: $0.id, at: $0.at, pass: $0.pass + shift, kind: $0.kind, text: $0.text,
+          evidence: $0.evidence)
+      }
   }
 
   /// Same fold, without mutating — what a reader's output becomes when a node has no

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -503,7 +503,10 @@ public actor GraphStore {
   private func refreshSummary() async -> Bool {
     guard let onReadSummary else { return false }
     let path = graph.project.path
-    let nodes = Array(graph.nodes)
+    // A resolved loop is asked only while it still carries a summary to clear. Its session
+    // is over, so a reading can tell it nothing new — but finding that out costs a
+    // directory walk per backend, and Codex's is over every rollout on the machine.
+    let nodes = graph.nodes.filter { !$0.isResolved || $0.summary != nil }
     let readings = await withTaskGroup(of: (UUID, SummaryReading?).self) { group in
       for node in nodes {
         group.addTask { (node.id, await onReadSummary(node, path)) }
@@ -787,6 +790,10 @@ public actor GraphStore {
     graph.edges.removeAll { $0.from == node.id || $0.to == node.id }
     graph.nodes.remove(id: node.id)
     cancelGoalPoller(node.id)
+    // The summary reader keeps one modification date per node so a quiet transcript costs
+    // a `stat` and no read; a deleted loop should not keep one for the life of the daemon.
+    let deletedID = node.id
+    Task { await TranscriptFreshness.shared.forget(deletedID) }
     for targetID in downstream {
       unblockIfStillIdle(targetID)
     }

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -482,13 +482,49 @@ public actor GraphStore {
   /// of a run — the last thing a loop was doing is exactly what a human coming back wants
   /// on screen, and blanking it the moment the session goes quiet would empty the rail at
   /// precisely the moment it is most worth reading.
+  ///
+  /// **An *empty* reading is different from no reading, and it is what turns the feature
+  /// off.** `nil` means nothing new was read — a quiet transcript, a remote loop, a
+  /// backend with nothing to say — and the node keeps what it has. An empty one is the
+  /// reader saying it will not be narrating this node at all, which is what
+  /// `CLISessionBackend` answers when the human has switched the producer off, and the
+  /// node's summary goes with it. Without that, switching the experiment off left every
+  /// card showing a beat frozen at the moment it was switched, outranking the live
+  /// activity line it had been standing in for. Resolved loops are swept too, which is why
+  /// this loop is over every node.
+  ///
+  /// **Asked concurrently, unlike the other two readings.** Those are file reads and a
+  /// `stat`, and a queue of them is nothing; this one may have the optional model pass
+  /// behind it, which is a subprocess with a timeout on it. Sequentially that is one
+  /// timeout *per loop* on a tick that presence rides on, so a canvas of six loops could
+  /// stop reporting state for a minute over a caption. One task each bounds the whole
+  /// sweep at a single timeout however many loops there are.
   @discardableResult
   private func refreshSummary() async -> Bool {
     guard let onReadSummary else { return false }
+    let path = graph.project.path
+    let nodes = Array(graph.nodes)
+    let readings = await withTaskGroup(of: (UUID, SummaryReading?).self) { group in
+      for node in nodes {
+        group.addTask { (node.id, await onReadSummary(node, path)) }
+      }
+      var collected: [UUID: SummaryReading] = [:]
+      for await (id, reading) in group {
+        guard let reading else { continue }
+        collected[id] = reading
+      }
+      return collected
+    }
     var changed = false
-    for node in graph.nodes where !node.isResolved {
-      guard let reading = await onReadSummary(node, graph.project.path), !reading.isEmpty
-      else { continue }
+    for node in nodes {
+      guard let reading = readings[node.id] else { continue }
+      guard !reading.isEmpty else {
+        guard graph.nodes[id: node.id]?.summary != nil else { continue }
+        graph.nodes[id: node.id]?.summary = nil
+        changed = true
+        continue
+      }
+      guard !node.isResolved else { continue }
       let merged = (graph.nodes[id: node.id]?.summary ?? LoopSummary()).merging(reading)
       guard graph.nodes[id: node.id]?.summary != merged else { continue }
       graph.nodes[id: node.id]?.summary = merged

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -39,6 +39,9 @@ public actor GraphStore {
   private let onCaptureScript: (@Sendable (ShellPredicate) async -> String?)?
   private let onReadUsage: (@Sendable (LoopNode, String?) async -> UsageSample?)?
   private let onReadActivity: (@Sendable (LoopNode, String?) async -> String?)?
+  /// What a working session has narrated, folded into `LoopNode.summary`. `nil` when
+  /// nothing produces beats — no reader wired, or the human has left the producer off.
+  private let onReadSummary: (@Sendable (LoopNode, String?) async -> SummaryReading?)?
   private let onReadPresence: (@Sendable (LoopNode, String?) async -> PresenceReading)?
   /// Cross-graph `.spawn`. `GraphStore` owns exactly one graph and cannot reach another,
   /// so it hands the request up to `ProjectRegistry`, which is the layer that knows every
@@ -106,6 +109,7 @@ public actor GraphStore {
     onCaptureScript: (@Sendable (ShellPredicate) async -> String?)? = nil,
     onReadUsage: (@Sendable (LoopNode, String?) async -> UsageSample?)? = nil,
     onReadActivity: (@Sendable (LoopNode, String?) async -> String?)? = nil,
+    onReadSummary: (@Sendable (LoopNode, String?) async -> SummaryReading?)? = nil,
     onReadPresence: (@Sendable (LoopNode, String?) async -> PresenceReading)? = nil,
     onSpawnIntoProject: (@Sendable (String, NodeDraft) -> Void)? = nil,
     onAppendMemory: (@Sendable (UUID, String) -> Void)? = nil,
@@ -122,6 +126,7 @@ public actor GraphStore {
     self.onCaptureScript = onCaptureScript
     self.onReadUsage = onReadUsage
     self.onReadActivity = onReadActivity
+    self.onReadSummary = onReadSummary
     self.onReadPresence = onReadPresence
     self.onSpawnIntoProject = onSpawnIntoProject
     self.onAppendMemory = onAppendMemory
@@ -294,6 +299,7 @@ public actor GraphStore {
       // asking it against last tick's readings would describe the wrong ones.
       await refreshPresence()
       await refreshActivity()
+      await refreshSummary()
     }
 
     // Guarded re-fires need an `until` predicate answered first, which means a
@@ -456,6 +462,35 @@ public actor GraphStore {
     return changed
   }
 
+  /// Asks each *working* session what it has narrated, and folds it into the node's own
+  /// bounded store.
+  ///
+  /// Same guard as `refreshActivity` and for the same reason: a loop that has answered,
+  /// stopped or gone is not narrating anything, so reading its transcript would spend a
+  /// file read per quiet loop per tick for a reading nothing has changed.
+  ///
+  /// **Unlike `activity`, a nil reading does not clear the field.** The two say different
+  /// things: `activity` is the tool call happening *now*, and a session between calls is
+  /// genuinely doing none, so blanking it is the honest answer. A summary is the account
+  /// of a run — the last thing a loop was doing is exactly what a human coming back wants
+  /// on screen, and blanking it the moment the session goes quiet would empty the rail at
+  /// precisely the moment it is most worth reading.
+  @discardableResult
+  private func refreshSummary() async -> Bool {
+    guard let onReadSummary else { return false }
+    var changed = false
+    for node in graph.nodes {
+      guard !node.isResolved, node.presence?.presence == .busy else { continue }
+      guard let reading = await onReadSummary(node, graph.project.path), !reading.isEmpty
+      else { continue }
+      let merged = (graph.nodes[id: node.id]?.summary ?? LoopSummary()).merging(reading)
+      guard graph.nodes[id: node.id]?.summary != merged else { continue }
+      graph.nodes[id: node.id]?.summary = merged
+      changed = true
+    }
+    return changed
+  }
+
   /// Asks each session what it is doing, the third reading on the same channel and the
   /// same trip as the other two.
   ///
@@ -519,6 +554,7 @@ public actor GraphStore {
     // whenever that happened to be.
     var changed = await refreshPresence()
     if await refreshActivity() { changed = true }
+    if await refreshSummary() { changed = true }
     guard changed else { return }
     notifyClients()
   }

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -462,12 +462,19 @@ public actor GraphStore {
     return changed
   }
 
-  /// Asks each *working* session what it has narrated, and folds it into the node's own
+  /// Asks each unresolved session what it has narrated, and folds it into the node's own
   /// bounded store.
   ///
-  /// Same guard as `refreshActivity` and for the same reason: a loop that has answered,
-  /// stopped or gone is not narrating anything, so reading its transcript would spend a
-  /// file read per quiet loop per tick for a reading nothing has changed.
+  /// **Not guarded on `busy`, unlike `refreshActivity`, and that was a real bug.** A
+  /// turn's last beats are written and *then* the session goes idle, so the closing
+  /// narration always landed after the final busy poll and was never read: the terminal
+  /// showed a finished turn while the rail sat on a beat from minutes earlier. Activity
+  /// can be guarded that way because a quiet session genuinely has no current tool call. A
+  /// summary is the account of what happened, and the end of a turn is the part of it a
+  /// human coming back most wants.
+  ///
+  /// What keeps that cheap is `TranscriptFreshness`: a quiet loop costs one `stat` and no
+  /// read at all, because its transcript has not moved since the last poll.
   ///
   /// **Unlike `activity`, a nil reading does not clear the field.** The two say different
   /// things: `activity` is the tool call happening *now*, and a session between calls is
@@ -479,8 +486,7 @@ public actor GraphStore {
   private func refreshSummary() async -> Bool {
     guard let onReadSummary else { return false }
     var changed = false
-    for node in graph.nodes {
-      guard !node.isResolved, node.presence?.presence == .busy else { continue }
+    for node in graph.nodes where !node.isResolved {
       guard let reading = await onReadSummary(node, graph.project.path), !reading.isEmpty
       else { continue }
       let merged = (graph.nodes[id: node.id]?.summary ?? LoopSummary()).merging(reading)

--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -30,6 +30,7 @@ public actor ProjectRegistry {
   private let captureScript: (@Sendable (ShellPredicate) async -> String?)?
   private let readUsage: (@Sendable (LoopNode, String?) async -> UsageSample?)?
   private let readActivity: (@Sendable (LoopNode, String?) async -> String?)?
+  private let readSummary: (@Sendable (LoopNode, String?) async -> SummaryReading?)?
   private let readPresence: (@Sendable (LoopNode, String?) async -> PresenceReading)?
   /// Non-nil only while at least one client is attached — see `startPresencePolling`.
   private var presencePoller: Task<Void, Never>?
@@ -53,6 +54,8 @@ public actor ProjectRegistry {
       CLISessionBackend.readUsage,
     readActivity: (@Sendable (LoopNode, String?) async -> String?)? =
       CLISessionBackend.readActivity,
+    readSummary: (@Sendable (LoopNode, String?) async -> SummaryReading?)? =
+      CLISessionBackend.readSummary,
     readPresence: (@Sendable (LoopNode, String?) async -> PresenceReading)? =
       CLISessionBackend.readPresence
   ) {
@@ -64,6 +67,7 @@ public actor ProjectRegistry {
     self.captureScript = captureScript
     self.readUsage = readUsage
     self.readActivity = readActivity
+    self.readSummary = readSummary
     self.readPresence = readPresence
   }
 
@@ -312,6 +316,7 @@ public actor ProjectRegistry {
       onCaptureScript: captureScript,
       onReadUsage: readUsage,
       onReadActivity: readActivity,
+      onReadSummary: readSummary,
       onReadPresence: readPresence,
       onSpawnIntoProject: spawnIntoProject,
       // The node memory log (`NodeMemory`): episode records in, whole directory out

--- a/GraphcodeKit/Sources/Sessions/CLISessionBackend.swift
+++ b/GraphcodeKit/Sources/Sessions/CLISessionBackend.swift
@@ -142,7 +142,10 @@ extension CLISessionBackend {
       // reader without a settings file on disk.
       summary: { node, projectPath in
         let settings = GraphcodeSettingsStore.load()
-        guard settings.summarisesLoops else { return nil }
+        // An empty reading rather than `nil`: the store reads that as "this node carries
+        // no summary" and clears one it already has, which is what switching the
+        // experiment off has to mean. `nil` would leave the last beat on every card.
+        guard settings.summarisesLoops else { return SummaryReading(beats: []) }
         let reading: SummaryReading?
         switch kind {
         case .claudeCode:

--- a/GraphcodeKit/Sources/Sessions/CLISessionBackend.swift
+++ b/GraphcodeKit/Sources/Sessions/CLISessionBackend.swift
@@ -48,6 +48,11 @@ public struct CLISessionBackend: Sendable {
   /// What the session says it is doing right now, or `nil` when nothing reports it —
   /// see `LoopNode.activity`. `projectPath` routed as `presence`'s is.
   public var activity: @Sendable (LoopNode, String?) async -> String?
+  /// The beats this session has narrated, or `nil` when the backend has no transcript to
+  /// read, the loop is remote, or the human hasn't switched the producer on. Folded into
+  /// `LoopNode.summary` by `GraphStore`, never written straight onto the node — see
+  /// `LoopSummary.merge` for why the store has the last word.
+  public var summary: @Sendable (LoopNode, String?) async -> SummaryReading?
 
   public init(
     kind: CLISessionBackendKind,
@@ -56,7 +61,8 @@ public struct CLISessionBackend: Sendable {
     sendInput: @escaping @Sendable (LoopNode, String, String?) async -> Bool,
     presence: @escaping @Sendable (LoopNode, String?) async -> PresenceReading,
     usage: @escaping @Sendable (LoopNode, String?) async -> UsageSample?,
-    activity: @escaping @Sendable (LoopNode, String?) async -> String? = { _, _ in nil }
+    activity: @escaping @Sendable (LoopNode, String?) async -> String? = { _, _ in nil },
+    summary: @escaping @Sendable (LoopNode, String?) async -> SummaryReading? = { _, _ in nil }
   ) {
     self.kind = kind
     self.launch = launch
@@ -65,6 +71,7 @@ public struct CLISessionBackend: Sendable {
     self.presence = presence
     self.usage = usage
     self.activity = activity
+    self.summary = summary
   }
 }
 
@@ -124,6 +131,32 @@ extension CLISessionBackend {
         case .codex:
           return await CodexSessionLog.activity(of: node, projectPath: projectPath)
         }
+      },
+      // Every backend narrates before it acts, and all three write that narration to disk
+      // — so the summary rail costs three tail reads and no tokens. See
+      // `SummaryBeatBuilder` for why there is no model in this path.
+      //
+      // **Gated here rather than in `GraphStore`.** The setting is about whether graphcode
+      // watches a session this closely at all, which is a property of the reading, not of
+      // the graph; and keeping the store policy-free is what lets its tests inject a
+      // reader without a settings file on disk.
+      summary: { node, projectPath in
+        let settings = GraphcodeSettingsStore.load()
+        guard settings.summarisesLoops else { return nil }
+        let reading: SummaryReading?
+        switch kind {
+        case .claudeCode:
+          reading = await ClaudeSessionLog.summary(of: node, projectPath: projectPath)
+        case .copilotCLI:
+          reading = await CopilotSessionLog.summary(of: node, projectPath: projectPath)
+        case .codex:
+          reading = await CodexSessionLog.summary(of: node, projectPath: projectPath)
+        }
+        // The optional second pass, which is the only part of this that costs anything.
+        // Off, `applied` returns what it was given untouched.
+        guard let reading else { return nil }
+        return await SummaryModelWriter.applied(
+          to: reading, node: node, projectPath: projectPath, settings: settings)
       }
     )
   }
@@ -196,6 +229,12 @@ extension CLISessionBackend {
   public static let readActivity: @Sendable (LoopNode, String?) async -> String? = {
     node, path in
     await backend(for: node).activity(node, path)
+  }
+
+  /// The summary-reading hook `GraphStore` is wired with.
+  public static let readSummary: @Sendable (LoopNode, String?) async -> SummaryReading? = {
+    node, path in
+    await backend(for: node).summary(node, path)
   }
 
   /// The presence-reading hook `GraphStore` is wired with. The last missing link in a

--- a/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
@@ -106,10 +106,10 @@ public enum ClaudeSessionLog {
 
   /// The same read, as the reading the store merges — beats, the turns that bound them,
   /// and where the metric got to.
-  static func reading(inTranscriptAt url: URL, deltas: [Int: String]) -> SummaryReading {
+  static func reading(inTranscriptAt url: URL, metricSamples: [MetricSample]) -> SummaryReading {
     var builder = builder(inTranscriptAt: url)
     return SummaryBeatBuilder.reading(
-      from: builder.beats(), turns: builder.userTurns(), deltas: deltas)
+      from: builder.beats(), turns: builder.userTurns(), metricSamples: metricSamples)
   }
 
   private static func builder(inTranscriptAt url: URL) -> SummaryBeatBuilder {
@@ -180,30 +180,22 @@ public enum ClaudeSessionLog {
       let transcript = transcript(forSessionID: sessionID),
       await TranscriptFreshness.shared.hasChanged(transcript, forNode: node.id)
     else { return nil }
-    let reading = reading(inTranscriptAt: transcript, deltas: LoopSummaryDeltas.of(node))
+    let reading = reading(inTranscriptAt: transcript, metricSamples: node.metricHistory)
     return reading.isEmpty ? nil : reading
   }
 }
 
-/// Where the metric got to, per pass — the one number the rail's pass divider carries.
+/// How the one number the rail carries is written.
 ///
-/// Read off `metricHistory` rather than recomputed: that series is what the sparkline and
-/// the plateau rule already use, so a pass line saying `1.4k → 1.3k` and a bar chart
-/// disagreeing is impossible by construction.
+/// Which pass a movement belongs to is `LoopSummary.delta`'s answer, and it is matched on
+/// *when* the sample was taken. Keying the series by position — sample *n* to pass *n* —
+/// was the first version, and it printed a real movement under a pass it did not happen
+/// in as soon as a human typed twice in one pass.
+///
+/// The values themselves come off `metricHistory` unrecomputed: that series is what the
+/// sparkline and the plateau rule already use, so a pass line saying `1.4k → 1.3k` and a
+/// bar chart disagreeing is impossible by construction.
 public enum LoopSummaryDeltas {
-  public static func of(_ node: LoopNode) -> [Int: String] {
-    let samples = node.metricHistory
-    guard samples.count >= 2 else { return [:] }
-    var deltas: [Int: String] = [:]
-    for index in 1..<samples.count {
-      let previous = samples[index - 1].value
-      let current = samples[index].value
-      guard previous != current else { continue }
-      deltas[index + 1] = "\(number(previous)) → \(number(current))"
-    }
-    return deltas
-  }
-
   /// Short enough for a 188pt line: `1.4k`, `0.62`, `312`.
   public static func number(_ value: Double) -> String {
     let magnitude = abs(value)

--- a/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
@@ -164,7 +164,8 @@ public enum ClaudeSessionLog {
       return nil
     }
     guard let sessionID = SessionIDStore.load(forNodeID: node.id),
-      let transcript = transcript(forSessionID: sessionID)
+      let transcript = transcript(forSessionID: sessionID),
+      await TranscriptFreshness.shared.hasChanged(transcript, forNode: node.id)
     else { return nil }
     let beats = beats(inTranscriptAt: transcript)
     guard !beats.isEmpty else { return nil }

--- a/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+/// Claude Code's narration, read out of the transcript it already writes.
+///
+/// Claude Code is the one backend that reports its activity *itself*, through the
+/// `PreToolUse` hook `PresenceHooks` installs — which is why it never needed a log reader
+/// the way Copilot and Codex did. That hook reports one phrase at a time into a label
+/// store, though, and a summary rail needs the sentence *around* the phrase: what the
+/// session said it was about to do, before it did it.
+///
+/// So this is the third reader in the shape of the other two. Every session appends
+/// `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`, one record per message, and the
+/// assistant's own text blocks are the narration. The session id is the one graphcode
+/// already banks for `--resume` (`SessionIDStore`), so the file is found without guessing.
+///
+/// This is the "scanned" tier of docs/04-cli-backends.md#presence, same as the others: a
+/// reading taken from outside, carrying no claim that the agent reported it.
+public enum ClaudeSessionLog {
+  /// Where Claude Code keeps one directory per project. A `var` only so tests can point it
+  /// at a fixture; nothing in the app writes it.
+  public static var projectsDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".claude/projects", isDirectory: true)
+
+  /// The transcript for a session id, found by name across the project directories.
+  ///
+  /// Searched rather than derived. The directory name is the working directory with its
+  /// separators flattened, and reproducing that encoding here would be a second copy of a
+  /// rule Claude Code owns and can change — while the file name is exactly the session id,
+  /// which graphcode banked itself. One shallow pass over a directory of directories is
+  /// cheaper than being wrong.
+  public static func transcript(forSessionID sessionID: String) -> URL? {
+    let manager = FileManager.default
+    guard
+      let projects = try? manager.contentsOfDirectory(
+        at: projectsDirectory, includingPropertiesForKeys: nil)
+    else { return nil }
+    let name = "\(sessionID).jsonl"
+    for project in projects {
+      let candidate = project.appendingPathComponent(name)
+      if manager.fileExists(atPath: candidate.path) { return candidate }
+    }
+    return nil
+  }
+
+  /// What one `tool_use` block is doing, in the same voice as the other two readers.
+  ///
+  /// Deliberately a second copy of `PresenceHooks.activityScript`'s `case` rather than a
+  /// shared table: that one is a `sed` pipeline that has to run inside a hook on a machine
+  /// graphcode may not be on, and this one runs in-process over a parsed record. Sharing
+  /// them would mean generating shell from Swift or parsing JSON in `sh`. They are checked
+  /// against each other in `SummaryRailTests`.
+  public static func phrase(forTool name: String, input: [String: Any]) -> String? {
+    func text(_ key: String) -> String? {
+      guard let raw = input[key] as? String else { return nil }
+      let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? nil : trimmed
+    }
+    func leaf(_ key: String) -> String? {
+      text(key).map { String($0.split(separator: "/").last ?? Substring($0)) }
+    }
+    let specific: String?
+    switch name {
+    case "Edit", "Write", "MultiEdit", "NotebookEdit":
+      specific = leaf("file_path").map { "editing \($0)" }
+    case "Read":
+      specific = leaf("file_path").map { "reading \($0)" }
+    case "Bash", "BashOutput":
+      specific = (text("description") ?? text("command")).map { "running \($0)" }
+    case "Grep":
+      specific = text("pattern").map { "searching for \($0)" }
+    case "Glob":
+      specific = text("pattern").map { "looking for \($0)" }
+    case "WebSearch":
+      specific = text("query").map { "searching the web for \($0)" }
+    case "WebFetch":
+      specific = text("url").map { url in
+        let host = url.split(separator: "/").dropFirst(2).first.map(String.init) ?? url
+        return "reading \(host)"
+      }
+    case "Task", "Agent":
+      specific = text("description").map { "delegating \($0)" }
+    case "Skill":
+      specific = text("skill").map { "running the \($0) skill" }
+    case "TodoWrite", "TaskCreate", "TaskUpdate":
+      specific = "planning"
+    default:
+      specific =
+        name.hasPrefix("mcp__")
+        ? "using \(name.split(separator: "_").last.map(String.init) ?? name)" : nil
+    }
+    // A recognised tool whose input isn't the shape expected names itself rather than
+    // going quiet — the same fallback the other two readers make.
+    return specific ?? "using \(name)"
+  }
+
+  /// Every beat in a transcript's tail, oldest first.
+  ///
+  /// **Sidechains are skipped.** A `Task`/`Agent` sub-agent writes its whole conversation
+  /// into the same file marked `isSidechain`, and folding that in would narrate the
+  /// sub-agent's work as if it were the loop's — five beats deep in a file the human never
+  /// asked about, while the loop's own beat says "delegating".
+  public static func beats(inTranscriptAt url: URL) -> [SummaryBeat] {
+    var builder = SummaryBeatBuilder()
+    for line in SummaryBeatBuilder.tailLines(of: url) {
+      guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
+        let record = object as? [String: Any],
+        record["isSidechain"] as? Bool != true,
+        let type = record["type"] as? String
+      else { continue }
+      let at = SummaryBeatBuilder.date(fromTimestamp: record["timestamp"]) ?? Date()
+      let message = record["message"] as? [String: Any] ?? [:]
+      switch type {
+      case "user":
+        guard isUserTurn(message) else { continue }
+        builder.noteUserTurn(at: at)
+      case "assistant":
+        for block in message["content"] as? [[String: Any]] ?? [] {
+          switch block["type"] as? String {
+          case "text":
+            builder.noteNarration(block["text"] as? String ?? "", at: at)
+          case "tool_use":
+            guard let name = block["name"] as? String,
+              let phrase = phrase(
+                forTool: name, input: block["input"] as? [String: Any] ?? [:])
+            else { continue }
+            builder.noteTool(phrase, at: at)
+          default:
+            continue
+          }
+        }
+      default:
+        continue
+      }
+    }
+    return builder.beats()
+  }
+
+  /// Whether a `user` record is a turn or a tool result wearing the user role.
+  ///
+  /// Every tool result comes back as a `user` message whose content is an array of
+  /// `tool_result` blocks, so counting those as passes would make a pass out of every
+  /// `grep`. A turn is a plain string, or an array carrying real text.
+  static func isUserTurn(_ message: [String: Any]) -> Bool {
+    if let text = message["content"] as? String {
+      return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+    guard let blocks = message["content"] as? [[String: Any]] else { return false }
+    return blocks.contains { block in
+      guard block["type"] as? String == "text" else { return false }
+      let text = block["text"] as? String ?? ""
+      return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+  }
+
+  /// What this node's Claude Code session has been doing, or `nil` when nothing says.
+  ///
+  /// Local only, for the reason `CopilotSessionLog.activity` is: the transcript lives on
+  /// whichever machine ran the agent, and carrying beats back through a remote shell is a
+  /// larger change than this one. Remote loops keep the card line they already had.
+  public static func summary(of node: LoopNode, projectPath: String? = nil) async
+    -> SummaryReading?
+  {
+    if let projectPath, RemoteProjectLocation.parse(projectPath: projectPath) != nil {
+      return nil
+    }
+    guard let sessionID = SessionIDStore.load(forNodeID: node.id),
+      let transcript = transcript(forSessionID: sessionID)
+    else { return nil }
+    let beats = beats(inTranscriptAt: transcript)
+    guard !beats.isEmpty else { return nil }
+    return SummaryBeatBuilder.reading(from: beats, deltas: LoopSummaryDeltas.of(node))
+  }
+}
+
+/// Where the metric got to, per pass — the one number the rail's pass divider carries.
+///
+/// Read off `metricHistory` rather than recomputed: that series is what the sparkline and
+/// the plateau rule already use, so a pass line saying `1.4k → 1.3k` and a bar chart
+/// disagreeing is impossible by construction.
+public enum LoopSummaryDeltas {
+  public static func of(_ node: LoopNode) -> [Int: String] {
+    let samples = node.metricHistory
+    guard samples.count >= 2 else { return [:] }
+    var deltas: [Int: String] = [:]
+    for index in 1..<samples.count {
+      let previous = samples[index - 1].value
+      let current = samples[index].value
+      guard previous != current else { continue }
+      deltas[index + 1] = "\(number(previous)) → \(number(current))"
+    }
+    return deltas
+  }
+
+  /// Short enough for a 188pt line: `1.4k`, `0.62`, `312`.
+  public static func number(_ value: Double) -> String {
+    let magnitude = abs(value)
+    if magnitude >= 1000 {
+      return String(format: "%.1fk", value / 1000)
+    }
+    if magnitude >= 100 || value == value.rounded() {
+      return String(format: "%.0f", value)
+    }
+    return String(format: "%.2f", value)
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
@@ -100,6 +100,19 @@ public enum ClaudeSessionLog {
   /// sub-agent's work as if it were the loop's — five beats deep in a file the human never
   /// asked about, while the loop's own beat says "delegating".
   public static func beats(inTranscriptAt url: URL) -> [SummaryBeat] {
+    var builder = builder(inTranscriptAt: url)
+    return builder.beats()
+  }
+
+  /// The same read, as the reading the store merges — beats, the turns that bound them,
+  /// and where the metric got to.
+  static func reading(inTranscriptAt url: URL, deltas: [Int: String]) -> SummaryReading {
+    var builder = builder(inTranscriptAt: url)
+    return SummaryBeatBuilder.reading(
+      from: builder.beats(), turns: builder.userTurns(), deltas: deltas)
+  }
+
+  private static func builder(inTranscriptAt url: URL) -> SummaryBeatBuilder {
     var builder = SummaryBeatBuilder()
     for line in SummaryBeatBuilder.tailLines(of: url) {
       guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
@@ -132,7 +145,7 @@ public enum ClaudeSessionLog {
         continue
       }
     }
-    return builder.beats()
+    return builder
   }
 
   /// Whether a `user` record is a turn or a tool result wearing the user role.
@@ -167,9 +180,8 @@ public enum ClaudeSessionLog {
       let transcript = transcript(forSessionID: sessionID),
       await TranscriptFreshness.shared.hasChanged(transcript, forNode: node.id)
     else { return nil }
-    let beats = beats(inTranscriptAt: transcript)
-    guard !beats.isEmpty else { return nil }
-    return SummaryBeatBuilder.reading(from: beats, deltas: LoopSummaryDeltas.of(node))
+    let reading = reading(inTranscriptAt: transcript, deltas: LoopSummaryDeltas.of(node))
+    return reading.isEmpty ? nil : reading
   }
 }
 

--- a/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
@@ -115,7 +115,7 @@ public enum ClaudeSessionLog {
   private static func builder(inTranscriptAt url: URL) -> SummaryBeatBuilder {
     var builder = SummaryBeatBuilder()
     for line in SummaryBeatBuilder.tailLines(of: url) {
-      guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
+      guard let object = try? JSONSerialization.jsonObject(with: line),
         let record = object as? [String: Any],
         record["isSidechain"] as? Bool != true,
         let type = record["type"] as? String

--- a/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
@@ -205,10 +205,10 @@ public enum CodexSessionLog {
   }
 
   /// The same read, as the reading the store merges — see `ClaudeSessionLog.reading`.
-  static func reading(inRolloutAt url: URL, deltas: [Int: String]) -> SummaryReading {
+  static func reading(inRolloutAt url: URL, metricSamples: [MetricSample]) -> SummaryReading {
     var builder = builder(inRolloutAt: url)
     return SummaryBeatBuilder.reading(
-      from: builder.beats(), turns: builder.userTurns(), deltas: deltas)
+      from: builder.beats(), turns: builder.userTurns(), metricSamples: metricSamples)
   }
 
   private static func builder(inRolloutAt url: URL) -> SummaryBeatBuilder {
@@ -253,7 +253,7 @@ public enum CodexSessionLog {
       let rollout = rollout(forWorkingDirectory: directory),
       await TranscriptFreshness.shared.hasChanged(rollout, forNode: node.id)
     else { return nil }
-    let reading = reading(inRolloutAt: rollout, deltas: LoopSummaryDeltas.of(node))
+    let reading = reading(inRolloutAt: rollout, metricSamples: node.metricHistory)
     return reading.isEmpty ? nil : reading
   }
 

--- a/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
@@ -238,7 +238,8 @@ public enum CodexSessionLog {
     guard
       let directory = ZmxSessionLauncher.workingDirectory(
         forNode: node, projectPath: projectPath),
-      let rollout = rollout(forWorkingDirectory: directory)
+      let rollout = rollout(forWorkingDirectory: directory),
+      await TranscriptFreshness.shared.hasChanged(rollout, forNode: node.id)
     else { return nil }
     let beats = beats(inRolloutAt: rollout)
     guard !beats.isEmpty else { return nil }

--- a/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
@@ -214,7 +214,7 @@ public enum CodexSessionLog {
   private static func builder(inRolloutAt url: URL) -> SummaryBeatBuilder {
     var builder = SummaryBeatBuilder()
     for line in SummaryBeatBuilder.tailLines(of: url) {
-      guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
+      guard let object = try? JSONSerialization.jsonObject(with: line),
         let record = object as? [String: Any],
         let payload = record["payload"] as? [String: Any]
       else { continue }

--- a/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
@@ -190,6 +190,61 @@ public enum CodexSessionLog {
     return nil
   }
 
+  /// Every beat in a rollout's tail, oldest first.
+  ///
+  /// Codex narrates in two places and both are used: `agent_reasoning` carries a bolded
+  /// header over a paragraph — the header *is* an intent beat, which is why
+  /// `SummaryBeatBuilder.condense` prefers it — and `agent_message` is what it says out
+  /// loud when it has something to report. `user_message` is the pass boundary.
+  ///
+  /// Tool calls come through `phrase(forRecord:)` unchanged, so a beat's evidence names
+  /// exactly what the card's live line would have.
+  public static func beats(inRolloutAt url: URL) -> [SummaryBeat] {
+    var builder = SummaryBeatBuilder()
+    for line in SummaryBeatBuilder.tailLines(of: url) {
+      guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
+        let record = object as? [String: Any],
+        let payload = record["payload"] as? [String: Any]
+      else { continue }
+      let at = SummaryBeatBuilder.date(fromTimestamp: record["timestamp"]) ?? Date()
+      switch record["type"] as? String {
+      case "event_msg":
+        switch payload["type"] as? String {
+        case "user_message":
+          builder.noteUserTurn(at: at)
+        case "agent_reasoning", "agent_message":
+          builder.noteNarration(payload["text"] as? String ?? "", at: at)
+        default:
+          continue
+        }
+      case "response_item":
+        guard let phrase = phrase(forRecord: payload) else { continue }
+        builder.noteTool(phrase, at: at)
+      default:
+        continue
+      }
+    }
+    return builder.beats()
+  }
+
+  /// What this node's Codex session has been doing, or `nil` when nothing says. Local
+  /// only, for the reason `activity` is.
+  public static func summary(of node: LoopNode, projectPath: String? = nil) async
+    -> SummaryReading?
+  {
+    if let projectPath, RemoteProjectLocation.parse(projectPath: projectPath) != nil {
+      return nil
+    }
+    guard
+      let directory = ZmxSessionLauncher.workingDirectory(
+        forNode: node, projectPath: projectPath),
+      let rollout = rollout(forWorkingDirectory: directory)
+    else { return nil }
+    let beats = beats(inRolloutAt: rollout)
+    guard !beats.isEmpty else { return nil }
+    return SummaryBeatBuilder.reading(from: beats, deltas: LoopSummaryDeltas.of(node))
+  }
+
   /// What this node's Codex session is doing, or `nil` when nothing says.
   ///
   /// Local only, for the reason `CopilotSessionLog.activity` is: the rollout lives on

--- a/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
@@ -200,6 +200,18 @@ public enum CodexSessionLog {
   /// Tool calls come through `phrase(forRecord:)` unchanged, so a beat's evidence names
   /// exactly what the card's live line would have.
   public static func beats(inRolloutAt url: URL) -> [SummaryBeat] {
+    var builder = builder(inRolloutAt: url)
+    return builder.beats()
+  }
+
+  /// The same read, as the reading the store merges — see `ClaudeSessionLog.reading`.
+  static func reading(inRolloutAt url: URL, deltas: [Int: String]) -> SummaryReading {
+    var builder = builder(inRolloutAt: url)
+    return SummaryBeatBuilder.reading(
+      from: builder.beats(), turns: builder.userTurns(), deltas: deltas)
+  }
+
+  private static func builder(inRolloutAt url: URL) -> SummaryBeatBuilder {
     var builder = SummaryBeatBuilder()
     for line in SummaryBeatBuilder.tailLines(of: url) {
       guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
@@ -224,7 +236,7 @@ public enum CodexSessionLog {
         continue
       }
     }
-    return builder.beats()
+    return builder
   }
 
   /// What this node's Codex session has been doing, or `nil` when nothing says. Local
@@ -241,9 +253,8 @@ public enum CodexSessionLog {
       let rollout = rollout(forWorkingDirectory: directory),
       await TranscriptFreshness.shared.hasChanged(rollout, forNode: node.id)
     else { return nil }
-    let beats = beats(inRolloutAt: rollout)
-    guard !beats.isEmpty else { return nil }
-    return SummaryBeatBuilder.reading(from: beats, deltas: LoopSummaryDeltas.of(node))
+    let reading = reading(inRolloutAt: rollout, deltas: LoopSummaryDeltas.of(node))
+    return reading.isEmpty ? nil : reading
   }
 
   /// What this node's Codex session is doing, or `nil` when nothing says.

--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -220,7 +220,7 @@ public enum CopilotSessionLog {
   private static func builder(inLogAt url: URL) -> SummaryBeatBuilder {
     var builder = SummaryBeatBuilder()
     for line in SummaryBeatBuilder.tailLines(of: url) {
-      guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
+      guard let object = try? JSONSerialization.jsonObject(with: line),
         let event = object as? [String: Any],
         let type = event["type"] as? String
       else { continue }

--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -243,7 +243,9 @@ public enum CopilotSessionLog {
     }
     let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
     guard let directory = directory(forSessionNamed: name) else { return nil }
-    let beats = beats(inLogAt: directory.appendingPathComponent("events.jsonl"))
+    let log = directory.appendingPathComponent("events.jsonl")
+    guard await TranscriptFreshness.shared.hasChanged(log, forNode: node.id) else { return nil }
+    let beats = beats(inLogAt: log)
     guard !beats.isEmpty else { return nil }
     return SummaryBeatBuilder.reading(from: beats, deltas: LoopSummaryDeltas.of(node))
   }

--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -199,6 +199,55 @@ public enum CopilotSessionLog {
     return lastActivity(inLogAt: directory.appendingPathComponent("events.jsonl"))
   }
 
+  /// Every beat in an event log's tail, oldest first.
+  ///
+  /// Copilot's `assistant.message` is the narration — the sentence it writes alongside the
+  /// `toolRequests` it is about to make — and `user.message` is the pass boundary. Tool
+  /// calls come through `phrase(forTool:arguments:)` unchanged, which means a beat's
+  /// evidence prefers Copilot's own `description` exactly as the card's live line does.
+  public static func beats(inLogAt url: URL) -> [SummaryBeat] {
+    var builder = SummaryBeatBuilder()
+    for line in SummaryBeatBuilder.tailLines(of: url) {
+      guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
+        let event = object as? [String: Any],
+        let type = event["type"] as? String
+      else { continue }
+      let data = event["data"] as? [String: Any] ?? [:]
+      let at =
+        SummaryBeatBuilder.date(fromTimestamp: event["timestamp"] ?? data["timestamp"]) ?? Date()
+      switch type {
+      case "user.message":
+        builder.noteUserTurn(at: at)
+      case "assistant.message":
+        builder.noteNarration(data["content"] as? String ?? "", at: at)
+      case "tool.execution_start":
+        guard let name = data["toolName"] as? String,
+          let phrase = phrase(
+            forTool: name, arguments: data["arguments"] as? [String: Any] ?? [:])
+        else { continue }
+        builder.noteTool(phrase, at: at)
+      default:
+        continue
+      }
+    }
+    return builder.beats()
+  }
+
+  /// What this node's Copilot session has been doing, or `nil` when nothing says. Local
+  /// only, for the reason `activity` is.
+  public static func summary(of node: LoopNode, projectPath: String? = nil) async
+    -> SummaryReading?
+  {
+    if let projectPath, RemoteProjectLocation.parse(projectPath: projectPath) != nil {
+      return nil
+    }
+    let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
+    guard let directory = directory(forSessionNamed: name) else { return nil }
+    let beats = beats(inLogAt: directory.appendingPathComponent("events.jsonl"))
+    guard !beats.isEmpty else { return nil }
+    return SummaryBeatBuilder.reading(from: beats, deltas: LoopSummaryDeltas.of(node))
+  }
+
   /// The last event in a log that says anything about what the session is doing.
   static func lastStateChange(inLogAt url: URL) -> Presence? {
     for line in tailLines(ofLogAt: url).reversed() {

--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -206,6 +206,18 @@ public enum CopilotSessionLog {
   /// calls come through `phrase(forTool:arguments:)` unchanged, which means a beat's
   /// evidence prefers Copilot's own `description` exactly as the card's live line does.
   public static func beats(inLogAt url: URL) -> [SummaryBeat] {
+    var builder = builder(inLogAt: url)
+    return builder.beats()
+  }
+
+  /// The same read, as the reading the store merges — see `ClaudeSessionLog.reading`.
+  static func reading(inLogAt url: URL, deltas: [Int: String]) -> SummaryReading {
+    var builder = builder(inLogAt: url)
+    return SummaryBeatBuilder.reading(
+      from: builder.beats(), turns: builder.userTurns(), deltas: deltas)
+  }
+
+  private static func builder(inLogAt url: URL) -> SummaryBeatBuilder {
     var builder = SummaryBeatBuilder()
     for line in SummaryBeatBuilder.tailLines(of: url) {
       guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
@@ -230,7 +242,7 @@ public enum CopilotSessionLog {
         continue
       }
     }
-    return builder.beats()
+    return builder
   }
 
   /// What this node's Copilot session has been doing, or `nil` when nothing says. Local
@@ -245,9 +257,8 @@ public enum CopilotSessionLog {
     guard let directory = directory(forSessionNamed: name) else { return nil }
     let log = directory.appendingPathComponent("events.jsonl")
     guard await TranscriptFreshness.shared.hasChanged(log, forNode: node.id) else { return nil }
-    let beats = beats(inLogAt: log)
-    guard !beats.isEmpty else { return nil }
-    return SummaryBeatBuilder.reading(from: beats, deltas: LoopSummaryDeltas.of(node))
+    let reading = reading(inLogAt: log, deltas: LoopSummaryDeltas.of(node))
+    return reading.isEmpty ? nil : reading
   }
 
   /// The last event in a log that says anything about what the session is doing.

--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -211,10 +211,10 @@ public enum CopilotSessionLog {
   }
 
   /// The same read, as the reading the store merges — see `ClaudeSessionLog.reading`.
-  static func reading(inLogAt url: URL, deltas: [Int: String]) -> SummaryReading {
+  static func reading(inLogAt url: URL, metricSamples: [MetricSample]) -> SummaryReading {
     var builder = builder(inLogAt: url)
     return SummaryBeatBuilder.reading(
-      from: builder.beats(), turns: builder.userTurns(), deltas: deltas)
+      from: builder.beats(), turns: builder.userTurns(), metricSamples: metricSamples)
   }
 
   private static func builder(inLogAt url: URL) -> SummaryBeatBuilder {
@@ -257,7 +257,7 @@ public enum CopilotSessionLog {
     guard let directory = directory(forSessionNamed: name) else { return nil }
     let log = directory.appendingPathComponent("events.jsonl")
     guard await TranscriptFreshness.shared.hasChanged(log, forNode: node.id) else { return nil }
-    let reading = reading(inLogAt: log, deltas: LoopSummaryDeltas.of(node))
+    let reading = reading(inLogAt: log, metricSamples: node.metricHistory)
     return reading.isEmpty ? nil : reading
   }
 

--- a/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
@@ -1,0 +1,295 @@
+import Foundation
+
+/// Turns one session's transcript into intent beats, for whichever backend wrote it.
+///
+/// **Why there is no model here.** The obvious way to narrate a loop is to summarise its
+/// scrollback with a small model, and that costs money per loop per poll, has to be
+/// bounded, cached and kept out of the loop's own budget line, and can be confidently
+/// wrong — which the design is explicit is worse than the scrollback it replaced. All
+/// three backends already write the sentence: Claude Code emits a text block before the
+/// tool calls it is about to make, Codex an `agent_reasoning` with a bolded header, Copilot
+/// an `assistant.message` alongside its `toolRequests`. That narration *is* the shift in
+/// intent, in the agent's own words, and it is already on disk. So a beat costs a tail read
+/// of a file graphcode is already reading for `activity`, and nothing is generated.
+///
+/// Feed events in transcript order and take `beats()` at the end. The builder holds the
+/// three rules the design puts on the daemon: a beat is a shift (a new narration closes the
+/// open beat, twenty greps in a row do not), it is under ten words (`condense`), and it
+/// cites what it came from (`evidence`).
+struct SummaryBeatBuilder {
+  /// The narration and calls of one beat, before it is closed.
+  private struct Open {
+    var at: Date
+    var pass: Int
+    var text: String?
+    var phrases: [String] = []
+  }
+
+  private var pass = 0
+  private var open: Open?
+  private var closed: [SummaryBeat] = []
+
+  /// A user turn — a human typing, or a `/loop` waking the session. Either way it is the
+  /// boundary the design rolls passes up at.
+  mutating func noteUserTurn(at date: Date) {
+    close()
+    pass += 1
+  }
+
+  /// The agent saying what it is about to do. Closes whatever beat was open: this is the
+  /// shift.
+  mutating func noteNarration(_ raw: String, at date: Date) {
+    guard let text = Self.condense(raw) else { return }
+    close()
+    open = Open(at: date, pass: max(pass, 1), text: text)
+  }
+
+  /// One tool call, in the phrase its backend reader already speaks — `"editing
+  /// Foo.swift"`, `"running make check"`.
+  ///
+  /// Calls attach to the open beat rather than making one. A beat that never got a
+  /// narration takes the first phrase as its own text: that is the tool call restated, not
+  /// a summary invented over it, and it is exactly what `LoopNode.activity` has always put
+  /// on the card.
+  mutating func noteTool(_ phrase: String, at date: Date) {
+    let clean = phrase.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !clean.isEmpty else { return }
+    if open == nil { open = Open(at: date, pass: max(pass, 1)) }
+    open?.phrases.append(clean)
+  }
+
+  mutating func close() {
+    guard let open, open.text != nil || !open.phrases.isEmpty else {
+      self.open = nil
+      return
+    }
+    let kind = Self.kind(text: open.text, phrases: open.phrases)
+    let text = open.text ?? Self.sentence(fromPhrase: open.phrases[0])
+    closed.append(
+      SummaryBeat(
+        id: Self.identifier(pass: open.pass, at: open.at),
+        at: open.at,
+        pass: open.pass,
+        kind: kind,
+        text: text,
+        evidence: Self.evidence(kind: kind, phrases: open.phrases)))
+    self.open = nil
+  }
+
+  /// Every beat read, oldest first, including the one still open — a session mid-call is
+  /// the case the rail exists for, so the current beat must not wait for the next
+  /// narration to appear.
+  mutating func beats() -> [SummaryBeat] {
+    close()
+    return closed
+  }
+
+  /// How many user turns the window saw. `LoopSummary` reads passes off the beats
+  /// themselves; this is here for a reader that wants to know whether it saw the start.
+  var passCount: Int { pass }
+
+  // MARK: - Text
+
+  /// Stable across polls: the same record read twice is the same beat. Position in the
+  /// file would not be — the tail window moves as the session grows.
+  static func identifier(pass: Int, at date: Date) -> String {
+    "p\(pass)-\(Int(date.timeIntervalSince1970 * 1000))"
+  }
+
+  /// Openers that carry no intent, so the beat starts at the verb.
+  private static let fillers = [
+    "now", "okay", "ok", "alright", "right", "great", "perfect", "good", "so", "next",
+  ]
+
+  /// A narration turned into a beat: one sentence, under ten words, or nothing.
+  ///
+  /// Codex's reasoning arrives as `**Planning code mode inspection**\n\nI'm preparing to…`
+  /// — the bolded header is already a beat and the paragraph under it is already too long,
+  /// so the header wins where there is one. Everything else takes its first sentence.
+  ///
+  /// Nothing here rewrites the agent's words beyond dropping a leading filler and cutting
+  /// at ten. Rephrasing into the design's past tense would mean generating a sentence the
+  /// session never said, which is the one thing a derived beat must not do.
+  static func condense(_ raw: String) -> String? {
+    var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !text.isEmpty else { return nil }
+    if let header = boldHeader(of: text) { text = header }
+    text = firstSentence(of: text)
+    text = stripLeadingFiller(text)
+    guard text.count >= 3 else { return nil }
+    return truncate(text, words: 10, characters: 64)
+  }
+
+  /// `**Planning code mode inspection**` → `Planning code mode inspection`, but only when
+  /// the whole first line is one.
+  static func boldHeader(of text: String) -> String? {
+    guard let line = text.split(separator: "\n").first else { return nil }
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    guard trimmed.hasPrefix("**"), trimmed.hasSuffix("**"), trimmed.count > 4 else { return nil }
+    let inner = String(trimmed.dropFirst(2).dropLast(2)).trimmingCharacters(in: .whitespaces)
+    return inner.isEmpty ? nil : inner
+  }
+
+  static func firstSentence(of text: String) -> String {
+    let line = text.split(separator: "\n").first.map(String.init) ?? text
+    var sentence = line
+    // `. ` rather than `.`: a sentence about `UsageProbe.swift` must not stop at the
+    // extension, which is the whole evidence the beat is carrying.
+    for terminator in [". ", "! ", "? "] {
+      if let range = sentence.range(of: terminator) {
+        sentence = String(sentence[sentence.startIndex..<range.lowerBound])
+      }
+    }
+    if sentence.hasSuffix(".") || sentence.hasSuffix(":") { sentence.removeLast() }
+    return sentence.trimmingCharacters(in: .whitespaces)
+  }
+
+  static func stripLeadingFiller(_ text: String) -> String {
+    var words = text.split(separator: " ").map(String.init)
+    while let first = words.first {
+      let bare = first.trimmingCharacters(in: CharacterSet(charactersIn: ",.!—-"))
+      guard fillers.contains(bare.lowercased()), words.count > 2 else { break }
+      words.removeFirst()
+    }
+    guard var rebuilt = words.first else { return text }
+    // Capitalising only the first character leaves `UsageProbe` and `I'll` alone; a
+    // `capitalized` would lowercase every one of them.
+    rebuilt = rebuilt.prefix(1).uppercased() + rebuilt.dropFirst()
+    return ([rebuilt] + words.dropFirst()).joined(separator: " ")
+  }
+
+  static func truncate(_ text: String, words limit: Int, characters: Int) -> String {
+    var result = text
+    let parts = result.split(separator: " ")
+    if parts.count > limit { result = parts.prefix(limit).joined(separator: " ") + "…" }
+    if result.count > characters {
+      result = String(result.prefix(characters)).trimmingCharacters(in: .whitespaces) + "…"
+    }
+    return result
+  }
+
+  /// A tool phrase as a beat of its own — `"editing Foo.swift"` → `"Editing Foo.swift"`.
+  static func sentence(fromPhrase phrase: String) -> String {
+    truncate(
+      phrase.prefix(1).uppercased() + phrase.dropFirst(), words: 10, characters: 64)
+  }
+
+  // MARK: - Kind and evidence
+
+  /// Past-tense openers that mean the beat is a finding rather than a step. Small and
+  /// literal on purpose: a finding gets a green dot, and a dot that lights up for every
+  /// third beat says nothing.
+  private static let findingOpeners = [
+    "found", "turns out", "confirmed", "the bug", "the issue", "root cause", "spotted",
+    "identified", "the cause", "fixed",
+  ]
+
+  /// What the beat mostly was. An edit outranks the reads that led to it — a pass that
+  /// read five files and changed one is an edit, and that is the shape the dots are meant
+  /// to show.
+  static func kind(text: String?, phrases: [String]) -> BeatKind {
+    if let text {
+      let lowered = text.lowercased()
+      if findingOpeners.contains(where: { lowered.hasPrefix($0) }) { return .found }
+    }
+    let kinds = phrases.map(BeatKind.inferred(fromPhrase:))
+    for candidate in [BeatKind.editing, .running, .reading] where kinds.contains(candidate) {
+      return candidate
+    }
+    return .thinking
+  }
+
+  /// `"UsageProbe.swift · 3 files read"` — what the beat came from, one line.
+  ///
+  /// The target is the first call's, not the last: the beat is named for what it opened
+  /// on, and the count says how far it went. A beat with no calls under it has nothing to
+  /// cite and says nothing rather than something vague.
+  static func evidence(kind: BeatKind, phrases: [String]) -> String? {
+    guard let first = phrases.first else { return nil }
+    let target = target(ofPhrase: first)
+    guard phrases.count > 1 else { return target }
+    let noun: String
+    switch kind {
+    case .reading: noun = phrases.count == 1 ? "file read" : "files read"
+    case .editing: noun = "edits"
+    case .running: noun = "commands"
+    default: noun = "steps"
+    }
+    return "\(target) · \(phrases.count) \(noun)"
+  }
+
+  /// The object of a phrase — `"editing UsageProbe.swift"` → `"UsageProbe.swift"`. The
+  /// verb is already said by the kind row above it, so repeating it costs a line the rail
+  /// does not have.
+  ///
+  /// Two words of verb where the readers speak two: `searching for X` and `looking for X`
+  /// leave a dangling "for" otherwise, which reads as a truncation bug rather than as
+  /// evidence.
+  static func target(ofPhrase phrase: String) -> String {
+    var words = phrase.split(separator: " ").map(String.init)
+    guard words.count > 1 else { return phrase }
+    words.removeFirst()
+    while let first = words.first, ["for", "the", "web"].contains(first.lowercased()),
+      words.count > 1
+    {
+      words.removeFirst()
+    }
+    let object = words.joined(separator: " ")
+    return truncate(object.trimmingCharacters(in: .whitespaces), words: 6, characters: 34)
+  }
+
+  // MARK: - Reading a transcript
+
+  /// How much of a transcript's tail is enough to see the current pass and the one before
+  /// it. Bigger than the activity readers' windows because those need only the last tool
+  /// call, and this needs the narration that opened the pass.
+  static let tailBytes = 512 * 1024
+
+  /// The tail of a JSONL transcript, as whole lines.
+  ///
+  /// The first line of a mid-file read is a fragment and is dropped rather than repaired —
+  /// one record's worth of tail is nowhere near this window.
+  static func tailLines(of url: URL, bytes: Int = SummaryBeatBuilder.tailBytes) -> [Substring] {
+    guard let handle = try? FileHandle(forReadingFrom: url) else { return [] }
+    defer { try? handle.close() }
+    guard let end = try? handle.seekToEnd() else { return [] }
+    let start = end > UInt64(bytes) ? end - UInt64(bytes) : 0
+    try? handle.seek(toOffset: start)
+    guard let data = try? handle.readToEnd() else { return [] }
+    var lines = String(decoding: data, as: UTF8.self).split(separator: "\n")
+    if start > 0, !lines.isEmpty { lines.removeFirst() }
+    return lines
+  }
+
+  /// ISO-8601 with fractional seconds, which is what all three backends stamp records
+  /// with. A record whose timestamp doesn't parse takes the reader's fallback rather than
+  /// being dropped: a beat with an approximate time still says what the loop is doing.
+  static let timestampFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
+  }()
+
+  static func date(fromTimestamp raw: Any?) -> Date? {
+    guard let text = raw as? String else { return nil }
+    if let date = timestampFormatter.date(from: text) { return date }
+    return ISO8601DateFormatter().date(from: text)
+  }
+
+  /// Folds beats into the reading the store merges: the newest pass's beats, and one line
+  /// per finished pass before it.
+  ///
+  /// A pass's summary is its **last** beat — what it ended up doing, which is the honest
+  /// one-line account of a pass and the only one available without generating a sentence.
+  static func reading(from beats: [SummaryBeat], deltas: [Int: String] = [:]) -> SummaryReading {
+    guard let newest = beats.map(\.pass).max() else { return SummaryReading(beats: []) }
+    let finished = Dictionary(grouping: beats.filter { $0.pass < newest }, by: \.pass)
+      .compactMap { pass, passBeats -> PassSummary? in
+        guard let last = passBeats.max(by: { $0.at < $1.at }) else { return nil }
+        return PassSummary(pass: pass, text: last.text, delta: deltas[pass])
+      }
+      .sorted { $0.pass < $1.pass }
+    return SummaryReading(
+      beats: beats.filter { $0.pass == newest }, finishedPasses: finished)
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
@@ -395,10 +395,12 @@ struct SummaryBeatBuilder {
   /// its last beat is whatever the tail read happened to open on, which is not what that
   /// pass ended up doing. A pass is summarised from the turn that opened it or not at all.
   static func reading(
-    from beats: [SummaryBeat], turns: [Date] = [], deltas: [Int: String] = [:]
+    from beats: [SummaryBeat], turns: [Date] = [], metricSamples: [MetricSample] = []
   ) -> SummaryReading {
     guard let newest = beats.map(\.pass).max() else { return SummaryReading(beats: []) }
     let partial = turns.count < newest ? beats.map(\.pass).min() : nil
+    var endedAt: [Int: Date] = [:]
+    for beat in beats { endedAt[beat.pass] = max(endedAt[beat.pass] ?? beat.at, beat.at) }
     let finished = Dictionary(grouping: beats.filter { $0.pass < newest }, by: \.pass)
       .compactMap { pass, passBeats -> PassSummary? in
         guard pass != partial, let last = passBeats.max(by: { $0.at < $1.at }) else { return nil }
@@ -407,6 +409,6 @@ struct SummaryBeatBuilder {
       .sorted { $0.pass < $1.pass }
     return SummaryReading(
       beats: beats.filter { $0.pass == newest }, finishedPasses: finished, turns: turns,
-      deltas: deltas)
+      passEndedAt: endedAt, metricSamples: metricSamples)
   }
 }

--- a/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
@@ -354,18 +354,25 @@ struct SummaryBeatBuilder {
   /// call, and this needs the narration that opened the pass.
   static let tailBytes = 512 * 1024
 
-  /// The tail of a JSONL transcript, as whole lines.
+  /// The tail of a JSONL transcript, as whole lines, still as bytes.
   ///
   /// The first line of a mid-file read is a fragment and is dropped rather than repaired —
   /// one record's worth of tail is nowhere near this window.
-  static func tailLines(of url: URL, bytes: Int = SummaryBeatBuilder.tailBytes) -> [Substring] {
+  ///
+  /// **Bytes rather than a `String`, and this was measured.** Decoding the window into a
+  /// `String` to split it, then re-encoding every kept line for `JSONSerialization`, was
+  /// three quarters of the whole read: 8.3 ms of an 11.1 ms parse on a real 113 MB
+  /// transcript, most of it spent on one 400 KB tool result that is dropped as a fragment
+  /// two lines later. Splitting on the newline byte and handing the slices straight to
+  /// `JSONSerialization` — which wanted `Data` all along — does no conversion at all.
+  static func tailLines(of url: URL, bytes: Int = SummaryBeatBuilder.tailBytes) -> [Data] {
     guard let handle = try? FileHandle(forReadingFrom: url) else { return [] }
     defer { try? handle.close() }
     guard let end = try? handle.seekToEnd() else { return [] }
     let start = end > UInt64(bytes) ? end - UInt64(bytes) : 0
     try? handle.seek(toOffset: start)
     guard let data = try? handle.readToEnd() else { return [] }
-    var lines = String(decoding: data, as: UTF8.self).split(separator: "\n")
+    var lines = data.split(separator: UInt8(ascii: "\n"))
     if start > 0, !lines.isEmpty { lines.removeFirst() }
     return lines
   }

--- a/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
@@ -28,12 +28,21 @@ struct SummaryBeatBuilder {
   private var pass = 0
   private var open: Open?
   private var closed: [SummaryBeat] = []
+  private var turns: [Date] = []
 
   /// A user turn — a human typing, or a `/loop` waking the session. Either way it is the
   /// boundary the design rolls passes up at.
+  ///
+  /// The pass it opens is one past whatever came before it *in this window*, and a window
+  /// that starts mid-run has a partial pass in front of its first turn. Counting that
+  /// partial as the same pass as the turn that ends it was the older reading, and it put
+  /// the previous pass's beats on the current pass's rail. These numbers are still only
+  /// relative to the window — `LoopSummary.merge` is what turns them into the number a
+  /// person reads.
   mutating func noteUserTurn(at date: Date) {
     close()
-    pass += 1
+    turns.append(date)
+    pass = max(pass, closed.isEmpty ? 0 : 1) + 1
   }
 
   /// The agent saying what it is about to do. Closes whatever beat was open: this is the
@@ -67,7 +76,7 @@ struct SummaryBeatBuilder {
     let text = open.text ?? Self.sentence(fromPhrase: open.phrases[0])
     closed.append(
       SummaryBeat(
-        id: Self.identifier(pass: open.pass, at: open.at),
+        id: identifier(at: open.at),
         at: open.at,
         pass: open.pass,
         kind: kind,
@@ -84,16 +93,32 @@ struct SummaryBeatBuilder {
     return closed
   }
 
-  /// How many user turns the window saw. `LoopSummary` reads passes off the beats
-  /// themselves; this is here for a reader that wants to know whether it saw the start.
-  var passCount: Int { pass }
+  /// When each user turn in the window happened, oldest first — what `LoopSummary.merge`
+  /// counts absolute passes with.
+  mutating func userTurns() -> [Date] {
+    turns
+  }
 
   // MARK: - Text
 
-  /// Stable across polls: the same record read twice is the same beat. Position in the
-  /// file would not be — the tail window moves as the session grows.
-  static func identifier(pass: Int, at date: Date) -> String {
-    "p\(pass)-\(Int(date.timeIntervalSince1970 * 1000))"
+  /// Stable across polls: the same record read twice is the same beat.
+  ///
+  /// The beat's own instant, and **not** its pass — the pass a window thinks a beat is on
+  /// moves as the tail slides past the turn that opened it, and an id that moved with it
+  /// re-animated every row in the rail and lost the `SINCE YOU LOOKED` watermark every
+  /// time. Position in the file would not be stable either, for the same reason.
+  ///
+  /// Two beats can share a millisecond, so a repeat takes a suffix; that is stable too, as
+  /// long as the window still holds the first of the pair.
+  private mutating func identifier(at date: Date) -> String {
+    let base = "b-\(Int(date.timeIntervalSince1970 * 1000))"
+    var candidate = base
+    var repeats = 1
+    while closed.contains(where: { $0.id == candidate }) {
+      repeats += 1
+      candidate = "\(base)-\(repeats)"
+    }
+    return candidate
   }
 
   /// Openers that carry no intent, so the beat starts at the verb.
@@ -114,6 +139,9 @@ struct SummaryBeatBuilder {
     var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !text.isEmpty else { return nil }
     if let header = boldHeader(of: text) { text = header }
+    // Before the sentence is cut, so a link's own dots and slashes cannot be mistaken for
+    // where the sentence ends.
+    text = stripLinks(text)
     text = firstSentence(of: text)
     text = stripMarkdown(text)
     text = stripLeadingFiller(text)
@@ -162,6 +190,21 @@ struct SummaryBeatBuilder {
     return sentences.map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
   }
 
+  /// `[@cgopireddy](https://www.threads.com/@cgopireddy)` → `@cgopireddy`.
+  ///
+  /// Read off a real transcript, where the URL reached the rail and took the whole line
+  /// with it: the words a beat gets are the label, and the address is not one of them.
+  /// Each pass shortens the string, so the loop cannot run away on nested brackets.
+  static func stripLinks(_ text: String) -> String {
+    var result = text
+    while let range = result.range(of: #"\[[^\]\n]*\]\([^)\n]*\)"#, options: .regularExpression) {
+      let match = result[range]
+      let label = match.dropFirst().prefix { $0 != "]" }
+      result.replaceSubrange(range, with: label)
+    }
+    return result
+  }
+
   /// The rail draws plain text, and agents narrate in markdown.
   ///
   /// Measured on a real transcript rather than guessed at: a line that is *entirely* bold
@@ -205,14 +248,24 @@ struct SummaryBeatBuilder {
     return ([rebuilt] + words.dropFirst()).joined(separator: " ")
   }
 
+  /// Cut to the budget, and cut **between** words.
+  ///
+  /// A character cut through the middle of one — `Threads/Instagr…` — reads as a rendering
+  /// fault rather than as a summary, which is the impression the whole rail is trying not
+  /// to give. The last space still leaves most of the budget, or the word itself is longer
+  /// than the line and the hard cut is the only answer.
   static func truncate(_ text: String, words limit: Int, characters: Int) -> String {
     var result = text
     let parts = result.split(separator: " ")
     if parts.count > limit { result = parts.prefix(limit).joined(separator: " ") + "…" }
-    if result.count > characters {
-      result = String(result.prefix(characters)).trimmingCharacters(in: .whitespaces) + "…"
+    guard result.count > characters else { return result }
+    var cut = String(result.prefix(characters))
+    if let space = cut.lastIndex(of: " "),
+      cut.distance(from: cut.startIndex, to: space) > characters / 2
+    {
+      cut = String(cut[cut.startIndex..<space])
     }
-    return result
+    return cut.trimmingCharacters(in: .whitespaces) + "…"
   }
 
   /// A tool phrase as a beat of its own — `"editing Foo.swift"` → `"Editing Foo.swift"`.
@@ -337,15 +390,23 @@ struct SummaryBeatBuilder {
   ///
   /// A pass's summary is its **last** beat — what it ended up doing, which is the honest
   /// one-line account of a pass and the only one available without generating a sentence.
-  static func reading(from beats: [SummaryBeat], deltas: [Int: String] = [:]) -> SummaryReading {
+  ///
+  /// The **first** pass in a window that started mid-run is dropped rather than rolled up:
+  /// its last beat is whatever the tail read happened to open on, which is not what that
+  /// pass ended up doing. A pass is summarised from the turn that opened it or not at all.
+  static func reading(
+    from beats: [SummaryBeat], turns: [Date] = [], deltas: [Int: String] = [:]
+  ) -> SummaryReading {
     guard let newest = beats.map(\.pass).max() else { return SummaryReading(beats: []) }
+    let partial = turns.count < newest ? beats.map(\.pass).min() : nil
     let finished = Dictionary(grouping: beats.filter { $0.pass < newest }, by: \.pass)
       .compactMap { pass, passBeats -> PassSummary? in
-        guard let last = passBeats.max(by: { $0.at < $1.at }) else { return nil }
-        return PassSummary(pass: pass, text: last.text, delta: deltas[pass])
+        guard pass != partial, let last = passBeats.max(by: { $0.at < $1.at }) else { return nil }
+        return PassSummary(pass: pass, text: last.text)
       }
       .sorted { $0.pass < $1.pass }
     return SummaryReading(
-      beats: beats.filter { $0.pass == newest }, finishedPasses: finished)
+      beats: beats.filter { $0.pass == newest }, finishedPasses: finished, turns: turns,
+      deltas: deltas)
   }
 }

--- a/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
@@ -131,18 +131,35 @@ struct SummaryBeatBuilder {
     return inner.isEmpty ? nil : inner
   }
 
+  /// The opening sentence, or the first two when the opening one is a fragment.
+  ///
+  /// "Clean. Rebuilding Release and reinstalling" is one beat, not two, and stopping at the
+  /// full stop put the word `Clean` alone in the rail with the useful half discarded —
+  /// seen on a real loop. Under three words is the test: a verdict like that is a preamble
+  /// to the sentence that says what is being done, and the pair still fits the ten-word
+  /// budget.
   static func firstSentence(of text: String) -> String {
     let line = text.split(separator: "\n").first.map(String.init) ?? text
-    var sentence = line
-    // `. ` rather than `.`: a sentence about `UsageProbe.swift` must not stop at the
-    // extension, which is the whole evidence the beat is carrying.
-    for terminator in [". ", "! ", "? "] {
-      if let range = sentence.range(of: terminator) {
-        sentence = String(sentence[sentence.startIndex..<range.lowerBound])
-      }
+    let sentences = split(intoSentences: line)
+    guard var sentence = sentences.first else { return "" }
+    if sentence.split(separator: " ").count < 3, sentences.count > 1 {
+      sentence = "\(sentence). \(sentences[1])"
     }
     if sentence.hasSuffix(".") || sentence.hasSuffix(":") { sentence.removeLast() }
     return sentence.trimmingCharacters(in: .whitespaces)
+  }
+
+  /// Sentences, cut on `. ` rather than `.` — a sentence about `UsageProbe.swift` must not
+  /// stop at the extension, which is the whole evidence the beat is carrying.
+  static func split(intoSentences line: String) -> [String] {
+    var sentences: [String] = []
+    var rest = Substring(line)
+    while let range = earliestRange(of: [". ", "! ", "? "], in: rest) {
+      sentences.append(String(rest[rest.startIndex..<range.lowerBound]))
+      rest = rest[range.upperBound...]
+    }
+    sentences.append(String(rest))
+    return sentences.map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
   }
 
   /// The rail draws plain text, and agents narrate in markdown.
@@ -164,6 +181,14 @@ struct SummaryBeatBuilder {
       result = String(result.dropFirst()).trimmingCharacters(in: .whitespaces)
     }
     return result.trimmingCharacters(in: .whitespaces)
+  }
+
+  /// The earliest of several terminators, so sentences are cut in the order they appear
+  /// rather than in the order the list happens to be written.
+  static func earliestRange(of terminators: [String], in text: Substring) -> Range<
+    Substring.Index
+  >? {
+    terminators.compactMap { text.range(of: $0) }.min { $0.lowerBound < $1.lowerBound }
   }
 
   static func stripLeadingFiller(_ text: String) -> String {

--- a/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
@@ -115,6 +115,7 @@ struct SummaryBeatBuilder {
     guard !text.isEmpty else { return nil }
     if let header = boldHeader(of: text) { text = header }
     text = firstSentence(of: text)
+    text = stripMarkdown(text)
     text = stripLeadingFiller(text)
     guard text.count >= 3 else { return nil }
     return truncate(text, words: 10, characters: 64)
@@ -142,6 +143,27 @@ struct SummaryBeatBuilder {
     }
     if sentence.hasSuffix(".") || sentence.hasSuffix(":") { sentence.removeLast() }
     return sentence.trimmingCharacters(in: .whitespaces)
+  }
+
+  /// The rail draws plain text, and agents narrate in markdown.
+  ///
+  /// Measured on a real transcript rather than guessed at: a line that is *entirely* bold
+  /// is caught by `boldHeader`, but a bold **run** inside a longer sentence is not, and its
+  /// asterisks were reaching the rail. Emphasis and code spans are dropped; the words
+  /// inside them are the beat.
+  ///
+  /// A lone `*` or `_` is left alone: `total_tokens` and a glob are far commoner in this
+  /// vocabulary than single-character emphasis, and stripping them would corrupt the one
+  /// thing a beat has to get right — the name it is citing.
+  static func stripMarkdown(_ text: String) -> String {
+    var result = text
+    for token in ["**", "__", "`"] {
+      result = result.replacingOccurrences(of: token, with: "")
+    }
+    while result.hasPrefix("#") || result.hasPrefix(">") {
+      result = String(result.dropFirst()).trimmingCharacters(in: .whitespaces)
+    }
+    return result.trimmingCharacters(in: .whitespaces)
   }
 
   static func stripLeadingFiller(_ text: String) -> String {
@@ -204,18 +226,27 @@ struct SummaryBeatBuilder {
   /// The target is the first call's, not the last: the beat is named for what it opened
   /// on, and the count says how far it went. A beat with no calls under it has nothing to
   /// cite and says nothing rather than something vague.
+  ///
+  /// **The first call *of the beat's own kind*.** A beat that greps twice and then writes a
+  /// file is an edit, and naming it after the grep put a search string under the word
+  /// EDITING — observed on a real transcript, and it reads as a bug in the rail rather than
+  /// as evidence.
   static func evidence(kind: BeatKind, phrases: [String]) -> String? {
-    guard let first = phrases.first else { return nil }
+    let matching = phrases.filter { BeatKind.inferred(fromPhrase: $0) == kind }
+    let counted = matching.isEmpty ? phrases : matching
+    guard let first = counted.first else { return nil }
     let target = target(ofPhrase: first)
-    guard phrases.count > 1 else { return target }
+    // The count is of the calls being named, not of everything the beat did — `3 edits`
+    // beside a file name has to mean three edits.
+    guard counted.count > 1 else { return target }
     let noun: String
     switch kind {
-    case .reading: noun = phrases.count == 1 ? "file read" : "files read"
+    case .reading: noun = "files read"
     case .editing: noun = "edits"
     case .running: noun = "commands"
     default: noun = "steps"
     }
-    return "\(target) · \(phrases.count) \(noun)"
+    return "\(target) · \(counted.count) \(noun)"
   }
 
   /// The object of a phrase — `"editing UsageProbe.swift"` → `"UsageProbe.swift"`. The

--- a/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
@@ -124,6 +124,11 @@ public enum SummaryModelWriter {
       group.cancelAll()
       return first
     }
+    // Cancelling the task that was *waiting* does nothing to the process it was waiting
+    // on. A backend that hangs would otherwise leave a `claude -p` per poll per loop
+    // alive on its own PTY, spending tokens on a caption nobody is going to see — the
+    // one cost this feature promises to keep bounded. A no-op once it has exited.
+    session.terminate()
     guard let outcome, outcome.0, let text = accepted(outcome.1) else { return beat }
     return SummaryBeat(
       id: beat.id, at: beat.at, pass: beat.pass, kind: beat.kind, text: text,

--- a/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// The optional second pass: a small model rewrites the current beat into the sentence the
+/// design asks for, when a human has said they are happy to pay for that.
+///
+/// **The derived beat comes first and is never replaced by nothing.** `SummaryBeatBuilder`
+/// reads the agent's own narration off disk for free, and that is what the rail shows.
+/// This runs *over* that beat — its own sentence and its one line of evidence, nothing
+/// else — and if it fails, times out, or answers with something unusable, the beat stands.
+/// A rail that empties itself because a subprocess was slow would be worse than one that
+/// never called a model at all.
+///
+/// Five things keep it from costing more than the work it describes:
+///
+/// 1. **One beat, not a transcript.** The prompt carries the beat's own sentence and its
+///    one line of evidence — a hundred tokens or so, bounded by construction, whatever the
+///    session's scrollback has grown to.
+/// 2. **Only when the beat changes.** `LoopSummary.beats` carries stable ids, so a beat
+///    already rewritten is never sent twice — see `GraphStore.refreshSummary`.
+/// 3. **Only for working loops.** The same guard `refreshActivity` uses.
+/// 4. **The fast tier.** `--model haiku` and its equivalents, not whatever the loop runs on.
+/// 5. **Out of the loop's budget line.** This is its own process, not the loop's session,
+///    and `usage` is read from the session's own label store — so nothing here can land on
+///    the loop's token count.
+public enum SummaryModelWriter {
+  /// How long a rewrite may take before the derived beat stands. Deliberately short: this
+  /// is a caption on a panel, and a poll that blocks on it stops reporting presence.
+  static let timeout: Duration = .seconds(20)
+
+  /// The instruction, which is mostly a list of refusals.
+  ///
+  /// Every rule in it is one the design puts on the daemon, and the last is the one that
+  /// matters most: a model asked to summarise will happily narrate something plausible
+  /// from a thin beat, and a confident wrong summary is worse than the scrollback it
+  /// replaced.
+  static func prompt(beat: SummaryBeat) -> String {
+    var lines = [
+      "Rewrite one line for a status panel. Reply with the line and nothing else.",
+      "",
+      "Rules:",
+      "- Under ten words. It renders in 188 points; anything longer is cut.",
+      "- Plain past or present tense, no headings, no bullets, no quotes, no trailing stop.",
+      "- Say what the agent is trying to do, not which tools it used.",
+      "- Use only the facts below. Invent nothing. If they are too thin to improve on,",
+      "  reply with the agent's own line unchanged.",
+      "",
+      "The agent's own line: \(beat.text)",
+    ]
+    if let evidence = beat.evidence {
+      lines.append("What it touched: \(evidence)")
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  /// The non-interactive invocation for a backend, at the fast tier.
+  ///
+  /// Every flag here was checked against the installed CLI's own `--help` rather than
+  /// assumed — `claude -p`, `copilot -p/--prompt`, `codex exec`, and `--model`/`-m` on all
+  /// three. `BackendCapabilities.isSpiked` exists because a capability claimed on a hunch
+  /// is how a feature ships broken.
+  ///
+  /// The prompt is an argv element, never a shell string: it carries the agent's own
+  /// sentence, which is arbitrary text from a model.
+  public static func invocation(
+    forBackend backend: CLISessionBackendKind, prompt: String, tier: ModelTier = .fast
+  ) -> [String] {
+    let model = tier.modelAlias.map { ["--model", $0] } ?? []
+    switch backend {
+    case .claudeCode:
+      return ["claude", "-p", prompt] + model
+    case .copilotCLI:
+      // No `--allow-all`: this asks for a sentence, and a summariser that can run tools is
+      // a summariser that can change the repository it is describing.
+      return ["copilot", "-p", prompt] + model
+    case .codex:
+      let codexModel = tier.modelAlias.map { ["-m", $0] } ?? []
+      return ["codex", "exec", prompt] + codexModel
+    }
+  }
+
+  /// What a model's answer is allowed to become.
+  ///
+  /// A CLI in print mode still prefixes banners, wraps things in quotes, and occasionally
+  /// answers in three paragraphs. Anything that isn't one short line is refused outright
+  /// rather than trimmed into shape — `nil` means the derived beat stands, which is a good
+  /// outcome, not a failure.
+  static func accepted(_ raw: String) -> String? {
+    let lines =
+      raw
+      .split(separator: "\n")
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty }
+    // The last non-empty line: banners and warnings come first, the answer comes last.
+    guard var text = lines.last else { return nil }
+    if text.hasPrefix("\""), text.hasSuffix("\""), text.count > 2 {
+      text = String(text.dropFirst().dropLast())
+    }
+    guard !text.isEmpty, text.count <= 90, !text.contains("```"),
+      text.split(separator: " ").count <= 14
+    else { return nil }
+    return SummaryBeatBuilder.condense(text)
+  }
+
+  /// The beat, rewritten — or the beat unchanged, which is every failure path.
+  public static func rewrite(
+    _ beat: SummaryBeat, backend: CLISessionBackendKind, workingDirectory: String?
+  ) async -> SummaryBeat {
+    let invocation = invocation(forBackend: backend, prompt: prompt(beat: beat))
+    guard
+      let session = try? PTYProcessSession(
+        executable: invocation[0], arguments: Array(invocation.dropFirst()),
+        workingDirectory: workingDirectory)
+    else { return beat }
+    let outcome = await withTaskGroup(of: (Bool, String)?.self) { group in
+      group.addTask { await session.waitCollectingOutput() }
+      group.addTask {
+        try? await Task.sleep(for: timeout)
+        return nil
+      }
+      let first = await group.next() ?? nil
+      group.cancelAll()
+      return first
+    }
+    guard let outcome, outcome.0, let text = accepted(outcome.1) else { return beat }
+    return SummaryBeat(
+      id: beat.id, at: beat.at, pass: beat.pass, kind: beat.kind, text: text,
+      evidence: beat.evidence)
+  }
+
+  /// The reading a backend just took, with its newest beat rewritten if the human has
+  /// asked for that and the beat is one graphcode has not already spent a call on.
+  ///
+  /// **Only the newest beat.** The receding rows and the pass summaries are already on
+  /// screen in the words they were first written in, and rewriting them would spend a call
+  /// per poll to change text a person may be mid-way through reading.
+  ///
+  /// The dedupe needs no state of its own: `node.summary` is what the store already holds,
+  /// so a beat whose id is already the current one has been through here.
+  public static func applied(
+    to reading: SummaryReading, node: LoopNode, projectPath: String?,
+    settings: GraphcodeSettings = GraphcodeSettingsStore.load()
+  ) async -> SummaryReading {
+    guard settings.summarisesLoops, settings.summaryUsesModel,
+      let newest = reading.beats.last, newest.id != node.summary?.current?.id
+    else { return reading }
+    let rewritten = await rewrite(
+      newest, backend: node.backend,
+      workingDirectory: ZmxSessionLauncher.workingDirectory(
+        forNode: node, projectPath: projectPath))
+    var beats = reading.beats
+    beats[beats.count - 1] = rewritten
+    return SummaryReading(beats: beats, finishedPasses: reading.finishedPasses)
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
@@ -23,9 +23,12 @@ import Foundation
 ///    and `usage` is read from the session's own label store — so nothing here can land on
 ///    the loop's token count.
 public enum SummaryModelWriter {
-  /// How long a rewrite may take before the derived beat stands. Deliberately short: this
-  /// is a caption on a panel, and a poll that blocks on it stops reporting presence.
-  static let timeout: Duration = .seconds(20)
+  /// How long a rewrite may take before the derived beat stands.
+  ///
+  /// Under `ProjectRegistry.presencePollInterval`, deliberately: a caption that takes
+  /// longer to write than the gap between polls is one the rail will never show in time,
+  /// and the tick it is holding up is the one every state dot in the app rides on.
+  static let timeout: Duration = .seconds(10)
 
   /// The instruction, which is mostly a list of refusals.
   ///

--- a/GraphcodeKit/Sources/Sessions/TranscriptFreshness.swift
+++ b/GraphcodeKit/Sources/Sessions/TranscriptFreshness.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Whether a node's transcript has been written to since the last time it was read.
+///
+/// This exists because of what it replaced. `refreshSummary` used to ask only sessions
+/// that `refreshPresence` had just found **busy** — the guard `refreshActivity` uses, and
+/// the wrong one here. A turn's last beats are written and *then* the session goes idle,
+/// so the closing narration always landed after the final busy poll and was never read:
+/// the terminal said the turn was over while the rail sat on a beat from three minutes
+/// earlier. Activity can be guarded that way because a quiet session genuinely has no
+/// current tool call; a summary is the account of what happened, and the end of a turn is
+/// the most important part of it.
+///
+/// So every unresolved node is asked now, busy or not, and this is what keeps that cheap:
+/// one `stat` per node per poll, and the tail read only when the file has actually moved.
+/// A quiet loop — the common case, and the one the old guard was protecting against —
+/// costs a stat and nothing else.
+///
+/// Modification *dates* rather than a timestamp of our own: comparing against "when we
+/// last read" needs a tolerance, and any tolerance is a window in which a final beat is
+/// missed, which is the bug this is fixing. A date that has not changed means bytes that
+/// have not changed.
+actor TranscriptFreshness {
+  static let shared = TranscriptFreshness()
+
+  private var seen: [UUID: Date] = [:]
+
+  /// True when `url` has been modified since this node last read it — and records the new
+  /// date, so a caller that asks twice without a write in between gets `false` the second
+  /// time.
+  ///
+  /// An unreadable date is `true`: failing towards reading keeps a summary correct at the
+  /// cost of one tail read, where failing the other way would freeze the rail silently.
+  /// `FileManager` rather than `URL.resourceValues`, which caches per `URL` instance and
+  /// would hand back the date from the first call forever — a rail frozen by an
+  /// optimisation, which is precisely the failure this type exists to end. Caught by its
+  /// own test.
+  func hasChanged(_ url: URL, forNode nodeID: UUID) -> Bool {
+    let modified =
+      (try? FileManager.default.attributesOfItem(atPath: url.path))?[.modificationDate]
+      as? Date
+    guard let modified else { return true }
+    guard seen[nodeID] != modified else { return false }
+    seen[nodeID] = modified
+    return true
+  }
+
+  /// Forgets a node, so a deleted loop doesn't hold a date forever.
+  func forget(_ nodeID: UUID) {
+    seen[nodeID] = nil
+  }
+}

--- a/graphcode/Resources/Localizable.xcstrings
+++ b/graphcode/Resources/Localizable.xcstrings
@@ -1,6 +1,70 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "%@ ago": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hace %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "il y a %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ fa"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@前"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 전"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "há %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ назад"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@前"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@前"
+          }
+        }
+      }
+    },
     "%@ · %@": {
       "localizations": {
         "de": {
@@ -125,6 +189,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ · 點按以安裝"
+          }
+        }
+      }
+    },
+    "%@ — ⌥G to show the rail": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — ⌥G zeigt die Leiste"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — ⌥G para mostrar el panel"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — ⌥G pour afficher le panneau"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — ⌥G per mostrare la barra"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — ⌥G でレールを表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — ⌥G로 레일 표시"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — ⌥G para mostrar a barra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — ⌥G показывает панель"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — 按 ⌥G 显示侧栏"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — 按 ⌥G 顯示側欄"
           }
         }
       }
@@ -321,6 +449,70 @@
         }
       }
     },
+    "%lld earlier passes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld frühere Durchläufe"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld pasadas anteriores"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld passages antérieurs"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld passaggi precedenti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以前のパス %lld 件"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 패스 %lld개"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld passagens anteriores"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld предыдущих проходов"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "另有 %lld 轮"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "另有 %lld 輪"
+          }
+        }
+      }
+    },
     "%lld loops": {
       "localizations": {
         "de": {
@@ -509,6 +701,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld 個需要你"
+          }
+        }
+      }
+    },
+    "%lld passes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Durchläufe"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld pasadas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld passages"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld passaggi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld パス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 패스"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld passagens"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld проходов"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 轮"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 輪"
           }
         }
       }
@@ -705,6 +961,70 @@
         }
       }
     },
+    "1 earlier pass": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 früherer Durchlauf"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 pasada anterior"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 passage antérieur"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 passaggio precedente"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以前のパス 1 件"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 패스 1개"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 passagem anterior"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 предыдущий проход"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "另有 1 轮"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "另有 1 輪"
+          }
+        }
+      }
+    },
     "1 loop": {
       "localizations": {
         "de": {
@@ -829,6 +1149,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "1 個迴圈需要你"
+          }
+        }
+      }
+    },
+    "1 pass": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Durchlauf"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 pasada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 passage"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 passaggio"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 パス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 패스"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 passagem"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 проход"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 轮"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 輪"
           }
         }
       }
@@ -1213,6 +1597,134 @@
           "stringUnit": {
             "state": "translated",
             "value": "活動"
+          }
+        }
+      }
+    },
+    "ASKING YOU": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FRAGT DICH"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TE PREGUNTA"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VOUS DEMANDE"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TI STA CHIEDENDO"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認待ち"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인 요청"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PERGUNTANDO A VOCÊ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "СПРАШИВАЕТ ВАС"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在询问你"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在詢問你"
+          }
+        }
+      }
+    },
+    "ASKS YOU": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FRAGT DICH"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TE PREGUNTA"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VOUS DEMANDE"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TI CHIEDE"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認待ち"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인 요청"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PERGUNTA A VOCÊ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "СПРАШИВАЕТ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要你"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要你"
           }
         }
       }
@@ -1661,6 +2173,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "琥珀色永遠只代表一件事：它正在等你。"
+          }
+        }
+      }
+    },
+    "Answer it": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antworten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Responder"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Répondre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rispondi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回答する"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "답하기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Responder"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ответить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回答"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回答"
           }
         }
       }
@@ -2753,6 +3329,70 @@
         }
       }
     },
+    "Collapse to one line": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf eine Zeile einklappen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraer a una línea"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réduire à une ligne"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprimi in una riga"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 行に折りたたむ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한 줄로 접기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recolher para uma linha"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Свернуть в одну строку"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠为一行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "摺疊為一行"
+          }
+        }
+      }
+    },
     "Connection Info": {
       "localizations": {
         "de": {
@@ -3261,6 +3901,134 @@
           "stringUnit": {
             "state": "translated",
             "value": "建立迴圈"
+          }
+        }
+      }
+    },
+    "DOING NOW": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TUT GERADE"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AHORA MISMO"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EN COURS"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "STA FACENDO"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지금 하는 일"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FAZENDO AGORA"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "СЕЙЧАС ДЕЛАЕТ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在做"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在做"
+          }
+        }
+      }
+    },
+    "DONE": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FERTIG"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HECHO"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TERMINÉ"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FATTO"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완료"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CONCLUÍDO"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ГОТОВО"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
           }
         }
       }
@@ -4417,6 +5185,70 @@
         }
       }
     },
+    "EDITING": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BEARBEITET"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EDITANDO"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ÉDITION"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MODIFICA"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編集中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집 중"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EDITANDO"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ПРАВКА"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑中"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯中"
+          }
+        }
+      }
+    },
     "ENTRY": {
       "localizations": {
         "de": {
@@ -4541,6 +5373,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "每一輪都會重置這裡到目標之間的迴圈。"
+          }
+        }
+      }
+    },
+    "FOUND": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GEFUNDEN"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HALLAZGO"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TROUVÉ"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TROVATO"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "発見"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "발견"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ENCONTROU"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "НАЙДЕНО"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发现"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "發現"
           }
         }
       }
@@ -5117,6 +6013,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "取得 Beta 版本"
+          }
+        }
+      }
+    },
+    "Getting its bearings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verschafft sich einen Überblick"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientándose"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prend ses repères"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si sta orientando"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "状況を把握しています"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상황을 파악하는 중"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se situando"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Осматривается"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在了解情况"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在了解狀況"
           }
         }
       }
@@ -6081,6 +7041,70 @@
         }
       }
     },
+    "LAST DID": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ZULETZT"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LO ÚLTIMO"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DERNIÈRE ACTION"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ULTIMA AZIONE"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直前の作業"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마지막으로 한 일"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ÚLTIMA AÇÃO"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ПОСЛЕДНЕЕ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近做了"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近做了"
+          }
+        }
+      }
+    },
     "Later": {
       "localizations": {
         "de": {
@@ -6141,6 +7165,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "稍後"
+          }
+        }
+      }
+    },
+    "Let a model write the summaries": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zusammenfassungen von einem Modell schreiben lassen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dejar que un modelo escriba los resúmenes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laisser un modèle rédiger les résumés"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lascia che sia un modello a scrivere i riepiloghi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要約をモデルに書かせる"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요약을 모델이 작성하도록 하기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deixar um modelo escrever os resumos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поручить сводки модели"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "让模型撰写摘要"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "讓模型撰寫摘要"
           }
         }
       }
@@ -8257,6 +9345,70 @@
         }
       }
     },
+    "One short call to your backend's CLI per change. The part that costs money.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein kurzer Aufruf der CLI deines Backends pro Änderung. Der Teil, der Geld kostet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una llamada corta a la CLI de tu backend por cada cambio. La parte que cuesta dinero."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un court appel à la CLI de votre backend à chaque changement. La partie qui coûte de l'argent."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una breve chiamata alla CLI del tuo backend a ogni cambiamento. La parte che costa."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変化のたびにバックエンドの CLI を 1 回だけ呼び出します。費用がかかるのはこの部分です。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "변경될 때마다 백엔드 CLI를 한 번씩 호출합니다. 비용이 드는 부분입니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uma chamada curta à CLI do seu backend a cada mudança. A parte que custa dinheiro."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Один короткий вызов CLI вашего бэкенда на каждое изменение. Именно эта часть стоит денег."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每次变化调用一次后端 CLI。这是会产生费用的部分。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每次變化呼叫一次後端 CLI。這是會產生費用的部分。"
+          }
+        }
+      }
+    },
     "Only attention": {
       "localizations": {
         "de": {
@@ -8893,6 +10045,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "打開此複合迴圈本身的畫布以檢視全部內容"
+          }
+        }
+      }
+    },
+    "PASS %lld": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DURCHLAUF %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PASADA %lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PASSAGE %lld"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PASSAGGIO %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パス %lld"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "패스 %lld"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PASSAGEM %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ПРОХОД %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第 %lld 轮"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第 %lld 輪"
           }
         }
       }
@@ -9597,6 +10813,134 @@
           "stringUnit": {
             "state": "translated",
             "value": "快速對話"
+          }
+        }
+      }
+    },
+    "READING": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LIEST"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LEYENDO"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LECTURE"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LETTURA"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み取り"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "읽는 중"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LENDO"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ЧТЕНИЕ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "读取中"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "讀取中"
+          }
+        }
+      }
+    },
+    "RUNNING": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FÜHRT AUS"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EJECUTANDO"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EXÉCUTION"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESECUZIONE"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 중"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EXECUTANDO"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ВЫПОЛНЕНИЕ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行中"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行中"
           }
         }
       }
@@ -10817,6 +12161,70 @@
         }
       }
     },
+    "SINCE YOU LOOKED": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SEIT ZULETZT"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DESDE LA ÚLTIMA VEZ"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEPUIS LA DERNIÈRE FOIS"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DALL'ULTIMA VOLTA"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前回見たとき以降"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마지막으로 본 이후"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DESDE A ÚLTIMA VEZ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "С ПРОШЛОГО РАЗА"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上次查看之后"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上次查看之後"
+          }
+        }
+      }
+    },
     "START": {
       "localizations": {
         "de": {
@@ -10877,6 +12285,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "開始"
+          }
+        }
+      }
+    },
+    "SUMMARY": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ÜBERBLICK"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RESUMEN"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RÉSUMÉ"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RIEPILOGO"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要約"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요약"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RESUMO"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "СВОДКА"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "摘要"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "摘要"
           }
         }
       }
@@ -11265,6 +12737,134 @@
         }
       }
     },
+    "Show the summary rail (⌥G)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überblicksleiste anzeigen (⌥G)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar el panel de resumen (⌥G)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher le panneau de résumé (⌥G)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra la barra del riepilogo (⌥G)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要約レールを表示（⌥G）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요약 레일 표시 (⌥G)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar a barra de resumo (⌥G)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать панель сводки (⌥G)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示摘要侧栏（⌥G）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示摘要側欄（⌥G）"
+          }
+        }
+      }
+    },
+    "Show what this loop is doing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeigen, was dieser Loop tut"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar lo que hace este bucle"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher ce que fait cette boucle"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra cosa sta facendo questo loop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このループの作業内容を表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 루프가 하는 일 표시"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar o que este loop está fazendo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать, чем занят этот цикл"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示这个循环正在做什么"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示這個迴圈正在做什麼"
+          }
+        }
+      }
+    },
     "Skip": {
       "localizations": {
         "de": {
@@ -11645,6 +13245,134 @@
           "stringUnit": {
             "state": "translated",
             "value": "已儲存並繪製，但尚未實際傳送 — 詳見第 6 階段的藍圖。"
+          }
+        }
+      }
+    },
+    "Summarise what loops are doing (experimental)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zusammenfassen, was Loops tun (experimentell)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumir lo que hacen los bucles (experimental)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Résumer ce que font les boucles (expérimental)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riassumere cosa stanno facendo i loop (sperimentale)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ループの作業内容を要約する（実験的）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "루프가 하는 일 요약 (실험적)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumir o que os loops estão fazendo (experimental)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кратко описывать, чем заняты циклы (эксперимент)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "总结循环正在做什么（实验性）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "摘要迴圈正在做什麼（實驗性）"
+          }
+        }
+      }
+    },
+    "THINKING": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DENKT NACH"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PENSANDO"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RÉFLEXION"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RAGIONA"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "思考中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "생각 중"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PENSANDO"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ДУМАЕТ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "思考中"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "思考中"
           }
         }
       }
@@ -12417,6 +14145,70 @@
         }
       }
     },
+    "WHAT IT DID": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WAS ES GETAN HAT"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LO QUE HIZO"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CE QU'ELLE A FAIT"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "COSA HA FATTO"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行内容"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한 일"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O QUE FEZ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ЧТО СДЕЛАНО"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "做了什么"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "做了什麼"
+          }
+        }
+      }
+    },
     "WORKTREES": {
       "localizations": {
         "de": {
@@ -12481,6 +14273,70 @@
         }
       }
     },
+    "Waiting for you": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartet auf dich"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperándote"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous attend"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ti sta aspettando"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "あなたの対応を待っています"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "당신을 기다리는 중"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperando por você"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ждёт вас"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在等你"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在等你"
+          }
+        }
+      }
+    },
     "What carries across": {
       "localizations": {
         "de": {
@@ -12541,6 +14397,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "有哪些內容會延續"
+          }
+        }
+      }
+    },
+    "What each loop is doing, at the top of its rail, read from the session's own transcript. Costs nothing.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Was jeder Loop gerade tut, oben in seiner Leiste, gelesen aus dem Transkript der Sitzung selbst. Kostet nichts."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo que hace cada bucle, en lo alto de su panel, leído de la propia transcripción de la sesión. No cuesta nada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce que fait chaque boucle, en haut de son panneau, lu dans la transcription de la session elle-même. Gratuit."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cosa sta facendo ogni loop, in cima alla sua barra, letto dalla trascrizione della sessione stessa. Non costa nulla."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各ループの作業内容を、セッション自身の記録から読み取ってレール上部に表示します。費用はかかりません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 루프가 무엇을 하는지, 세션 자체의 기록에서 읽어 레일 상단에 표시합니다. 비용은 들지 않습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O que cada loop está fazendo, no topo da barra lateral, lido da própria transcrição da sessão. Não custa nada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чем занят каждый цикл — вверху его панели, по собственной стенограмме сессии. Ничего не стоит."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在每个循环侧栏顶部显示它正在做什么，直接读取会话自己的记录。不产生任何费用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在每個迴圈側欄頂端顯示它正在做什麼，直接讀取工作階段自己的記錄。不產生任何費用。"
           }
         }
       }
@@ -13629,6 +15549,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "esc"
+          }
+        }
+      }
+    },
+    "first beat lands in a moment": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "der erste Beat kommt gleich"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "el primer apunte llega en un momento"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "le premier point arrive dans un instant"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "il primo passaggio arriva tra poco"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最初のビートはまもなく表示されます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "첫 기록이 곧 표시됩니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "o primeiro registro chega em instantes"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "первая запись появится через мгновение"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第一条记录马上就到"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第一則記錄馬上就到"
           }
         }
       }

--- a/graphcode/Sources/Features/Canvas/LoopCardPresentation.swift
+++ b/graphcode/Sources/Features/Canvas/LoopCardPresentation.swift
@@ -48,13 +48,16 @@ struct LoopCardPresentation: Equatable {
   /// The footer, already ordered: kind, branch, backend when it isn't the default, age.
   let meta: [String]
 
-  init(node: LoopNode, now: Date = Date(), reclaimOffer: WorktreeAssessment? = nil) {
+  init(
+    node: LoopNode, now: Date = Date(), reclaimOffer: WorktreeAssessment? = nil,
+    summarising: Bool = LoopSummaryPresentation.isProducing
+  ) {
     word = node.displayState.displayWord(for: node.loopType)
     if let reclaimOffer, node.isResolved {
       liveLine = Self.reclaimLine(reclaimOffer)
       detail = .reclaim
     } else {
-      liveLine = Self.liveLine(node)
+      liveLine = Self.liveLine(node, summarising: summarising)
       detail = Self.detail(node, now: now)
     }
     meta = Self.meta(node, now: now)
@@ -83,12 +86,16 @@ struct LoopCardPresentation: Equatable {
   /// A beat is the sentence the session wrote about what it is *trying* to do; `activity`
   /// is the tool call it happens to be inside. "Working out why cached tokens get counted
   /// twice" is worth more on a card than "reading UsageProbe.swift", and it is the same
-  /// reading — see `SummaryBeatBuilder`. With the producer off there is no beat and this
-  /// falls through to exactly what shipped before, which is why nothing here is
-  /// conditional on the setting.
-  private static func liveLine(_ node: LoopNode) -> String? {
+  /// reading — see `SummaryBeatBuilder`.
+  ///
+  /// Gated on the producer being on, and not merely on a beat existing. A node keeps the
+  /// last summary it was given until the daemon's next poll clears it, and a card
+  /// preferring that beat went on saying what a loop was doing days after the human
+  /// switched the reading off — while the live activity line it outranks sat unread
+  /// underneath it. With the producer off this is exactly what shipped before.
+  private static func liveLine(_ node: LoopNode, summarising: Bool) -> String? {
     let passes = node.metricHistory.count
-    if let beat = node.summary?.current?.text, !beat.isEmpty {
+    if summarising, let beat = node.summary?.current?.text, !beat.isEmpty {
       return passes > 0 ? "pass \(passes) · \(beat)" : beat
     }
     guard let reported = collapsed(node.activity) else { return handedLine(node) }

--- a/graphcode/Sources/Features/Canvas/LoopCardPresentation.swift
+++ b/graphcode/Sources/Features/Canvas/LoopCardPresentation.swift
@@ -78,9 +78,20 @@ struct LoopCardPresentation: Equatable {
   /// off `metricHistory`, the rest off `LoopNode.activity`, which a backend hook writes
   /// and which is `nil` in every session that has no such hook. The fallback is the
   /// goal, prompt or check the loop was created with — less immediate, and never wrong.
+  /// The newest beat outranks both, when there is one.
+  ///
+  /// A beat is the sentence the session wrote about what it is *trying* to do; `activity`
+  /// is the tool call it happens to be inside. "Working out why cached tokens get counted
+  /// twice" is worth more on a card than "reading UsageProbe.swift", and it is the same
+  /// reading — see `SummaryBeatBuilder`. With the producer off there is no beat and this
+  /// falls through to exactly what shipped before, which is why nothing here is
+  /// conditional on the setting.
   private static func liveLine(_ node: LoopNode) -> String? {
-    guard let reported = collapsed(node.activity) else { return handedLine(node) }
     let passes = node.metricHistory.count
+    if let beat = node.summary?.current?.text, !beat.isEmpty {
+      return passes > 0 ? "pass \(passes) · \(beat)" : beat
+    }
+    guard let reported = collapsed(node.activity) else { return handedLine(node) }
     return passes > 0 ? "pass \(passes) · \(reported)" : reported
   }
 

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
@@ -1,0 +1,156 @@
+import GraphcodeKit
+import SwiftUI
+
+/// What the summary section says, worked out once and drawn twice — the rail's own header
+/// block and the 26pt gutter it collapses to.
+///
+/// A value type rather than logic inside the view so the four states the design names —
+/// starting, working, asking, resolved — are assertable without a window.
+struct LoopSummaryPresentation: Equatable {
+  enum Mode: Equatable {
+    /// A session that has begun and not yet said anything. Honest about latency rather
+    /// than empty.
+    case starting
+    case working
+    /// The loop wants a human. Never derived from the summary itself — see `init`.
+    case asking
+    /// The account of a finished run.
+    case resolved
+  }
+
+  let mode: Mode
+  let kind: BeatKind
+  let text: String
+  let evidence: String?
+  /// How long the current beat has been the current beat, mono, in the header row.
+  let elapsed: String?
+  /// The receding rows under the now block, newest first.
+  let receding: [SummaryBeat]
+  /// How many of `receding` landed since the human last looked — the `SINCE YOU LOOKED`
+  /// hairline sits after this many rows.
+  let unseen: Int
+  let passes: [PassSummary]
+  let earlierPasses: Int
+  /// `PASS 7` plus where the metric got to, or nothing when there is no pass to name.
+  let passLabel: String?
+  let passDelta: String?
+
+  /// Whether the section has anything to say at all. A rail must never render an empty
+  /// section — see `LoopWorkspaceRail.hasContent`.
+  static func hasContent(node: LoopNode) -> Bool {
+    node.summary?.isEmpty == false
+  }
+
+  init(node: LoopNode, now: Date = Date(), seenBeatID: String? = nil) {
+    let summary = node.summary ?? LoopSummary()
+    let current = summary.current
+
+    // **Attention is not read off the summary.** `asking` is a beat kind the readers never
+    // produce: whether a loop wants a human is already answered by `state`/`presence`, and
+    // the attention rollup, the card, the sidebar and the titlebar chip all key off that
+    // one answer. A rail that decided for itself would be a second source of truth about
+    // the only thing in the app that must have exactly one.
+    if node.isResolved {
+      mode = .resolved
+      kind = .done
+    } else if node.displayState.wantsHuman {
+      mode = .asking
+      kind = .asking
+    } else if current == nil {
+      mode = .starting
+      kind = .thinking
+    } else {
+      mode = .working
+      kind = current?.kind ?? .thinking
+    }
+
+    switch mode {
+    case .starting:
+      text = "Getting its bearings"
+      evidence = "first beat lands in a moment"
+    case .resolved:
+      text = current?.text ?? node.goal?.summary ?? node.title
+      evidence = Self.runAccount(node, now: now)
+    case .asking:
+      // The question itself if the session narrated one, and otherwise the plain fact.
+      // Both are better than a beat about the tool call it stopped in the middle of.
+      text = current?.text ?? "Waiting for you"
+      evidence = current?.evidence
+    case .working:
+      text = current?.text ?? ""
+      evidence = current?.evidence
+    }
+
+    elapsed = current.map { LoopCardPresentation.duration(now.timeIntervalSince($0.at)) }
+    receding = summary.receding
+    unseen = min(summary.unseenCount(since: seenBeatID), summary.receding.count)
+    passes = summary.passes.reversed()
+    earlierPasses = summary.earlierPasses
+    let pass = current?.pass ?? summary.passes.last?.pass
+    passLabel = pass.map { "PASS \($0)" }
+    passDelta = summary.passes.last?.delta
+  }
+
+  /// `"7 passes · 1.4k → 1.1k · 2h 31m"` — what a finished run cost and what it moved.
+  /// Every part is dropped when it isn't known rather than filled with a zero.
+  static func runAccount(_ node: LoopNode, now: Date) -> String? {
+    var parts: [String] = []
+    let passes = node.metricHistory.count
+    if passes > 0 { parts.append("\(passes) \(passes == 1 ? "pass" : "passes")") }
+    if let first = node.metricHistory.first?.value, let last = node.metricHistory.last?.value,
+      first != last
+    {
+      parts.append("\(LoopSummaryDeltas.number(first)) → \(LoopSummaryDeltas.number(last))")
+    }
+    parts.append(LoopCardPresentation.duration(now.timeIntervalSince(node.createdAt)))
+    return parts.isEmpty ? nil : parts.joined(separator: " · ")
+  }
+}
+
+/// The six kinds' colours, in the palette the app already owns.
+///
+/// Kept beside the presentation rather than on `BeatKind` itself: the kind is a fact about
+/// a session and lives in `GraphcodeKit`, which draws nothing.
+enum BeatKindAppearance {
+  static func dot(_ kind: BeatKind) -> Color {
+    switch kind {
+    case .reading: return .white.opacity(0.45)
+    case .editing: return Color(red: 0.098, green: 0.620, blue: 0.439)  // #199e70
+    case .running: return Theme.paneFocusTint
+    case .thinking: return Color(red: 0.565, green: 0.522, blue: 0.914)  // #9085e9
+    case .found, .done: return Color(red: 0.188, green: 0.820, blue: 0.345)  // #30d158
+    case .asking: return Color(red: 1.0, green: 0.624, blue: 0.039)  // #ff9f0a
+    }
+  }
+
+  static func ink(_ kind: BeatKind) -> Color {
+    switch kind {
+    case .reading: return .white.opacity(0.6)
+    case .editing: return Color(red: 0.435, green: 0.827, blue: 0.671).opacity(0.85)
+    case .running: return Color(red: 0.549, green: 0.773, blue: 1.0).opacity(0.85)
+    case .thinking: return Color(red: 0.706, green: 0.675, blue: 0.941).opacity(0.85)
+    case .found, .done: return Color(red: 0.494, green: 0.894, blue: 0.608).opacity(0.9)
+    case .asking: return Color(red: 1.0, green: 0.804, blue: 0.478).opacity(0.95)
+    }
+  }
+
+  /// The now block's fill and border. `asking` wears the same amber every other attention
+  /// surface in the app does; `resolved` the same green a succeeded card does.
+  static func blockFill(_ mode: LoopSummaryPresentation.Mode, kind: BeatKind) -> Color {
+    switch mode {
+    case .asking: return dot(.asking).opacity(0.1)
+    case .resolved: return dot(.done).opacity(0.08)
+    case .starting: return .white.opacity(0.03)
+    case .working: return Theme.paneFocusTint.opacity(0.09)
+    }
+  }
+
+  static func blockBorder(_ mode: LoopSummaryPresentation.Mode, kind: BeatKind) -> Color {
+    switch mode {
+    case .asking: return dot(.asking).opacity(0.4)
+    case .resolved: return dot(.done).opacity(0.26)
+    case .starting: return .white.opacity(0.08)
+    case .working: return Theme.paneFocusTint.opacity(0.26)
+    }
+  }
+}

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
@@ -26,8 +26,7 @@ struct LoopSummaryPresentation: Equatable {
   let elapsed: String?
   /// The receding rows under the now block, newest first.
   let receding: [SummaryBeat]
-  /// How many of `receding` landed since the human last looked — the `SINCE YOU LOOKED`
-  /// hairline sits after this many rows.
+  /// How many beats have landed since the human last looked, the current one included.
   let unseen: Int
   let passes: [PassSummary]
   let earlierPasses: Int
@@ -38,6 +37,13 @@ struct LoopSummaryPresentation: Equatable {
   /// `LAST DID` — a beat is in the present tense only while something is producing beats,
   /// and a session parked at its prompt is describing the past.
   let isLive: Bool
+
+  /// How many **receding rows** the hairline has to fall above.
+  ///
+  /// One fewer than `unseen`, because the current beat is one of the unseen beats and is
+  /// not a row: it is the block under them. Drawing the hairline `unseen` rows from the
+  /// end marked a row the human had demonstrably already read, every time.
+  var unseenRows: Int { max(unseen - 1, 0) }
 
   /// Whether the section has anything to say at all. A rail must never render an empty
   /// section — see `LoopWorkspaceRail.hasContent`.
@@ -98,10 +104,16 @@ struct LoopSummaryPresentation: Equatable {
     isLive = node.presence?.presence == .busy && !node.isResolved
     elapsed = current.map { LoopCardPresentation.duration(now.timeIntervalSince($0.at)) }
     receding = summary.receding
-    unseen = min(summary.unseenCount(since: seenBeatID), summary.receding.count)
+    // Counted against every beat, including the current one, and clamped to the rows the
+    // hairline can actually sit between — the section draws it *above* a receding row, and
+    // the current beat is not one of those. `LoopSummarySection` puts the leftover case —
+    // only the now block is new — at the foot of the list, which is where it belongs.
+    unseen = min(summary.unseenCount(since: seenBeatID), summary.beats.count)
     passes = summary.passes.reversed()
     earlierPasses = summary.earlierPasses
-    let pass = current?.pass ?? summary.passes.last?.pass
+    // The beat's own pass, which `LoopSummary.merge` has already put on the store's
+    // absolute numbering; `currentPass` for a section that is all rollups and no beats.
+    let pass = current?.pass ?? (summary.currentPass > 0 ? summary.currentPass : nil)
     passLabel = pass.map { "PASS \($0)" }
     passDelta = summary.passes.last?.delta
   }

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
@@ -47,10 +47,23 @@ struct LoopSummaryPresentation: Equatable {
   /// end marked a row the human had demonstrably already read, every time.
   var unseenRows: Int { max(unseen - 1, 0) }
 
+  /// Whether the producer is switched on, from the app's own live copy of the settings
+  /// file — the same read `AppView` makes for the activity strip, and no disk on the
+  /// render path.
+  ///
+  /// **The view asks as well as the daemon, and that is deliberate.** `GraphStore` clears
+  /// a node's summary when the reader says it is not narrating (see `refreshSummary`), so
+  /// switching the experiment off empties the nodes within a poll. Until that poll lands —
+  /// and on any graph file written by a build that cleared nothing — the beats are still
+  /// on the node, and a rail that drew them would be showing a reading from a feature the
+  /// human has switched off. Two answers to one question, agreeing, at fifteen seconds
+  /// apart at worst.
+  static var isProducing: Bool { SettingsModel.shared.settings.summarisesLoops }
+
   /// Whether the section has anything to say at all. A rail must never render an empty
   /// section — see `LoopWorkspaceRail.hasContent`.
-  static func hasContent(node: LoopNode) -> Bool {
-    node.summary?.isEmpty == false
+  static func hasContent(node: LoopNode, producing: Bool = isProducing) -> Bool {
+    producing && node.summary?.isEmpty == false
   }
 
   init(node: LoopNode, now: Date = Date(), seenBeatID: String? = nil) {

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
@@ -34,6 +34,10 @@ struct LoopSummaryPresentation: Equatable {
   /// `PASS 7` plus where the metric got to, or nothing when there is no pass to name.
   let passLabel: String?
   let passDelta: String?
+  /// Whether the session is working this second. What separates `DOING NOW` from
+  /// `LAST DID` — a beat is in the present tense only while something is producing beats,
+  /// and a session parked at its prompt is describing the past.
+  let isLive: Bool
 
   /// Whether the section has anything to say at all. A rail must never render an empty
   /// section — see `LoopWorkspaceRail.hasContent`.
@@ -46,14 +50,24 @@ struct LoopSummaryPresentation: Equatable {
     let current = summary.current
 
     // **Attention is not read off the summary.** `asking` is a beat kind the readers never
-    // produce: whether a loop wants a human is already answered by `state`/`presence`, and
-    // the attention rollup, the card, the sidebar and the titlebar chip all key off that
-    // one answer. A rail that decided for itself would be a second source of truth about
-    // the only thing in the app that must have exactly one.
+    // produce: whether a loop wants a human is already answered by `state`, and the
+    // attention rollup, the card, the sidebar and the titlebar chip all key off that one
+    // answer. A rail that decided for itself would be a second source of truth about the
+    // only thing in the app that must have exactly one.
+    //
+    // **`state`, not `displayState`** — the same split `LoopCardPresentation` makes, and
+    // getting it wrong here was visible immediately. `displayState` turns a *running* loop
+    // into `.awaitingInput` the moment its session's presence says so, and Claude Code
+    // reports that presence for any `Notification`, including simply finishing a turn and
+    // sitting at an empty prompt. So an amber block and an `Answer it` button appeared over
+    // a loop that had asked nothing, under a beat that was not a question. The card has
+    // always taken its *word* from `displayState` and its *affordance* from `state`; the
+    // rail now does the same. A session quietly at its prompt is `waiting` below, not a
+    // question.
     if node.isResolved {
       mode = .resolved
       kind = .done
-    } else if node.displayState.wantsHuman {
+    } else if node.state.wantsHuman {
       mode = .asking
       kind = .asking
     } else if current == nil {
@@ -81,6 +95,7 @@ struct LoopSummaryPresentation: Equatable {
       evidence = current?.evidence
     }
 
+    isLive = node.presence?.presence == .busy && !node.isResolved
     elapsed = current.map { LoopCardPresentation.duration(now.timeIntervalSince($0.at)) }
     receding = summary.receding
     unseen = min(summary.unseenCount(since: seenBeatID), summary.receding.count)

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
@@ -30,8 +30,10 @@ struct LoopSummaryPresentation: Equatable {
   let unseen: Int
   let passes: [PassSummary]
   let earlierPasses: Int
-  /// `PASS 7` plus where the metric got to, or nothing when there is no pass to name.
-  let passLabel: String?
+  /// Which pass the divider names, or nothing when there is no pass to name. A number
+  /// rather than `PASS 7`: the word is the section's to draw, and the section is the layer
+  /// that can be translated.
+  let pass: Int?
   let passDelta: String?
   /// Whether the session is working this second. What separates `DOING NOW` from
   /// `LAST DID` — a beat is in the present tense only while something is producing beats,
@@ -84,17 +86,20 @@ struct LoopSummaryPresentation: Equatable {
       kind = current?.kind ?? .thinking
     }
 
+    // The rail's own words go through the catalog; a beat's never do. The app is shipped
+    // in ten languages and the agent narrates in whichever one it is talking in, so a
+    // translated frame around the session's own sentence is the only coherent answer.
     switch mode {
     case .starting:
-      text = "Getting its bearings"
-      evidence = "first beat lands in a moment"
+      text = String(localized: "Getting its bearings")
+      evidence = String(localized: "first beat lands in a moment")
     case .resolved:
       text = current?.text ?? node.goal?.summary ?? node.title
       evidence = Self.runAccount(node, now: now)
     case .asking:
       // The question itself if the session narrated one, and otherwise the plain fact.
       // Both are better than a beat about the tool call it stopped in the middle of.
-      text = current?.text ?? "Waiting for you"
+      text = current?.text ?? String(localized: "Waiting for you")
       evidence = current?.evidence
     case .working:
       text = current?.text ?? ""
@@ -113,8 +118,7 @@ struct LoopSummaryPresentation: Equatable {
     earlierPasses = summary.earlierPasses
     // The beat's own pass, which `LoopSummary.merge` has already put on the store's
     // absolute numbering; `currentPass` for a section that is all rollups and no beats.
-    let pass = current?.pass ?? (summary.currentPass > 0 ? summary.currentPass : nil)
-    passLabel = pass.map { "PASS \($0)" }
+    pass = current?.pass ?? (summary.currentPass > 0 ? summary.currentPass : nil)
     passDelta = summary.passes.last?.delta
   }
 
@@ -123,7 +127,11 @@ struct LoopSummaryPresentation: Equatable {
   static func runAccount(_ node: LoopNode, now: Date) -> String? {
     var parts: [String] = []
     let passes = node.metricHistory.count
-    if passes > 0 { parts.append("\(passes) \(passes == 1 ? "pass" : "passes")") }
+    if passes > 0 {
+      parts.append(
+        passes == 1
+          ? String(localized: "1 pass") : String(localized: "\(passes) passes"))
+    }
     if let first = node.metricHistory.first?.value, let last = node.metricHistory.last?.value,
       first != last
     {

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
@@ -1,0 +1,334 @@
+import GraphcodeKit
+import SwiftUI
+
+/// The summary rail — what this loop is doing, in beats, at the top of the workspace rail.
+///
+/// The terminal beside it is the record; this is the answer. A pass 1,284 lines into a
+/// grep is eleven words here, and the point of the feature is that nobody has to read the
+/// first to know the second.
+///
+/// One shape, four depths: the current beat at full size, the two before it collapsed and
+/// dimming with age, a pass line where the metric moved, and one row per finished pass
+/// down to a count. A six-hour loop and a six-minute one are the same height — see
+/// `LoopSummary`, which is bounded by construction.
+struct LoopSummarySection: View {
+  let node: LoopNode
+  let now: Date
+  let isFolded: Bool
+  /// The newest beat this window had on screen when the human last left it — what the
+  /// `SINCE YOU LOOKED` hairline is drawn against.
+  let seenBeatID: String?
+  let onToggleFold: () -> Void
+  /// Brings the keyboard to the agent's own pane. The rail already owns "what is it
+  /// doing", so a question is just the current beat wearing amber — and answering it is
+  /// typing into the terminal that asked.
+  let onAnswer: () -> Void
+
+  private var presentation: LoopSummaryPresentation {
+    LoopSummaryPresentation(node: node, now: now, seenBeatID: seenBeatID)
+  }
+
+  /// Whether the flowing spine should move. Only while the loop is actually working —
+  /// see `FlowingSpine` for why that guard is load-bearing rather than cosmetic.
+  private var isWorking: Bool {
+    node.presence?.presence == .busy && !node.isResolved
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      let presentation = presentation
+      header(presentation)
+      if isFolded {
+        foldedLine(presentation)
+      } else {
+        nowBlock(presentation)
+        if !presentation.receding.isEmpty || !presentation.passes.isEmpty
+          || presentation.earlierPasses > 0
+        {
+          history(presentation)
+        }
+      }
+      Rectangle().fill(.white.opacity(0.07)).frame(height: 1)
+    }
+  }
+
+  // MARK: - Header
+
+  /// `DOING NOW`, how long the current beat has been current, and the disclosure. The
+  /// whole row is the fold target — a 14pt chevron is not a click target anyone aims at.
+  private func header(_ presentation: LoopSummaryPresentation) -> some View {
+    HStack(spacing: 7) {
+      Text(headerTitle(presentation))
+        .font(.system(size: 10.5, weight: .bold))
+        .tracking(0.63)
+        .foregroundStyle(.white.opacity(0.5))
+      Spacer(minLength: 0)
+      if let elapsed = presentation.elapsed, !isFolded {
+        Text(elapsed)
+          .font(.system(size: 10.5, design: .monospaced))
+          .foregroundStyle(.white.opacity(0.55))
+      }
+      Image(systemName: isFolded ? "chevron.down" : "chevron.up")
+        .font(.system(size: 8, weight: .semibold))
+        .foregroundStyle(.white.opacity(0.6))
+        .frame(width: 14, height: 14)
+        .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 3))
+    }
+    .contentShape(Rectangle())
+    .onTapGesture(perform: onToggleFold)
+    .help(isFolded ? "Show what this loop is doing" : "Collapse to one line")
+  }
+
+  private func headerTitle(_ presentation: LoopSummaryPresentation) -> String {
+    switch presentation.mode {
+    case .resolved: return "WHAT IT DID"
+    case .asking: return "ASKING YOU"
+    case .starting, .working: return "DOING NOW"
+    }
+  }
+
+  /// Folded keeps one truncated line, because a folded section that shows nothing is a
+  /// section you forget exists.
+  private func foldedLine(_ presentation: LoopSummaryPresentation) -> some View {
+    HStack(spacing: 6) {
+      Circle()
+        .fill(BeatKindAppearance.dot(presentation.kind))
+        .frame(width: 6, height: 6)
+      Text(presentation.text)
+        .font(.system(size: 11.5))
+        .foregroundStyle(.white.opacity(0.75))
+        .lineLimit(1)
+        .truncationMode(.tail)
+      Spacer(minLength: 0)
+    }
+  }
+
+  // MARK: - Now
+
+  private func nowBlock(_ presentation: LoopSummaryPresentation) -> some View {
+    VStack(alignment: .leading, spacing: presentation.mode == .asking ? 7 : 6) {
+      HStack(spacing: 5) {
+        Circle()
+          .fill(BeatKindAppearance.dot(presentation.kind))
+          .frame(width: 6, height: 6)
+        Text(kindWord(presentation).uppercased())
+          .font(.system(size: 9.5, weight: .bold))
+          .tracking(0.48)
+          .foregroundStyle(BeatKindAppearance.ink(presentation.kind))
+        Spacer(minLength: 0)
+      }
+      Text(presentation.text)
+        .font(.system(size: 13))
+        .lineSpacing(2.2)
+        .foregroundStyle(.white.opacity(presentation.mode == .starting ? 0.7 : 0.94))
+        .fixedSize(horizontal: false, vertical: true)
+      if let evidence = presentation.evidence {
+        Text(evidence)
+          .font(.system(size: 10, design: .monospaced))
+          .foregroundStyle(.white.opacity(presentation.mode == .starting ? 0.45 : 0.55))
+          .lineLimit(2)
+      }
+      if presentation.mode == .asking {
+        Button(action: onAnswer) {
+          Text("Answer it")
+            .font(.system(size: 11, weight: .bold))
+            .foregroundStyle(Color(red: 0.141, green: 0.090, blue: 0.012))
+            .frame(maxWidth: .infinity, minHeight: 24)
+            .background(
+              BeatKindAppearance.dot(.asking).opacity(0.9),
+              in: RoundedRectangle(cornerRadius: 5))
+        }
+        .buttonStyle(.plain)
+      }
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 9)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      BeatKindAppearance.blockFill(presentation.mode, kind: presentation.kind),
+      in: RoundedRectangle(cornerRadius: 9)
+    )
+    .overlay {
+      RoundedRectangle(cornerRadius: 9)
+        .stroke(
+          BeatKindAppearance.blockBorder(presentation.mode, kind: presentation.kind),
+          lineWidth: 1)
+    }
+  }
+
+  private func kindWord(_ presentation: LoopSummaryPresentation) -> String {
+    presentation.mode == .asking ? "asking you" : presentation.kind.rawValue
+  }
+
+  // MARK: - History
+
+  /// The receding beats, the pass line, and the rollups — everything behind the current
+  /// beat, on one spine.
+  private func history(_ presentation: LoopSummaryPresentation) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      ForEach(Array(presentation.receding.enumerated()), id: \.element.id) { index, beat in
+        recedingRow(beat, depth: index)
+        if index + 1 == presentation.unseen, index + 1 < presentation.receding.count {
+          sinceYouLooked
+        }
+      }
+      if let label = presentation.passLabel {
+        passDivider(label, delta: presentation.passDelta)
+      }
+      if !presentation.passes.isEmpty || presentation.earlierPasses > 0 {
+        rollups(presentation)
+      }
+    }
+    .padding(.leading, 16)
+    .background(alignment: .leading) {
+      FlowingSpine(isFlowing: isFlowing)
+        .frame(width: 1)
+        .padding(.leading, 4)
+        .padding(.vertical, 3)
+    }
+  }
+
+  /// The spine only animates when there is something behind the current beat to have
+  /// flowed from, and only while the session is live.
+  private var isFlowing: Bool {
+    isWorking && !presentation.receding.isEmpty
+  }
+
+  /// A beat that is no longer current: one line, a dot on the spine, dimming with age.
+  ///
+  /// The dimming is the one place in the rail exempt from the project's tertiary-ink floor
+  /// — `.72` down to `.42` on beat body text is deliberate signal about recency, not a
+  /// contrast accident, and the design says so explicitly.
+  private func recedingRow(_ beat: SummaryBeat, depth: Int) -> some View {
+    let isRecent = depth == 0
+    return VStack(alignment: .leading, spacing: 3) {
+      Text(beat.text)
+        .font(.system(size: 11.5))
+        .lineSpacing(1.6)
+        .foregroundStyle(.white.opacity(isRecent ? 0.72 : 0.42))
+        .fixedSize(horizontal: false, vertical: true)
+      if isRecent {
+        Text(LoopCardPresentation.duration(now.timeIntervalSince(beat.at)) + " ago")
+          .font(.system(size: 10.5, design: .monospaced))
+          .foregroundStyle(.white.opacity(0.5))
+      }
+    }
+    .padding(.bottom, 8)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .overlay(alignment: .topLeading) {
+      Circle()
+        .fill(isRecent ? BeatKindAppearance.dot(beat.kind) : .white.opacity(0.28))
+        .frame(width: isRecent ? 7 : 5, height: isRecent ? 7 : 5)
+        .overlay { Circle().stroke(Theme.workspaceRail, lineWidth: 2) }
+        .offset(x: isRecent ? -15 : -14, y: 4)
+    }
+  }
+
+  /// Where the human left off. It moves only when the loop is on screen again — see
+  /// `LoopWorkspaceFeature.summarySeen` — never while they are reading.
+  private var sinceYouLooked: some View {
+    HStack(spacing: 7) {
+      Text("SINCE YOU LOOKED")
+        .font(.system(size: 9.5, weight: .bold))
+        .tracking(0.38)
+        .foregroundStyle(Color(red: 0.549, green: 0.773, blue: 1.0).opacity(0.85))
+      Rectangle().fill(Theme.paneFocusTint.opacity(0.35)).frame(height: 1)
+    }
+    .padding(.bottom, 8)
+  }
+
+  /// The only number in the section.
+  private func passDivider(_ label: String, delta: String?) -> some View {
+    HStack(spacing: 7) {
+      Text(label)
+        .font(.system(size: 10.5, weight: .bold, design: .monospaced))
+        .foregroundStyle(.white.opacity(0.55))
+      Rectangle().fill(.white.opacity(0.08)).frame(height: 1)
+      if let delta {
+        Text(delta)
+          .font(.system(size: 10.5, design: .monospaced))
+          .foregroundStyle(Color(red: 0.310, green: 0.769, blue: 0.561))  // #4fc48f
+          .lineLimit(1)
+      }
+    }
+    .padding(.vertical, 5)
+  }
+
+  /// One row per finished pass, then a count. Six hours of work stays six rows tall.
+  private func rollups(_ presentation: LoopSummaryPresentation) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      ForEach(presentation.passes) { pass in
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+          Text("p\(pass.pass)")
+            .font(.system(size: 10.5, design: .monospaced))
+            .foregroundStyle(.white.opacity(0.5))
+            .frame(width: 26, alignment: .leading)
+          Text(pass.text)
+            .font(.system(size: 11))
+            .lineSpacing(1.4)
+            .foregroundStyle(.white.opacity(0.45))
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      if presentation.earlierPasses > 0 {
+        Text(
+          "\(presentation.earlierPasses) earlier "
+            + (presentation.earlierPasses == 1 ? "pass" : "passes")
+        )
+        .font(.system(size: 10.5))
+        .foregroundStyle(.white.opacity(0.5))
+        .padding(.leading, 32)
+      }
+    }
+  }
+}
+
+/// The 1pt spine behind the receding beats, with a gradient segment travelling *up* it.
+///
+/// **Why an animation exists here at all.** `StateIndicator` documents why the running
+/// dot's pulse was removed: a `repeatForever` animation never settles, and that one was
+/// attached to every card and every sidebar row, so the app could not reach an idle frame
+/// while any loop ran. This is the opposite case on every count that mattered there. There
+/// is exactly **one** of these in a window — the workspace shows one loop — it is drawn
+/// only when the rail is open and unfolded, and `isFlowing` stops it the moment the
+/// session is not busy or there is nothing behind the current beat. A canvas of forty
+/// cards animates nothing.
+///
+/// It earns its place by saying the one thing no static rail can: that beats are still
+/// arriving. A spinner says "something is happening"; this says "the thing you are reading
+/// is moving", which is what a rail of receding text is for.
+private struct FlowingSpine: View {
+  let isFlowing: Bool
+
+  @State private var phase: CGFloat = 0
+
+  var body: some View {
+    GeometryReader { proxy in
+      let height = proxy.size.height
+      Rectangle()
+        .fill(.white.opacity(0.1))
+        .overlay(alignment: .top) {
+          if isFlowing {
+            RoundedRectangle(cornerRadius: 1)
+              .fill(
+                LinearGradient(
+                  colors: [
+                    Theme.paneFocusTint.opacity(0), Theme.paneFocusTint,
+                    Theme.paneFocusTint.opacity(0),
+                  ],
+                  startPoint: .top, endPoint: .bottom)
+              )
+              .frame(width: 2, height: 26)
+              .offset(x: -0.5, y: (height + 26) * (1 - phase) - 26)
+              .onAppear {
+                phase = 0
+                withAnimation(.linear(duration: 2.6).repeatForever(autoreverses: false)) {
+                  phase = 1
+                }
+              }
+          }
+        }
+        .clipped()
+    }
+  }
+}

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
@@ -35,18 +35,33 @@ struct LoopSummarySection: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: 10) {
       let presentation = presentation
       header(presentation)
       if isFolded {
         foldedLine(presentation)
       } else {
-        nowBlock(presentation)
-        if !presentation.receding.isEmpty || !presentation.passes.isEmpty
-          || presentation.earlierPasses > 0
-        {
-          history(presentation)
+        // History above, now at the foot — the same direction as the terminal beside it,
+        // and the direction the spine's segment travels. Scrolled to the bottom, so the
+        // current beat is what you land on and older work is a scroll up, exactly as
+        // scrollback is.
+        ScrollView(.vertical) {
+          VStack(alignment: .leading, spacing: 10) {
+            if !presentation.receding.isEmpty || !presentation.passes.isEmpty
+              || presentation.earlierPasses > 0
+            {
+              history(presentation)
+            }
+            nowBlock(presentation)
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .scrollBounceBehavior(.basedOnSize)
+        .defaultScrollAnchor(.bottom)
+        // Flexible, but never squeezed away: the sections under it are fixed-height, so
+        // without a floor a short window would collapse the one section the rail is now
+        // mostly for.
+        .frame(minHeight: 120, maxHeight: .infinity)
       }
       Rectangle().fill(.white.opacity(0.07)).frame(height: 1)
     }
@@ -162,21 +177,26 @@ struct LoopSummarySection: View {
 
   // MARK: - History
 
-  /// The receding beats, the pass line, and the rollups — everything behind the current
-  /// beat, on one spine.
+  /// Everything behind the current beat, oldest at the top, on one spine: the finished
+  /// passes, the line where this pass began, then this pass's beats in the order they
+  /// happened.
   private func history(_ presentation: LoopSummaryPresentation) -> some View {
     VStack(alignment: .leading, spacing: 0) {
-      ForEach(Array(presentation.receding.enumerated()), id: \.element.id) { index, beat in
-        recedingRow(beat, depth: index)
-        if index + 1 == presentation.unseen, index + 1 < presentation.receding.count {
-          sinceYouLooked
-        }
+      if !presentation.passes.isEmpty || presentation.earlierPasses > 0 {
+        rollups(presentation)
       }
       if let label = presentation.passLabel {
         passDivider(label, delta: presentation.passDelta)
       }
-      if !presentation.passes.isEmpty || presentation.earlierPasses > 0 {
-        rollups(presentation)
+      let beats = presentation.receding
+      // The hairline sits before the first beat the human has not seen, which is
+      // `unseen` rows from the end.
+      let firstUnseen = beats.count - presentation.unseen
+      ForEach(Array(beats.enumerated()), id: \.element.id) { index, beat in
+        if index == firstUnseen, presentation.unseen > 0 {
+          sinceYouLooked
+        }
+        recedingRow(beat, age: age(of: index, in: beats.count))
       }
     }
     .padding(.leading, 16)
@@ -194,18 +214,26 @@ struct LoopSummarySection: View {
     isWorking && !presentation.receding.isEmpty
   }
 
+  /// How faded a row is by its position: 0 at the top of the list, 1 for the one just
+  /// above the current beat. A single recent/older split was enough for two rows and is
+  /// not for twelve.
+  private func age(of index: Int, in count: Int) -> Double {
+    guard count > 1 else { return 1 }
+    return Double(index) / Double(count - 1)
+  }
+
   /// A beat that is no longer current: one line, a dot on the spine, dimming with age.
   ///
   /// The dimming is the one place in the rail exempt from the project's tertiary-ink floor
   /// — `.72` down to `.42` on beat body text is deliberate signal about recency, not a
   /// contrast accident, and the design says so explicitly.
-  private func recedingRow(_ beat: SummaryBeat, depth: Int) -> some View {
-    let isRecent = depth == 0
+  private func recedingRow(_ beat: SummaryBeat, age: Double) -> some View {
+    let isRecent = age > 0.999
     return VStack(alignment: .leading, spacing: 3) {
       Text(beat.text)
         .font(.system(size: 11.5))
         .lineSpacing(1.6)
-        .foregroundStyle(.white.opacity(isRecent ? 0.72 : 0.42))
+        .foregroundStyle(.white.opacity(0.42 + 0.30 * age))
         .fixedSize(horizontal: false, vertical: true)
       if isRecent {
         Text(LoopCardPresentation.duration(now.timeIntervalSince(beat.at)) + " ago")
@@ -216,8 +244,12 @@ struct LoopSummarySection: View {
     .padding(.bottom, 8)
     .frame(maxWidth: .infinity, alignment: .leading)
     .overlay(alignment: .topLeading) {
+      // The dot keeps its kind colour at every depth, dimmed rather than greyed. The
+      // claim the six kinds exist to make — that the shape of a pass is legible from the
+      // dots alone, without reading a word — is only true if the older dots still carry
+      // one, and over twelve rows that is where the shape actually shows.
       Circle()
-        .fill(isRecent ? BeatKindAppearance.dot(beat.kind) : .white.opacity(0.28))
+        .fill(BeatKindAppearance.dot(beat.kind).opacity(0.45 + 0.55 * age))
         .frame(width: isRecent ? 7 : 5, height: isRecent ? 7 : 5)
         .overlay { Circle().stroke(Theme.workspaceRail, lineWidth: 2) }
         .offset(x: isRecent ? -15 : -14, y: 4)

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
@@ -193,14 +193,21 @@ struct LoopSummarySection: View {
         passDivider(label, delta: presentation.passDelta)
       }
       let beats = presentation.receding
-      // The hairline sits before the first beat the human has not seen, which is
-      // `unseen` rows from the end.
-      let firstUnseen = beats.count - presentation.unseen
+      // The hairline sits before the first beat the human has not seen. `unseen` counts
+      // the current beat too — it is a beat, and it is always new when anything is — so
+      // the rows it covers here are one fewer, and a run where only the now block is new
+      // puts the hairline at the foot, immediately above it. Marking a row the human
+      // demonstrably saw is the bug this arithmetic replaced.
+      let unseenRows = presentation.unseenRows
+      let firstUnseen = beats.count - unseenRows
       ForEach(Array(beats.enumerated()), id: \.element.id) { index, beat in
         if index == firstUnseen, presentation.unseen > 0 {
           sinceYouLooked
         }
         recedingRow(beat, age: age(of: index, in: beats.count))
+      }
+      if presentation.unseen > 0, unseenRows == 0 {
+        sinceYouLooked
       }
     }
     .padding(.leading, 16)

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
@@ -94,11 +94,15 @@ struct LoopSummarySection: View {
     .help(isFolded ? "Show what this loop is doing" : "Collapse to one line")
   }
 
+  /// `DOING NOW` is a claim, and it is only true while something is producing beats. A
+  /// session that has finished its turn and is sitting at its prompt gets `LAST DID` — the
+  /// same sentence, in the tense it is actually in.
   private func headerTitle(_ presentation: LoopSummaryPresentation) -> String {
     switch presentation.mode {
     case .resolved: return "WHAT IT DID"
     case .asking: return "ASKING YOU"
-    case .starting, .working: return "DOING NOW"
+    case .starting: return "DOING NOW"
+    case .working: return presentation.isLive ? "DOING NOW" : "LAST DID"
     }
   }
 

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
@@ -97,7 +97,10 @@ struct LoopSummarySection: View {
   /// `DOING NOW` is a claim, and it is only true while something is producing beats. A
   /// session that has finished its turn and is sitting at its prompt gets `LAST DID` — the
   /// same sentence, in the tense it is actually in.
-  private func headerTitle(_ presentation: LoopSummaryPresentation) -> String {
+  ///
+  /// A `LocalizedStringKey` rather than a `String`: `Text` localizes the first and prints
+  /// the second, and the app ships in ten languages.
+  private func headerTitle(_ presentation: LoopSummaryPresentation) -> LocalizedStringKey {
     switch presentation.mode {
     case .resolved: return "WHAT IT DID"
     case .asking: return "ASKING YOU"
@@ -130,7 +133,7 @@ struct LoopSummarySection: View {
         Circle()
           .fill(BeatKindAppearance.dot(presentation.kind))
           .frame(width: 6, height: 6)
-        Text(kindWord(presentation).uppercased())
+        Text(kindWord(presentation))
           .font(.system(size: 9.5, weight: .bold))
           .tracking(0.48)
           .foregroundStyle(BeatKindAppearance.ink(presentation.kind))
@@ -175,8 +178,23 @@ struct LoopSummarySection: View {
     }
   }
 
-  private func kindWord(_ presentation: LoopSummaryPresentation) -> String {
-    presentation.mode == .asking ? "asking you" : presentation.kind.rawValue
+  /// The kind, in the word the dot beside it is colouring.
+  ///
+  /// Spelled out one case at a time rather than uppercasing `BeatKind.rawValue`: the raw
+  /// value is a wire format, and a language whose uppercase is not a mechanical transform
+  /// of its lowercase — or whose word for `running` is not one word — has nowhere to say
+  /// so if the string never reaches the catalog.
+  private func kindWord(_ presentation: LoopSummaryPresentation) -> LocalizedStringKey {
+    if presentation.mode == .asking { return "ASKING YOU" }
+    switch presentation.kind {
+    case .reading: return "READING"
+    case .editing: return "EDITING"
+    case .running: return "RUNNING"
+    case .thinking: return "THINKING"
+    case .found: return "FOUND"
+    case .asking: return "ASKING YOU"
+    case .done: return "DONE"
+    }
   }
 
   // MARK: - History
@@ -189,8 +207,8 @@ struct LoopSummarySection: View {
       if !presentation.passes.isEmpty || presentation.earlierPasses > 0 {
         rollups(presentation)
       }
-      if let label = presentation.passLabel {
-        passDivider(label, delta: presentation.passDelta)
+      if let pass = presentation.pass {
+        passDivider(pass, delta: presentation.passDelta)
       }
       let beats = presentation.receding
       // The hairline sits before the first beat the human has not seen. `unseen` counts
@@ -247,7 +265,7 @@ struct LoopSummarySection: View {
         .foregroundStyle(.white.opacity(0.42 + 0.30 * age))
         .fixedSize(horizontal: false, vertical: true)
       if isRecent {
-        Text(LoopCardPresentation.duration(now.timeIntervalSince(beat.at)) + " ago")
+        Text("\(LoopCardPresentation.duration(now.timeIntervalSince(beat.at))) ago")
           .font(.system(size: 10.5, design: .monospaced))
           .foregroundStyle(.white.opacity(0.5))
       }
@@ -281,9 +299,9 @@ struct LoopSummarySection: View {
   }
 
   /// The only number in the section.
-  private func passDivider(_ label: String, delta: String?) -> some View {
+  private func passDivider(_ pass: Int, delta: String?) -> some View {
     HStack(spacing: 7) {
-      Text(label)
+      Text("PASS \(pass)")
         .font(.system(size: 10.5, weight: .bold, design: .monospaced))
         .foregroundStyle(.white.opacity(0.55))
       Rectangle().fill(.white.opacity(0.08)).frame(height: 1)
@@ -302,6 +320,8 @@ struct LoopSummarySection: View {
     VStack(alignment: .leading, spacing: 4) {
       ForEach(presentation.passes) { pass in
         HStack(alignment: .firstTextBaseline, spacing: 6) {
+          // The one string in the section with no catalog entry, and deliberately: a 26pt
+          // mono column holds `p7` and not a translation of it.
           Text("p\(pass.pass)")
             .font(.system(size: 10.5, design: .monospaced))
             .foregroundStyle(.white.opacity(0.5))
@@ -315,8 +335,8 @@ struct LoopSummarySection: View {
       }
       if presentation.earlierPasses > 0 {
         Text(
-          "\(presentation.earlierPasses) earlier "
-            + (presentation.earlierPasses == 1 ? "pass" : "passes")
+          presentation.earlierPasses == 1
+            ? "1 earlier pass" : "\(presentation.earlierPasses) earlier passes"
         )
         .font(.system(size: 10.5))
         .foregroundStyle(.white.opacity(0.5))

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
@@ -34,7 +34,16 @@ struct LoopSummarySection: View {
     node.presence?.presence == .busy && !node.isResolved
   }
 
+  /// The spine only animates when there is something behind the current beat to have
+  /// flowed from, and only while the session is live.
+  private func isFlowing(_ presentation: LoopSummaryPresentation) -> Bool {
+    isWorking && !presentation.receding.isEmpty
+  }
+
   var body: some View {
+    // Built once and passed down. `body` runs on every clock tick to keep the elapsed
+    // line honest, and the two branches that used to read `presentation` separately were
+    // rebuilding it — a fold over the beats — a second time for the sake of one `Bool`.
     VStack(alignment: .leading, spacing: 10) {
       let presentation = presentation
       header(presentation)
@@ -230,17 +239,11 @@ struct LoopSummarySection: View {
     }
     .padding(.leading, 16)
     .background(alignment: .leading) {
-      FlowingSpine(isFlowing: isFlowing)
+      FlowingSpine(isFlowing: isFlowing(presentation))
         .frame(width: 1)
         .padding(.leading, 4)
         .padding(.vertical, 3)
     }
-  }
-
-  /// The spine only animates when there is something behind the current beat to have
-  /// flowed from, and only while the session is live.
-  private var isFlowing: Bool {
-    isWorking && !presentation.receding.isEmpty
   }
 
   /// How faded a row is by its position: 0 at the top of the list, 1 for the one just

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
@@ -28,6 +28,9 @@ struct LoopWorkspaceFeature {
     /// `@State` because the *toggle* lives in the window toolbar, which `AppView` owns —
     /// and a control and the thing it controls cannot hold the answer separately.
     var isRailVisible = LoopWorkspaceRail.loadVisible()
+    /// How wide the rail is, after any drag on its edge. Persisted like its visibility:
+    /// someone who widened it to read beats did not mean only this session.
+    var railWidth = LoopWorkspaceRail.loadWidth()
     /// Whether the summary section is collapsed to one line. Persisted beside the rail's
     /// own visibility, and for the same reason: both are choices about how much of the
     /// window a person wants back, and neither should have to be remade every launch.
@@ -71,6 +74,9 @@ struct LoopWorkspaceFeature {
     /// and handled up there, the way `.nodeTapped` already is.
     /// ⌥G, and the toolbar's trailing panel toggle.
     case railToggled
+    /// The rail's leading edge was dragged. Sent once, on release — a per-frame action
+    /// would put a reducer run and a `UserDefaults` write behind every pixel.
+    case railWidthChanged(CGFloat)
     /// The summary section's header row.
     case summaryFoldToggled
     /// The amber block's `Answer it` — the question is in the terminal, so this is a
@@ -205,6 +211,11 @@ struct LoopWorkspaceFeature {
       case .railToggled:
         state.isRailVisible.toggle()
         LoopWorkspaceRail.saveVisible(state.isRailVisible)
+        return .none
+
+      case .railWidthChanged(let width):
+        state.railWidth = LoopWorkspaceRail.clamped(width)
+        LoopWorkspaceRail.saveWidth(state.railWidth)
         return .none
 
       case .summaryFoldToggled:

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
@@ -28,6 +28,16 @@ struct LoopWorkspaceFeature {
     /// `@State` because the *toggle* lives in the window toolbar, which `AppView` owns —
     /// and a control and the thing it controls cannot hold the answer separately.
     var isRailVisible = LoopWorkspaceRail.loadVisible()
+    /// Whether the summary section is collapsed to one line. Persisted beside the rail's
+    /// own visibility, and for the same reason: both are choices about how much of the
+    /// window a person wants back, and neither should have to be remade every launch.
+    var isSummaryFolded = LoopWorkspaceRail.loadSummaryFolded()
+    /// The newest beat that was on screen when this workspace was last left — what the
+    /// rail's `SINCE YOU LOOKED` hairline is drawn against.
+    ///
+    /// Per window rather than on the node: "since *you* looked" is a fact about a person
+    /// at a screen, and the daemon writing it would answer for every window at once.
+    var seenBeatID: String?
     var layout: TerminalLayout
     // The project folder every surface without its own worktree binding should open
     // in — a loop's shells shouldn't land in the app's own launch directory (usually
@@ -61,6 +71,15 @@ struct LoopWorkspaceFeature {
     /// and handled up there, the way `.nodeTapped` already is.
     /// ⌥G, and the toolbar's trailing panel toggle.
     case railToggled
+    /// The summary section's header row.
+    case summaryFoldToggled
+    /// The amber block's `Answer it` — the question is in the terminal, so this is a
+    /// request for the keyboard to go there.
+    case summaryAnswerTapped
+    /// This workspace stopped being the one on screen. The moment everything it was
+    /// showing counts as seen — done on the way *out* so that coming back is what shows
+    /// the hairline, which is the whole point of it.
+    case workspaceLeft
     case stopLoopTapped
     case showInGraphTapped
     case railTargetTapped(UUID)
@@ -186,6 +205,28 @@ struct LoopWorkspaceFeature {
       case .railToggled:
         state.isRailVisible.toggle()
         LoopWorkspaceRail.saveVisible(state.isRailVisible)
+        return .none
+
+      case .summaryFoldToggled:
+        state.isSummaryFolded.toggle()
+        LoopWorkspaceRail.saveSummaryFolded(state.isSummaryFolded)
+        return .none
+
+      case .summaryAnswerTapped:
+        // The agent's own tab, and its own pane within it. A question was asked in that
+        // terminal and answering it means typing there — anything else would be a second
+        // place to answer from, which is the inbox the rail exists instead of.
+        guard
+          let tab = state.layout.tabs.first(where: {
+            $0.surfaces.contains(where: \.launchesClaudeCode)
+          })
+        else { return .none }
+        state.layout.selectedTabID = tab.id
+        guard let surface = tab.surfaces.first(where: \.launchesClaudeCode) else { return .none }
+        return .send(.paneFocused(tabID: tab.id, surfaceID: surface.id))
+
+      case .workspaceLeft:
+        state.seenBeatID = state.node.summary?.current?.id
         return .none
 
       case .stopLoopTapped, .showInGraphTapped, .railTargetTapped:

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
@@ -81,12 +81,16 @@ struct LoopWorkspaceRail: View {
   /// rect between two dashes, and a date; blank chrome is worse than absent chrome, and
   /// a panel that is permanently empty teaches people to stop looking at the panel next
   /// to it (the argument that already keeps the cost rollup out of the sidebar).
-  static func hasContent(node: LoopNode, graph: LoopGraph) -> Bool {
+  static func hasContent(
+    node: LoopNode, graph: LoopGraph,
+    summarising: Bool = LoopSummaryPresentation.isProducing
+  ) -> Bool {
     graph.edges.contains { $0.from == node.id || $0.to == node.id }
       || node.metricHistory.count >= 2
       // A loop that is narrating has something to say whether or not it is wired to
-      // anything — and that narration is the reason to open the rail at all.
-      || LoopSummaryPresentation.hasContent(node: node)
+      // anything — and that narration is the reason to open the rail at all. With the
+      // producer off it is not narrating, whatever a previous switch-on left on the node.
+      || LoopSummaryPresentation.hasContent(node: node, producing: summarising)
   }
 
   /// How many loops this one hands off to — what the loop bar's control counts.

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
@@ -12,11 +12,29 @@ struct LoopWorkspaceRail: View {
   let node: LoopNode
   let graph: LoopGraph
   let now: Date
+  /// Whether the summary section is collapsed to its one truncated line. Per window and
+  /// persisted, beside the rail's own visibility.
+  let isSummaryFolded: Bool
+  /// The newest beat this window had on screen when it was last left — see
+  /// `LoopWorkspaceFeature.seenBeatID`.
+  let seenBeatID: String?
+  let onSummaryFoldToggled: () -> Void
+  let onSummaryAnswerTapped: () -> Void
   let onTargetTapped: (UUID) -> Void
 
   static let width: CGFloat = 212
 
   static let visibleDefaultsKey = "loopWorkspaceRailVisible"
+
+  static let summaryFoldedDefaultsKey = "loopSummarySectionFolded"
+
+  static func loadSummaryFolded() -> Bool {
+    UserDefaults.standard.bool(forKey: summaryFoldedDefaultsKey)
+  }
+
+  static func saveSummaryFolded(_ folded: Bool) {
+    UserDefaults.standard.set(folded, forKey: summaryFoldedDefaultsKey)
+  }
 
   /// **Off** until someone asks for it. It used to default on, which meant every loop
   /// that feeds nothing opened with 212 points of empty panel beside its terminal.
@@ -38,6 +56,9 @@ struct LoopWorkspaceRail: View {
   static func hasContent(node: LoopNode, graph: LoopGraph) -> Bool {
     graph.edges.contains { $0.from == node.id || $0.to == node.id }
       || node.metricHistory.count >= 2
+      // A loop that is narrating has something to say whether or not it is wired to
+      // anything — and that narration is the reason to open the rail at all.
+      || LoopSummaryPresentation.hasContent(node: node)
   }
 
   /// How many loops this one hands off to — what the loop bar's control counts.
@@ -60,6 +81,14 @@ struct LoopWorkspaceRail: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 10) {
+      // Above `THIS LOOP` rather than below it: what the loop is doing this second
+      // outranks where it sits in the graph, and a section you have to scroll to is a
+      // section that answers nothing at a glance.
+      if LoopSummaryPresentation.hasContent(node: node) {
+        LoopSummarySection(
+          node: node, now: now, isFolded: isSummaryFolded, seenBeatID: seenBeatID,
+          onToggleFold: onSummaryFoldToggled, onAnswer: onSummaryAnswerTapped)
+      }
       section("THIS LOOP") {
         RailMinimap(node: node, upstream: inbound, downstream: outbound.map(\.target))
       }

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
@@ -12,6 +12,10 @@ struct LoopWorkspaceRail: View {
   let node: LoopNode
   let graph: LoopGraph
   let now: Date
+  /// What the rail is this window, after any drag. The section inside it is the reason
+  /// this is a variable at all — a beat is a sentence, and 188 points of content is where
+  /// a sentence starts wrapping to four lines.
+  var width: CGFloat = LoopWorkspaceRail.defaultWidth
   /// Whether the summary section is collapsed to its one truncated line. Per window and
   /// persisted, beside the rail's own visibility.
   let isSummaryFolded: Bool
@@ -22,9 +26,33 @@ struct LoopWorkspaceRail: View {
   let onSummaryAnswerTapped: () -> Void
   let onTargetTapped: (UUID) -> Void
 
-  static let width: CGFloat = 212
+  /// The handoff's number, and now the floor rather than the fixed size. Below this the
+  /// receding rows stop being one line each.
+  static let minimumWidth: CGFloat = 212
+  /// Half a 1280pt window is already more than a summary needs; past this the terminal —
+  /// the pane someone is actually working in — is the thing being taken from.
+  static let maximumWidth: CGFloat = 520
+  /// Wider than the 212 the design specified, because the section that arrived after it
+  /// carries prose rather than chips and rows of three.
+  static let defaultWidth: CGFloat = 280
 
   static let visibleDefaultsKey = "loopWorkspaceRailVisible"
+
+  static let widthDefaultsKey = "loopWorkspaceRailWidth"
+
+  static func loadWidth() -> CGFloat {
+    let stored = UserDefaults.standard.double(forKey: widthDefaultsKey)
+    guard stored > 0 else { return defaultWidth }
+    return clamped(stored)
+  }
+
+  static func saveWidth(_ width: CGFloat) {
+    UserDefaults.standard.set(Double(clamped(width)), forKey: widthDefaultsKey)
+  }
+
+  static func clamped(_ width: CGFloat) -> CGFloat {
+    min(max(width, minimumWidth), maximumWidth)
+  }
 
   static let summaryFoldedDefaultsKey = "loopSummarySectionFolded"
 
@@ -108,7 +136,7 @@ struct LoopWorkspaceRail: View {
       footer
     }
     .padding(12)
-    .frame(width: Self.width, alignment: .leading)
+    .frame(width: width, alignment: .leading)
     .frame(maxHeight: .infinity)
     .background(Theme.workspaceRail)
     .overlay(alignment: .leading) {

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
@@ -19,6 +19,7 @@ struct LoopWorkspaceView: View {
       if store.isRailVisible && railHasContent {
         LoopWorkspaceRail(
           node: store.node, graph: store.graph, now: now,
+          width: railWidth,
           isSummaryFolded: store.isSummaryFolded,
           seenBeatID: store.seenBeatID,
           onSummaryFoldToggled: { store.send(.summaryFoldToggled) },
@@ -26,6 +27,7 @@ struct LoopWorkspaceView: View {
         ) { targetID in
           store.send(.railTargetTapped(targetID))
         }
+        .overlay(alignment: .leading) { railResizeHandle }
       } else if LoopSummaryPresentation.hasContent(node: store.node) {
         // Hidden is not gone: 26 points keeps the loop's state dot and the word, and the
         // ask still gets through. See `SummaryGutter`.
@@ -43,6 +45,39 @@ struct LoopWorkspaceView: View {
     // into that band, and it puts the folder name level with the window controls while
     // the tab strip keeps the row below to itself.
     .toolbar { folderToolbar }
+  }
+
+  /// The rail's width mid-drag, before it is committed to the reducer on release.
+  @State private var dragWidth: CGFloat?
+
+  private var railWidth: CGFloat { dragWidth ?? store.railWidth }
+
+  /// The rail's leading edge, as a grab handle.
+  ///
+  /// Six points of transparent hit area over the hairline the rail already draws, rather
+  /// than a visible splitter: the seam is the affordance, and a second line beside the
+  /// first would read as a border that had been drawn twice. Dragging left widens, which
+  /// is what the sign flip is for — a right-hand panel grows as the pointer moves away
+  /// from its edge.
+  private var railResizeHandle: some View {
+    Rectangle()
+      .fill(.clear)
+      .frame(width: 6)
+      .contentShape(Rectangle())
+      .onHover { inside in
+        if inside { NSCursor.resizeLeftRight.push() } else { NSCursor.pop() }
+      }
+      .gesture(
+        DragGesture(minimumDistance: 1)
+          .onChanged { value in
+            dragWidth = LoopWorkspaceRail.clamped(store.railWidth - value.translation.width)
+          }
+          .onEnded { value in
+            let settled = LoopWorkspaceRail.clamped(store.railWidth - value.translation.width)
+            dragWidth = nil
+            store.send(.railWidthChanged(settled))
+          }
+      )
   }
 
   /// Whether this loop gives the rail anything to say — see `LoopWorkspaceRail`.

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
@@ -17,13 +17,24 @@ struct LoopWorkspaceView: View {
       workspace
       // Never drawn empty, whatever the toggle says — see `LoopWorkspaceRail.hasContent`.
       if store.isRailVisible && railHasContent {
-        LoopWorkspaceRail(node: store.node, graph: store.graph, now: now) { targetID in
+        LoopWorkspaceRail(
+          node: store.node, graph: store.graph, now: now,
+          isSummaryFolded: store.isSummaryFolded,
+          seenBeatID: store.seenBeatID,
+          onSummaryFoldToggled: { store.send(.summaryFoldToggled) },
+          onSummaryAnswerTapped: { store.send(.summaryAnswerTapped) }
+        ) { targetID in
           store.send(.railTargetTapped(targetID))
         }
+      } else if LoopSummaryPresentation.hasContent(node: store.node) {
+        // Hidden is not gone: 26 points keeps the loop's state dot and the word, and the
+        // ask still gets through. See `SummaryGutter`.
+        SummaryGutter(node: store.node, now: now) { store.send(.railToggled) }
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .onReceive(CanvasClock.tick) { now = $0 }
+    .onDisappear { store.send(.workspaceLeft) }
     // The folder header goes in the toolbar, not in the `VStack` above, and the pane
     // does *not* claim the titlebar inset. Both were tried: `.ignoresSafeArea(.top)`
     // does slide content up into the band, but whatever lands there is drawn under the

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
@@ -50,6 +50,9 @@ struct LoopWorkspaceView: View {
   /// The rail's width mid-drag, before it is committed to the reducer on release.
   @State private var dragWidth: CGFloat?
 
+  /// Whether the resize cursor is currently pushed — see `railResizeHandle`.
+  @State private var isOverRailEdge = false
+
   private var railWidth: CGFloat { dragWidth ?? store.railWidth }
 
   /// The rail's leading edge, as a grab handle.
@@ -64,8 +67,19 @@ struct LoopWorkspaceView: View {
       .fill(.clear)
       .frame(width: 6)
       .contentShape(Rectangle())
+      // `push`/`pop` is a stack, and the pop only arrives if the pointer leaves the way it
+      // came. Hiding the rail with ⌥G mid-hover, or switching to the canvas, takes the
+      // handle out from under the cursor with no exit — and the resize arrows then follow
+      // the pointer around the whole app until something else pushes over them.
       .onHover { inside in
+        guard inside != isOverRailEdge else { return }
+        isOverRailEdge = inside
         if inside { NSCursor.resizeLeftRight.push() } else { NSCursor.pop() }
+      }
+      .onDisappear {
+        guard isOverRailEdge else { return }
+        isOverRailEdge = false
+        NSCursor.pop()
       }
       .gesture(
         DragGesture(minimumDistance: 1)

--- a/graphcode/Sources/Features/LoopWorkspace/SummaryGutter.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/SummaryGutter.swift
@@ -26,7 +26,7 @@ struct SummaryGutter: View {
 
   private var wantsHuman: Bool { node.state.wantsHuman }
 
-  var label: String { wantsHuman ? "ASKS YOU" : "SUMMARY" }
+  var label: LocalizedStringKey { wantsHuman ? "ASKS YOU" : "SUMMARY" }
 
   private var tint: Color {
     wantsHuman ? BeatKindAppearance.dot(.asking) : Theme.paneFocusTint
@@ -66,7 +66,9 @@ struct SummaryGutter: View {
 
   private var hoverText: String {
     let presentation = LoopSummaryPresentation(node: node, now: now)
-    guard !presentation.text.isEmpty else { return "Show the summary rail (⌥G)" }
-    return "\(presentation.text) — ⌥G to show the rail"
+    guard !presentation.text.isEmpty else {
+      return String(localized: "Show the summary rail (⌥G)")
+    }
+    return String(localized: "\(presentation.text) — ⌥G to show the rail")
   }
 }

--- a/graphcode/Sources/Features/LoopWorkspace/SummaryGutter.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/SummaryGutter.swift
@@ -9,8 +9,14 @@ import SwiftUI
 ///
 /// **Hiding never hides the ask.** When the loop wants a human the gutter turns amber and
 /// names it in one word. The card, the sidebar and the titlebar chip are unaffected either
-/// way — attention was never this section's job to report, which is why the colour here is
-/// read off `displayState` and not off the summary.
+/// way — attention was never this section's job to report, which is why the claim here is
+/// read off the graph's own `state` and not off the summary.
+///
+/// `state`, not `displayState`, for the reason `LoopSummaryPresentation` gives at length:
+/// `displayState` turns a running loop into `.awaitingInput` as soon as its session's
+/// presence says so, and Claude Code says so for any notification — including finishing a
+/// turn at an empty prompt. A gutter that went amber and said `ASKS YOU` at that moment
+/// would be the same false alarm the section beside it was just fixed for.
 struct SummaryGutter: View {
   let node: LoopNode
   let now: Date
@@ -18,9 +24,9 @@ struct SummaryGutter: View {
 
   static let width: CGFloat = 26
 
-  private var wantsHuman: Bool { node.displayState.wantsHuman }
+  private var wantsHuman: Bool { node.state.wantsHuman }
 
-  private var label: String { wantsHuman ? "ASKS YOU" : "SUMMARY" }
+  var label: String { wantsHuman ? "ASKS YOU" : "SUMMARY" }
 
   private var tint: Color {
     wantsHuman ? BeatKindAppearance.dot(.asking) : Theme.paneFocusTint

--- a/graphcode/Sources/Features/LoopWorkspace/SummaryGutter.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/SummaryGutter.swift
@@ -1,0 +1,66 @@
+import GraphcodeKit
+import SwiftUI
+
+/// The 26pt strip left at the window's right edge when the rail is hidden.
+///
+/// Hiding the rail gives the terminal the width back; it should not make the loop
+/// unobservable. What survives is the smallest honest thing: the loop's state dot, the
+/// word `SUMMARY` on its side, and the current beat on hover.
+///
+/// **Hiding never hides the ask.** When the loop wants a human the gutter turns amber and
+/// names it in one word. The card, the sidebar and the titlebar chip are unaffected either
+/// way — attention was never this section's job to report, which is why the colour here is
+/// read off `displayState` and not off the summary.
+struct SummaryGutter: View {
+  let node: LoopNode
+  let now: Date
+  let onTapped: () -> Void
+
+  static let width: CGFloat = 26
+
+  private var wantsHuman: Bool { node.displayState.wantsHuman }
+
+  private var label: String { wantsHuman ? "ASKS YOU" : "SUMMARY" }
+
+  private var tint: Color {
+    wantsHuman ? BeatKindAppearance.dot(.asking) : Theme.paneFocusTint
+  }
+
+  var body: some View {
+    VStack(spacing: 10) {
+      Circle().fill(tint).frame(width: 6, height: 6)
+      Text(label)
+        .font(.system(size: 10.5, weight: .bold))
+        .tracking(1.05)
+        .foregroundStyle(
+          wantsHuman
+            ? BeatKindAppearance.ink(.asking) : Color.white.opacity(0.58)
+        )
+        .fixedSize()
+        .rotationEffect(.degrees(90))
+        .frame(width: 12)
+      Spacer(minLength: 0)
+    }
+    .padding(.vertical, 10)
+    .frame(width: Self.width)
+    .frame(maxHeight: .infinity)
+    .background(wantsHuman ? BeatKindAppearance.dot(.asking).opacity(0.14) : Theme.workspaceRail)
+    .overlay(alignment: .leading) {
+      Rectangle()
+        .fill(wantsHuman ? BeatKindAppearance.dot(.asking).opacity(0.4) : .white.opacity(0.07))
+        .frame(width: 1)
+    }
+    .contentShape(Rectangle())
+    .onTapGesture(perform: onTapped)
+    // Hover peeks at the current beat. A tooltip rather than a popover: the gutter exists
+    // because someone wanted the width back, and a panel that springs out of it on hover
+    // would take it again.
+    .help(hoverText)
+  }
+
+  private var hoverText: String {
+    let presentation = LoopSummaryPresentation(node: node, now: now)
+    guard !presentation.text.isEmpty else { return "Show the summary rail (⌥G)" }
+    return "\(presentation.text) — ⌥G to show the rail"
+  }
+}

--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -101,6 +101,34 @@ struct SettingsView: View {
 
       Section {
         Toggle("Show the activity strip", isOn: $model.settings.showsActivityStrip)
+        Toggle(
+          "Summarise what loops are doing (experimental)",
+          isOn: $model.settings.summarisesLoops)
+        Text(
+          "Reads each working session's own transcript and puts what it is doing at the "
+            + "top of the loop's rail — and on its card — as a few short lines instead of "
+            + "a terminal to scroll. Costs nothing: the words are the agent's own. Off, "
+            + "nothing is read and nothing changes. Experimental: a summary is a claim "
+            + "about what an agent is trying to do, and it is worth watching on your own "
+            + "loops before trusting it."
+        )
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+        Toggle("Let a model write the summaries", isOn: $model.settings.summaryUsesModel)
+          .disabled(!model.settings.summarisesLoops)
+        Text(
+          "Sharpens the current line with one short call to your backend's own CLI "
+            + "(claude -p, copilot -p, codex exec) on its fast model, per change, over one "
+            + "sentence — never the transcript. It runs outside the loop's session, so it "
+            + "never lands on that loop's token count, and if it is slow or unavailable "
+            + "the agent's own wording stands. This is the only part of summaries that "
+            + "costs money."
+        )
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
       } footer: {
         Text(
           "A strip along the window's bottom listing passes, hand-offs and state changes "

--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -105,12 +105,8 @@ struct SettingsView: View {
           "Summarise what loops are doing (experimental)",
           isOn: $model.settings.summarisesLoops)
         Text(
-          "Reads each working session's own transcript and puts what it is doing at the "
-            + "top of the loop's rail — and on its card — as a few short lines instead of "
-            + "a terminal to scroll. Costs nothing: the words are the agent's own. Off, "
-            + "nothing is read and nothing changes. Experimental: a summary is a claim "
-            + "about what an agent is trying to do, and it is worth watching on your own "
-            + "loops before trusting it."
+          "What each loop is doing, at the top of its rail, read from the session's own "
+            + "transcript. Costs nothing."
         )
         .font(.caption2)
         .foregroundStyle(.secondary)
@@ -118,17 +114,10 @@ struct SettingsView: View {
 
         Toggle("Let a model write the summaries", isOn: $model.settings.summaryUsesModel)
           .disabled(!model.settings.summarisesLoops)
-        Text(
-          "Sharpens the current line with one short call to your backend's own CLI "
-            + "(claude -p, copilot -p, codex exec) on its fast model, per change, over one "
-            + "sentence — never the transcript. It runs outside the loop's session, so it "
-            + "never lands on that loop's token count, and if it is slow or unavailable "
-            + "the agent's own wording stands. This is the only part of summaries that "
-            + "costs money."
-        )
-        .font(.caption2)
-        .foregroundStyle(.secondary)
-        .fixedSize(horizontal: false, vertical: true)
+        Text("One short call to your backend's CLI per change. The part that costs money.")
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
       } footer: {
         Text(
           "A strip along the window's bottom listing passes, hand-offs and state changes "

--- a/graphcode/Tests/LoopSummarySectionTests.swift
+++ b/graphcode/Tests/LoopSummarySectionTests.swift
@@ -58,7 +58,7 @@ struct LoopSummarySectionTests {
     // Chronological, oldest first — the rail reads in the same direction as the terminal
     // beside it, with the newest at the foot. The current beat is not repeated among them.
     #expect(presentation.receding.map(\.text) == ["Traced totalTokens", "Found the double count"])
-    #expect(presentation.passLabel == "PASS 7")
+    #expect(presentation.pass == 7)
   }
 
   /// The one rule the rail must not break: attention has exactly one source of truth, and

--- a/graphcode/Tests/LoopSummarySectionTests.swift
+++ b/graphcode/Tests/LoopSummarySectionTests.swift
@@ -168,11 +168,38 @@ struct LoopSummarySectionTests {
   /// chrome out of the rail entirely.
   @Test
   func aLoopWithNothingToSayDrawsNoSection() {
-    #expect(LoopSummaryPresentation.hasContent(node: node(summary: nil)) == false)
-    #expect(LoopSummaryPresentation.hasContent(node: node(summary: LoopSummary())) == false)
+    #expect(
+      LoopSummaryPresentation.hasContent(node: node(summary: nil), producing: true) == false)
+    #expect(
+      LoopSummaryPresentation.hasContent(node: node(summary: LoopSummary()), producing: true)
+        == false)
     #expect(
       LoopSummaryPresentation.hasContent(
-        node: node(summary: LoopSummary(beats: [beat(1, "Reading", at: 1)]))) == true)
+        node: node(summary: LoopSummary(beats: [beat(1, "Reading", at: 1)])), producing: true)
+        == true)
+  }
+
+  /// Switching the producer off has to empty the rail *now*, not at the next poll.
+  ///
+  /// The daemon clears the node itself, and until that lands — or on a graph file written
+  /// by a build that cleared nothing — the beats are still there. A section drawn from
+  /// them is a reading from a feature the human has switched off, expanded or folded, and
+  /// the gutter that survives hiding the rail is drawn from the same answer.
+  @Test
+  func nothingIsDrawnFromBeatsLeftBehindByAProducerThatIsOff() {
+    let stale = node(summary: LoopSummary(beats: [beat(3, "Reading the probe", at: 1)]))
+
+    #expect(LoopSummaryPresentation.hasContent(node: stale, producing: false) == false)
+    #expect(
+      LoopWorkspaceRail.hasContent(
+        node: stale, graph: LoopGraph(scope: LoopGraphScope(projectPath: "/tmp/p", name: "p")),
+        summarising: false) == false)
+
+    // And the card goes back to the line it had before the experiment was ever switched on.
+    var card = stale
+    card.activity = "reading UsageProbe.swift"
+    #expect(
+      LoopCardPresentation(node: card, summarising: false).liveLine == "reading UsageProbe.swift")
   }
 
   // MARK: - The card
@@ -186,7 +213,8 @@ struct LoopSummarySectionTests {
     ]
 
     #expect(
-      LoopCardPresentation(node: node).liveLine == "pass 2 · Working out the double count")
+      LoopCardPresentation(node: node, summarising: true).liveLine
+        == "pass 2 · Working out the double count")
   }
 
   /// With the producer off there is no summary, and the card says exactly what it said

--- a/graphcode/Tests/LoopSummarySectionTests.swift
+++ b/graphcode/Tests/LoopSummarySectionTests.swift
@@ -55,8 +55,9 @@ struct LoopSummarySectionTests {
     #expect(presentation.mode == .working)
     #expect(presentation.text == "Working out why cached tokens double-count")
     #expect(presentation.elapsed == "1m")
-    // Newest first behind it, and the current beat is not repeated among them.
-    #expect(presentation.receding.map(\.text) == ["Found the double count", "Traced totalTokens"])
+    // Chronological, oldest first — the rail reads in the same direction as the terminal
+    // beside it, with the newest at the foot. The current beat is not repeated among them.
+    #expect(presentation.receding.map(\.text) == ["Traced totalTokens", "Found the double count"])
     #expect(presentation.passLabel == "PASS 7")
   }
 
@@ -109,6 +110,18 @@ struct LoopSummarySectionTests {
     // Never left: no hairline at all rather than a section marked all-new.
     let first = LoopSummaryPresentation(node: node(summary: summary), now: now)
     #expect(first.unseen == 0)
+  }
+
+  /// The rail is draggable now that a beat is prose rather than a chip, and the stored
+  /// width has to survive both a hand that overshoots and a defaults file with nothing in
+  /// it — a rail 8 points wide is one nobody can get back.
+  @Test
+  func theRailsWidthIsBoundedWhateverItIsHanded() {
+    #expect(LoopWorkspaceRail.clamped(40) == LoopWorkspaceRail.minimumWidth)
+    #expect(LoopWorkspaceRail.clamped(4000) == LoopWorkspaceRail.maximumWidth)
+    #expect(LoopWorkspaceRail.clamped(300) == 300)
+    #expect(LoopWorkspaceRail.defaultWidth >= LoopWorkspaceRail.minimumWidth)
+    #expect(LoopWorkspaceRail.defaultWidth <= LoopWorkspaceRail.maximumWidth)
   }
 
   /// A rail must never render an empty section — the argument that already keeps blank

--- a/graphcode/Tests/LoopSummarySectionTests.swift
+++ b/graphcode/Tests/LoopSummarySectionTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// What the summary section says in each of the four states the design names, and what
+/// the card does with a beat.
+///
+/// Tested as a value rather than through the view, the way `LoopCardPresentationTests` is:
+/// the judgements here are which state wins, where the "since you looked" line falls, and
+/// whether the rail can appear empty. None of that needs pixels.
+@Suite
+struct LoopSummarySectionTests {
+  private func beat(
+    _ pass: Int, _ text: String, kind: BeatKind = .reading, at seconds: Int
+  ) -> SummaryBeat {
+    SummaryBeat(
+      id: "p\(pass)-\(seconds)", at: Date(timeIntervalSince1970: Double(seconds)), pass: pass,
+      kind: kind, text: text)
+  }
+
+  private func node(
+    summary: LoopSummary?, state: LoopState = .running, presence: Presence? = .busy
+  ) -> LoopNode {
+    var node = LoopNode(title: "Usage", loopType: .goalBased, state: state)
+    node.summary = summary
+    if let presence {
+      node.presence = PresenceReading(presence: presence, confidence: .reported)
+    }
+    return node
+  }
+
+  private let now = Date(timeIntervalSince1970: 1000)
+
+  @Test
+  func aSessionThatHasNotSpokenYetIsHonestAboutIt() {
+    let presentation = LoopSummaryPresentation(node: node(summary: nil), now: now)
+
+    #expect(presentation.mode == .starting)
+    #expect(presentation.text == "Getting its bearings")
+    #expect(presentation.evidence == "first beat lands in a moment")
+  }
+
+  @Test
+  func theCurrentBeatIsTheOnlyThingAtFullSize() {
+    let summary = LoopSummary(beats: [
+      beat(7, "Traced totalTokens", at: 100),
+      beat(7, "Found the double count", kind: .found, at: 200),
+      beat(7, "Working out why cached tokens double-count", at: 940),
+    ])
+
+    let presentation = LoopSummaryPresentation(node: node(summary: summary), now: now)
+
+    #expect(presentation.mode == .working)
+    #expect(presentation.text == "Working out why cached tokens double-count")
+    #expect(presentation.elapsed == "1m")
+    // Newest first behind it, and the current beat is not repeated among them.
+    #expect(presentation.receding.map(\.text) == ["Found the double count", "Traced totalTokens"])
+    #expect(presentation.passLabel == "PASS 7")
+  }
+
+  /// The one rule the rail must not break: attention has exactly one source of truth, and
+  /// it is not the summary.
+  @Test
+  func askingIsReadOffTheLoopsStateNotOffItsBeats() {
+    let summary = LoopSummary(beats: [beat(2, "Reading the probe", at: 900)])
+
+    let asking = LoopSummaryPresentation(
+      node: node(summary: summary, state: .awaitingInput), now: now)
+    #expect(asking.mode == .asking)
+    #expect(asking.kind == .asking)
+    // The beat is still the text — a question is just what the loop is doing now.
+    #expect(asking.text == "Reading the probe")
+
+    let working = LoopSummaryPresentation(node: node(summary: summary), now: now)
+    #expect(working.mode == .working)
+  }
+
+  @Test
+  func aResolvedLoopBecomesTheAccountOfItsRun() {
+    var resolved = node(
+      summary: LoopSummary(beats: [beat(7, "Cached reads no longer double-count", at: 900)]),
+      state: .succeeded, presence: nil)
+    resolved.metricHistory = (0..<7).map {
+      MetricSample(
+        value: 1400 - Double($0) * 50, recordedAt: Date(timeIntervalSince1970: Double($0)))
+    }
+
+    let presentation = LoopSummaryPresentation(node: resolved, now: now)
+
+    #expect(presentation.mode == .resolved)
+    #expect(presentation.kind == .done)
+    #expect(presentation.text == "Cached reads no longer double-count")
+    #expect(presentation.evidence?.hasPrefix("7 passes · 1.4k → 1.1k · ") == true)
+  }
+
+  @Test
+  func theHairlineFallsWhereTheWindowLastLeftOff() {
+    let summary = LoopSummary(beats: [
+      beat(7, "oldest", at: 100), beat(7, "middle", at: 200), beat(7, "newest", at: 300),
+    ])
+
+    // Left when "oldest" was current: the two after it are unseen.
+    let returning = LoopSummaryPresentation(
+      node: node(summary: summary), now: now, seenBeatID: "p7-100")
+    #expect(returning.unseen == 2)
+
+    // Never left: no hairline at all rather than a section marked all-new.
+    let first = LoopSummaryPresentation(node: node(summary: summary), now: now)
+    #expect(first.unseen == 0)
+  }
+
+  /// A rail must never render an empty section — the argument that already keeps blank
+  /// chrome out of the rail entirely.
+  @Test
+  func aLoopWithNothingToSayDrawsNoSection() {
+    #expect(LoopSummaryPresentation.hasContent(node: node(summary: nil)) == false)
+    #expect(LoopSummaryPresentation.hasContent(node: node(summary: LoopSummary())) == false)
+    #expect(
+      LoopSummaryPresentation.hasContent(
+        node: node(summary: LoopSummary(beats: [beat(1, "Reading", at: 1)]))) == true)
+  }
+
+  // MARK: - The card
+
+  @Test
+  func theCardsLiveLinePrefersTheNewestBeat() {
+    var node = node(summary: LoopSummary(beats: [beat(7, "Working out the double count", at: 1)]))
+    node.activity = "reading UsageProbe.swift"
+    node.metricHistory = [
+      MetricSample(value: 1, recordedAt: Date()), MetricSample(value: 2, recordedAt: Date()),
+    ]
+
+    #expect(
+      LoopCardPresentation(node: node).liveLine == "pass 2 · Working out the double count")
+  }
+
+  /// With the producer off there is no summary, and the card says exactly what it said
+  /// before this feature existed.
+  @Test
+  func theCardFallsBackWhenNothingIsSummarising() {
+    var node = node(summary: nil)
+    node.activity = "reading UsageProbe.swift"
+    #expect(LoopCardPresentation(node: node).liveLine == "reading UsageProbe.swift")
+
+    var handed = LoopNode(
+      title: "Usage", loopType: .goalBased,
+      goal: GoalSpec(summary: "tokens per request under 1.2k", metricCommand: "./m.sh"),
+      state: .running)
+    handed.summary = nil
+    #expect(LoopCardPresentation(node: handed).liveLine == "tokens per request under 1.2k")
+  }
+}

--- a/graphcode/Tests/LoopSummarySectionTests.swift
+++ b/graphcode/Tests/LoopSummarySectionTests.swift
@@ -100,6 +100,10 @@ struct LoopSummarySectionTests {
     // A loop the graph really has parked on a human still wears amber.
     let asking = node(summary: summary, state: .awaitingInput, presence: .awaitingInput)
     #expect(LoopSummaryPresentation(node: asking, now: now).mode == .asking)
+    // And the gutter the rail collapses to makes the same split, or hiding the rail would
+    // reintroduce the false alarm at 26 points wide.
+    #expect(SummaryGutter(node: quiet, now: now, onTapped: {}).label == "SUMMARY")
+    #expect(SummaryGutter(node: asking, now: now, onTapped: {}).label == "ASKS YOU")
   }
 
   @Test
@@ -130,10 +134,22 @@ struct LoopSummarySectionTests {
     let returning = LoopSummaryPresentation(
       node: node(summary: summary), now: now, seenBeatID: "p7-100")
     #expect(returning.unseen == 2)
+    // Only one of them is a *row*: "newest" is the block under them, not a row above it.
+    // Counting rows off `unseen` drew the hairline above "oldest" — the one beat the
+    // human had demonstrably read.
+    #expect(returning.unseenRows == 1)
+
+    // Back after only the current beat changed: no row is unseen, and the section puts
+    // the hairline at the foot rather than dropping it.
+    let justOne = LoopSummaryPresentation(
+      node: node(summary: summary), now: now, seenBeatID: "p7-200")
+    #expect(justOne.unseen == 1)
+    #expect(justOne.unseenRows == 0)
 
     // Never left: no hairline at all rather than a section marked all-new.
     let first = LoopSummaryPresentation(node: node(summary: summary), now: now)
     #expect(first.unseen == 0)
+    #expect(first.unseenRows == 0)
   }
 
   /// The rail is draggable now that a beat is prose rather than a chip, and the stored

--- a/graphcode/Tests/LoopSummarySectionTests.swift
+++ b/graphcode/Tests/LoopSummarySectionTests.swift
@@ -78,6 +78,30 @@ struct LoopSummarySectionTests {
     #expect(working.mode == .working)
   }
 
+  /// The fault this caught in the field: an amber block and an `Answer it` button over a
+  /// loop that had asked nothing.
+  ///
+  /// `displayState` turns a *running* loop into `.awaitingInput` as soon as its session's
+  /// presence says so, and Claude Code reports that for any `Notification` — including
+  /// finishing a turn and sitting at an empty prompt. `LoopCardPresentation` has always
+  /// taken its word from `displayState` and its affordance from `state`; the rail must
+  /// make the same split or it offers an answer to a question nobody asked.
+  @Test
+  func aSessionQuietAtItsPromptIsNotAskingAnything() {
+    let summary = LoopSummary(beats: [beat(3, "Clean. Rebuilding Release", at: 900)])
+    let quiet = node(summary: summary, state: .running, presence: .awaitingInput)
+
+    // The graph's own state still says running, so nothing is being asked.
+    #expect(quiet.displayState == .awaitingInput)
+    #expect(LoopSummaryPresentation(node: quiet, now: now).mode == .working)
+    // And it is not live, so the section says LAST DID rather than claiming the present.
+    #expect(LoopSummaryPresentation(node: quiet, now: now).isLive == false)
+
+    // A loop the graph really has parked on a human still wears amber.
+    let asking = node(summary: summary, state: .awaitingInput, presence: .awaitingInput)
+    #expect(LoopSummaryPresentation(node: asking, now: now).mode == .asking)
+  }
+
   @Test
   func aResolvedLoopBecomesTheAccountOfItsRun() {
     var resolved = node(

--- a/graphcode/Tests/PresencePollingTests.swift
+++ b/graphcode/Tests/PresencePollingTests.swift
@@ -221,6 +221,54 @@ struct PresencePollingTests {
     #expect(await store.graph.nodes.first?.activity == "running make check")
   }
 
+  // MARK: - The rail's own reading
+
+  /// Switching the summary producer off has to empty the nodes it filled.
+  ///
+  /// The reader answers `nil` for a transcript that has not moved and an *empty* reading
+  /// when it will not be narrating at all, and only the second clears. Without the split,
+  /// turning the experiment off left a beat frozen on every card — outranking the live
+  /// activity line it had been standing in for — until each loop was deleted.
+  @Test
+  func turningTheProducerOffEmptiesEveryNodeItFilled() async {
+    let presence = Probe()
+    await presence.answer("A", with: .busy)
+    let beat = SummaryBeat(
+      id: "b-1", at: Date(timeIntervalSince1970: 1), pass: 1, kind: .reading,
+      text: "Reading the probe")
+    let readings = ReadingProbe(
+      SummaryReading(beats: [beat], turns: [Date(timeIntervalSince1970: 0)]))
+    let store = GraphStore(
+      graph: graph([node("A", .running), node("done", .succeeded)]),
+      onReadSummary: { _, _ in await readings.read() },
+      onReadPresence: { node, _ in await presence.read(node) })
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    #expect(await store.graph.nodes.first?.summary?.current?.text == "Reading the probe")
+
+    // A poll with nothing new to say leaves it standing — the end of a turn is exactly
+    // when a rail is worth reading.
+    await readings.setAnswer(nil)
+    await store.pollPresence()
+    #expect(await store.graph.nodes.first?.summary?.current?.text == "Reading the probe")
+
+    await readings.setAnswer(SummaryReading(beats: []))
+    await store.pollPresence()
+    #expect(await store.graph.nodes.first?.summary == nil)
+  }
+
+  private actor ReadingProbe {
+    private var answer: SummaryReading?
+
+    init(_ answer: SummaryReading?) { self.answer = answer }
+
+    func setAnswer(_ reading: SummaryReading?) { answer = reading }
+
+    func read() -> SummaryReading? { answer }
+  }
+
   @Test
   func theIntervalIsSlowEnoughToBeBackgroundNoise() {
     // Fifteen seconds is the lag a human sees between a loop finishing and its card

--- a/graphcode/Tests/SummaryRailTests.swift
+++ b/graphcode/Tests/SummaryRailTests.swift
@@ -309,6 +309,16 @@ struct SummaryRailTests {
     #expect(
       SummaryBeatBuilder.condense("Tracing total_tokens through the probe")
         == "Tracing total_tokens through the probe")
+    // A one-word verdict is a preamble, not a beat: stopping at the full stop put "Clean"
+    // alone in the rail and threw away the half that said what was happening. Seen on a
+    // real loop.
+    #expect(
+      SummaryBeatBuilder.condense("Clean. Rebuilding Release and reinstalling.")
+        == "Clean. Rebuilding Release and reinstalling")
+    // A full opening sentence still stands alone.
+    #expect(
+      SummaryBeatBuilder.condense("Found the double count. Now fixing it.")
+        == "Found the double count")
     #expect(SummaryBeatBuilder.condense("   ") == nil)
     let long = SummaryBeatBuilder.condense(
       "One two three four five six seven eight nine ten eleven twelve")

--- a/graphcode/Tests/SummaryRailTests.swift
+++ b/graphcode/Tests/SummaryRailTests.swift
@@ -154,6 +154,31 @@ struct SummaryRailTests {
     #expect(beats[1].kind == .found)
   }
 
+  /// A beat that greps twice and then writes a file is an edit, and naming it after the
+  /// grep puts a search string under the word EDITING.
+  @Test
+  func evidenceNamesACallOfTheBeatsOwnKind() throws {
+    let root = try temporaryRoot("claude-evidence")
+    let url = try log(
+      [
+        try claudeUser("fix the double count", at: 0),
+        try claudeAssistant(
+          text: "Rewriting aggregate to skip cached reads.",
+          tools: [
+            ("Grep", ["pattern": "totalTokens"]),
+            ("Grep", ["pattern": "isBillable"]),
+            ("Edit", ["file_path": "/repo/UsageProbe.swift"]),
+            ("Edit", ["file_path": "/repo/UsageSample.swift"]),
+          ], at: 1),
+      ], named: "session.jsonl", in: root)
+
+    let beats = ClaudeSessionLog.beats(inTranscriptAt: url)
+
+    #expect(beats[0].kind == .editing)
+    // The first *edit*, and a count of the edits — not of the greps that led to them.
+    #expect(beats[0].evidence == "UsageProbe.swift · 2 edits")
+  }
+
   @Test
   func claudeToolPhrasesMatchTheHookScriptsVocabulary() {
     #expect(
@@ -273,6 +298,17 @@ struct SummaryRailTests {
     #expect(
       SummaryBeatBuilder.condense("Reading UsageProbe.swift now")
         == "Reading UsageProbe.swift now")
+    // Agents narrate in markdown and the rail draws plain text. A bold run inside a
+    // sentence is not a header, so `boldHeader` never sees it and its asterisks reached
+    // the rail — caught on a real transcript, not imagined.
+    #expect(
+      SummaryBeatBuilder.condense("**No LLM call** — nothing shells out to `claude -p`")
+        == "No LLM call — nothing shells out to claude -p")
+    // A lone underscore is left alone: an identifier is likelier than emphasis, and the
+    // name is the one thing a beat has to get right.
+    #expect(
+      SummaryBeatBuilder.condense("Tracing total_tokens through the probe")
+        == "Tracing total_tokens through the probe")
     #expect(SummaryBeatBuilder.condense("   ") == nil)
     let long = SummaryBeatBuilder.condense(
       "One two three four five six seven eight nine ten eleven twelve")

--- a/graphcode/Tests/SummaryRailTests.swift
+++ b/graphcode/Tests/SummaryRailTests.swift
@@ -1,0 +1,281 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// The summary rail's producer: what a loop is doing, read out of the transcript its own
+/// backend already writes.
+///
+/// Every fixture here is shaped after a real record taken off this machine's
+/// `~/.claude/projects`, `~/.codex/sessions` and `~/.copilot/session-state` — keys and
+/// nesting included, as `BackendActivityTests` does, because a hand-invented schema tests
+/// the parser against nothing.
+@Suite
+struct SummaryRailTests {
+  private func temporaryRoot(_ prefix: String) throws -> URL {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+  }
+
+  private func log(_ lines: [String], named name: String, in root: URL) throws -> URL {
+    let url = root.appendingPathComponent(name)
+    try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+    return url
+  }
+
+  private func line(_ object: [String: Any]) throws -> String {
+    String(decoding: try JSONSerialization.data(withJSONObject: object), as: UTF8.self)
+  }
+
+  private func stamp(_ seconds: Int) -> String {
+    let date = Date(timeIntervalSince1970: 1_777_000_000 + Double(seconds))
+    return SummaryBeatBuilder.timestampFormatter.string(from: date)
+  }
+
+  // MARK: - Claude Code
+
+  private func claudeUser(_ text: String, at seconds: Int) throws -> String {
+    try line([
+      "type": "user", "timestamp": stamp(seconds),
+      "message": ["role": "user", "content": text],
+    ])
+  }
+
+  private func claudeToolResult(_ id: String, at seconds: Int) throws -> String {
+    try line([
+      "type": "user", "timestamp": stamp(seconds),
+      "message": [
+        "role": "user",
+        "content": [["type": "tool_result", "tool_use_id": id, "content": "ok"]],
+      ],
+    ])
+  }
+
+  private func claudeAssistant(
+    text: String? = nil, tools: [(String, [String: Any])] = [], at seconds: Int,
+    isSidechain: Bool = false
+  ) throws -> String {
+    var content: [[String: Any]] = []
+    if let text { content.append(["type": "text", "text": text]) }
+    for (name, input) in tools {
+      content.append(["type": "tool_use", "name": name, "input": input, "id": "t\(name)"])
+    }
+    return try line([
+      "type": "assistant", "timestamp": stamp(seconds), "isSidechain": isSidechain,
+      "message": ["role": "assistant", "content": content],
+    ])
+  }
+
+  @Test
+  func aClaudeNarrationBecomesTheBeatAndItsToolCallsBecomeTheEvidence() throws {
+    let root = try temporaryRoot("claude-beats")
+    let url = try log(
+      [
+        try claudeUser("Find why cached tokens double-count", at: 0),
+        try claudeAssistant(
+          text: "Working out why cached tokens get counted twice.",
+          tools: [
+            ("Read", ["file_path": "/repo/GraphcodeKit/Sources/Sessions/UsageProbe.swift"]),
+            ("Read", ["file_path": "/repo/GraphcodeKit/Sources/Domain/UsageSample.swift"]),
+            ("Read", ["file_path": "/repo/CostRollup.swift"]),
+          ], at: 10),
+      ], named: "session.jsonl", in: root)
+
+    let beats = ClaudeSessionLog.beats(inTranscriptAt: url)
+
+    #expect(beats.count == 1)
+    #expect(beats[0].text == "Working out why cached tokens get counted twice")
+    #expect(beats[0].kind == .reading)
+    #expect(beats[0].evidence == "UsageProbe.swift · 3 files read")
+    #expect(beats[0].pass == 1)
+  }
+
+  /// The rule the whole feature rests on: a beat is a shift in intent, not a tool call.
+  @Test
+  func twentyGrepsInARowAreOneBeat() throws {
+    let root = try temporaryRoot("claude-greps")
+    var lines = [try claudeUser("Trace totalTokens", at: 0)]
+    lines.append(
+      try claudeAssistant(text: "Tracing totalTokens through the probe.", at: 1))
+    for index in 0..<20 {
+      lines.append(
+        try claudeAssistant(tools: [("Grep", ["pattern": "totalTokens\(index)"])], at: 2 + index))
+      lines.append(try claudeToolResult("t\(index)", at: 2 + index))
+    }
+
+    let beats = ClaudeSessionLog.beats(
+      inTranscriptAt: try log(lines, named: "session.jsonl", in: root))
+
+    #expect(beats.count == 1)
+    #expect(beats[0].text == "Tracing totalTokens through the probe")
+    #expect(beats[0].evidence == "totalTokens0 · 20 files read")
+    // Twenty tool results wearing the user role are not twenty passes.
+    #expect(beats[0].pass == 1)
+  }
+
+  /// A `Task` sub-agent writes its whole conversation into the same file. Narrating it
+  /// would put the sub-agent's work on the parent's rail while the parent's own beat says
+  /// "delegating".
+  @Test
+  func sidechainsDoNotNarrateTheParentLoop() throws {
+    let root = try temporaryRoot("claude-sidechain")
+    let url = try log(
+      [
+        try claudeUser("Audit the store", at: 0),
+        try claudeAssistant(
+          text: "Delegating the sweep.", tools: [("Task", ["description": "sweep sources"])],
+          at: 1),
+        try claudeAssistant(
+          text: "Reading every file in Sources.", at: 2, isSidechain: true),
+      ], named: "session.jsonl", in: root)
+
+    let beats = ClaudeSessionLog.beats(inTranscriptAt: url)
+
+    #expect(beats.map(\.text) == ["Delegating the sweep"])
+  }
+
+  @Test
+  func aPassIsAUserTurn() throws {
+    let root = try temporaryRoot("claude-passes")
+    let url = try log(
+      [
+        try claudeUser("first", at: 0),
+        try claudeAssistant(text: "Trimmed the system preamble.", at: 1),
+        try claudeUser("go again", at: 2),
+        try claudeAssistant(text: "Found the double count in aggregate.", at: 3),
+      ], named: "session.jsonl", in: root)
+
+    let beats = ClaudeSessionLog.beats(inTranscriptAt: url)
+
+    #expect(beats.map(\.pass) == [1, 2])
+    // A past-tense discovery is a finding, which is what earns the green dot.
+    #expect(beats[1].kind == .found)
+  }
+
+  @Test
+  func claudeToolPhrasesMatchTheHookScriptsVocabulary() {
+    #expect(
+      ClaudeSessionLog.phrase(forTool: "Edit", input: ["file_path": "/repo/LoopNode.swift"])
+        == "editing LoopNode.swift")
+    #expect(
+      ClaudeSessionLog.phrase(forTool: "Bash", input: ["command": "make check"])
+        == "running make check")
+    #expect(
+      ClaudeSessionLog.phrase(forTool: "Grep", input: ["pattern": "refreshActivity"])
+        == "searching for refreshActivity")
+    // A recognised tool whose input isn't the shape expected names itself rather than
+    // going quiet — the fallback all three readers share.
+    #expect(ClaudeSessionLog.phrase(forTool: "Read", input: [:]) == "using Read")
+  }
+
+  @Test
+  func theTranscriptIsFoundByTheSessionIDGraphcodeBanked() throws {
+    let root = try temporaryRoot("claude-projects")
+    let project = root.appendingPathComponent("-repo-worktree", isDirectory: true)
+    try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+    let sessionID = UUID().uuidString
+    _ = try log([try claudeUser("go", at: 0)], named: "\(sessionID).jsonl", in: project)
+
+    let previous = ClaudeSessionLog.projectsDirectory
+    ClaudeSessionLog.projectsDirectory = root
+    defer { ClaudeSessionLog.projectsDirectory = previous }
+
+    #expect(
+      ClaudeSessionLog.transcript(forSessionID: sessionID)?.lastPathComponent
+        == "\(sessionID).jsonl")
+    #expect(ClaudeSessionLog.transcript(forSessionID: UUID().uuidString) == nil)
+  }
+
+  // MARK: - Codex
+
+  @Test
+  func codexReasoningHeadersAreAlreadyBeats() throws {
+    let root = try temporaryRoot("codex-beats")
+    let url = try log(
+      [
+        try line([
+          "type": "event_msg", "timestamp": stamp(0),
+          "payload": ["type": "user_message", "message": "look at the probe"],
+        ]),
+        try line([
+          "type": "event_msg", "timestamp": stamp(5),
+          "payload": [
+            "type": "agent_reasoning",
+            "text":
+              "**Planning code mode inspection**\n\nI'm preparing to inspect the repo with "
+              + "ripgrep to locate where agents are defined, aiming to clarify the source.",
+          ],
+        ]),
+        try line([
+          "type": "response_item", "timestamp": stamp(6),
+          "payload": [
+            "type": "function_call", "name": "shell", "call_id": "c1",
+            "arguments": "{\"command\":\"rg totalTokens\"}",
+          ],
+        ]),
+      ], named: "rollout.jsonl", in: root)
+
+    let beats = CodexSessionLog.beats(inRolloutAt: url)
+
+    // The bolded header wins over the paragraph under it: it is already one line of
+    // intent, and the paragraph is already three.
+    #expect(beats.map(\.text) == ["Planning code mode inspection"])
+    #expect(beats[0].kind == .running)
+    #expect(beats[0].evidence == "rg totalTokens")
+  }
+
+  // MARK: - Copilot
+
+  @Test
+  func copilotAssistantMessagesAreTheNarration() throws {
+    let root = try temporaryRoot("copilot-beats")
+    let url = try log(
+      [
+        try line(["type": "user.message", "timestamp": stamp(0), "data": ["content": "go"]]),
+        try line([
+          "type": "assistant.message", "timestamp": stamp(1),
+          "data": [
+            "content":
+              "Running a short shell that starts two concurrent loops. Running it now.",
+            "model": "gpt-5-mini",
+          ],
+        ]),
+        try line([
+          "type": "tool.execution_start", "timestamp": stamp(2),
+          "data": [
+            "toolCallId": "call_1", "toolName": "bash",
+            "arguments": ["command": "bash -lc 'true'", "description": "Spin two loops"],
+          ],
+        ]),
+      ], named: "events.jsonl", in: root)
+
+    let beats = CopilotSessionLog.beats(inLogAt: url)
+
+    #expect(beats.map(\.text) == ["Running a short shell that starts two concurrent loops"])
+    #expect(beats[0].kind == .running)
+    // Copilot's own description of the call, which is a better line than the command.
+    #expect(beats[0].evidence == "Spin two loops")
+  }
+
+  // MARK: - Condensing
+
+  @Test
+  func beatsAreOneShortSentenceInTheAgentsOwnWords() {
+    #expect(
+      SummaryBeatBuilder.condense("Now let me read the design HTML and the rail.")
+        == "Let me read the design HTML and the rail")
+    #expect(
+      SummaryBeatBuilder.condense("**Checking for hidden files**") == "Checking for hidden files")
+    // A file name is not a sentence boundary — the extension is the evidence the beat
+    // carries.
+    #expect(
+      SummaryBeatBuilder.condense("Reading UsageProbe.swift now")
+        == "Reading UsageProbe.swift now")
+    #expect(SummaryBeatBuilder.condense("   ") == nil)
+    let long = SummaryBeatBuilder.condense(
+      "One two three four five six seven eight nine ten eleven twelve")
+    #expect(long == "One two three four five six seven eight nine ten…")
+  }
+}

--- a/graphcode/Tests/SummaryRailTests.swift
+++ b/graphcode/Tests/SummaryRailTests.swift
@@ -324,4 +324,25 @@ struct SummaryRailTests {
       "One two three four five six seven eight nine ten eleven twelve")
     #expect(long == "One two three four five six seven eight nine ten…")
   }
+
+  /// Both of these were read straight off a live loop's rail, not imagined.
+  @Test
+  func aLinksAddressNeverReachesTheRailAndNoWordIsCutInHalf() {
+    // The label is the words; the address is not one of them.
+    #expect(
+      SummaryBeatBuilder.condense(
+        "Posted. Live on [@cgopireddy](https://www.threads.com/@cgopireddy)")
+        == "Posted. Live on @cgopireddy")
+    #expect(
+      SummaryBeatBuilder.stripLinks("see [a](x) and [b](y)") == "see a and b")
+    // A cut through the middle of a word reads as a rendering fault rather than a summary.
+    let cut = SummaryBeatBuilder.truncate(
+      "Blocked on login because the browser has no Threads or Instagram session",
+      words: 20, characters: 64)
+    #expect(cut == "Blocked on login because the browser has no Threads or…")
+    // Unless the word itself is longer than the line, where a hard cut is the only answer.
+    #expect(
+      SummaryBeatBuilder.truncate(String(repeating: "x", count: 40), words: 10, characters: 10)
+        == "xxxxxxxxxx…")
+  }
 }

--- a/graphcode/Tests/SummaryStoreTests.swift
+++ b/graphcode/Tests/SummaryStoreTests.swift
@@ -97,6 +97,34 @@ struct SummaryStoreTests {
     #expect(summary.currentPass == 4)
   }
 
+  /// The section's only number has to belong to the pass it is printed under.
+  ///
+  /// Keying the metric series by position — sample *n* to pass *n* — holds for a `/loop`
+  /// waking on a timer and breaks the moment a human types twice in one pass: the movement
+  /// shown is real, and the pass it is shown under is not the one it happened in. Matching
+  /// on when the sample was taken cannot be wrong that way.
+  @Test
+  func aMetricMovementBelongsToThePassItHappenedIn() {
+    let samples = [
+      MetricSample(value: 1400, recordedAt: at(1)),
+      MetricSample(value: 1300, recordedAt: at(9)),
+    ]
+    var summary = LoopSummary()
+    summary.merge(
+      SummaryBeatBuilder.reading(
+        from: [
+          beat(1, "Read the probe", at: 2),
+          beat(2, "Trimmed the preamble", at: 10),
+          beat(3, "Working on the next thing", at: 20),
+        ],
+        turns: [at(0), at(8), at(18)], metricSamples: samples))
+
+    // Pass 1 ends before the second sample: nothing moved inside it yet.
+    #expect(summary.passes.first(where: { $0.pass == 1 })?.delta == nil)
+    // Pass 2 is the one the metric moved in.
+    #expect(summary.passes.first(where: { $0.pass == 2 })?.delta == "1.4k → 1.3k")
+  }
+
   /// A reader whose tail window has moved past a pass must not be able to rewrite what the
   /// store already recorded for it.
   @Test

--- a/graphcode/Tests/SummaryStoreTests.swift
+++ b/graphcode/Tests/SummaryStoreTests.swift
@@ -13,18 +13,21 @@ struct SummaryStoreTests {
 
   private func beat(_ pass: Int, _ text: String, at seconds: Int) -> SummaryBeat {
     SummaryBeat(
-      id: "p\(pass)-\(seconds)", at: Date(timeIntervalSince1970: Double(seconds)), pass: pass,
+      id: "b-\(seconds)", at: Date(timeIntervalSince1970: Double(seconds)), pass: pass,
       kind: .reading, text: text)
   }
 
+  private func at(_ seconds: Int) -> Date { Date(timeIntervalSince1970: Double(seconds)) }
+
   @Test
   func aPassBoundaryCollapsesItsBeatsToOneLineAndDropsTheRest() {
-    let reading = SummaryBeatBuilder.reading(from: [
-      beat(1, "Read the probe", at: 1),
-      beat(1, "Traced totalTokens", at: 2),
-      beat(1, "Trimmed the system preamble", at: 3),
-      beat(2, "Working out why cached tokens double-count", at: 4),
-    ])
+    let reading = SummaryBeatBuilder.reading(
+      from: [
+        beat(1, "Read the probe", at: 1),
+        beat(1, "Traced totalTokens", at: 2),
+        beat(1, "Trimmed the system preamble", at: 3),
+        beat(2, "Working out why cached tokens double-count", at: 5),
+      ], turns: [at(0), at(4)])
 
     #expect(reading.finishedPasses.map(\.text) == ["Trimmed the system preamble"])
     #expect(reading.beats.map(\.text) == ["Working out why cached tokens double-count"])
@@ -33,6 +36,7 @@ struct SummaryStoreTests {
     summary.merge(reading)
     #expect(summary.passes.map(\.pass) == [1])
     #expect(summary.beats.count == 1)
+    #expect(summary.currentPass == 2)
   }
 
   /// The bounding claim the whole design rests on: a six-hour loop and a six-minute one
@@ -41,16 +45,56 @@ struct SummaryStoreTests {
   func theStoreStaysBoundedAcrossAFiveHundredBeatRun() {
     var summary = LoopSummary()
     var beats: [SummaryBeat] = []
+    var turns: [Date] = []
     for index in 0..<500 {
+      if index % 5 == 0 { turns.append(at(index)) }
       beats.append(beat(index / 5 + 1, "beat \(index)", at: index))
-      // Merge each poll's view of the tail, the way `GraphStore.refreshSummary` does.
-      summary.merge(SummaryBeatBuilder.reading(from: Array(beats.suffix(40))))
+      // Merge each poll's view of the tail, the way `GraphStore.refreshSummary` does —
+      // window and all, since the window is what slides past the older turns.
+      let window = Array(beats.suffix(40))
+      summary.merge(
+        SummaryBeatBuilder.reading(
+          from: window,
+          turns: turns.filter { $0 >= window[0].at }))
       #expect(summary.beats.count <= LoopSummary.maxBeats)
       #expect(summary.passes.count <= LoopSummary.maxPassSummaries)
     }
+    #expect(summary.currentPass == 100)
     #expect(summary.earlierPasses > 90)
     // Everything ever seen is still accounted for, as a number rather than as rows.
     #expect(summary.earlierPasses + summary.passes.count == 99)
+  }
+
+  /// The number `PASS 7` prints has to be the loop's own, not the tail read's.
+  ///
+  /// Measured, not supposed: a transcript on this machine reaches a hundred megabytes and
+  /// the tail read is half of one, so a session on its forty-first turn shows ten of them
+  /// — and the count walks *backwards* as the file grows. The store counts a turn once,
+  /// when it first sees one newer than the last it counted, and everything a window says
+  /// is shifted onto that.
+  @Test
+  func passNumbersSurviveTheWindowSlidingPastTheTurnThatOpenedThem() {
+    var summary = LoopSummary()
+    // A window that still reaches the session's start: three turns, three passes.
+    summary.merge(
+      SummaryBeatBuilder.reading(
+        from: [beat(1, "one", at: 1), beat(2, "two", at: 3), beat(3, "three", at: 5)],
+        turns: [at(0), at(2), at(4)]))
+    #expect(summary.currentPass == 3)
+
+    // The same session later. The window has slid: the first two turns are out of it, so
+    // the reader calls the newest pass 2 — and a fourth turn has landed since.
+    summary.merge(
+      SummaryBeatBuilder.reading(
+        from: [beat(1, "three", at: 5), beat(2, "four", at: 7)], turns: [at(4), at(6)]))
+
+    #expect(summary.currentPass == 4)
+    #expect(summary.beats.map(\.pass) == [4])
+    // And a poll that reads the same window again counts nothing twice.
+    summary.merge(
+      SummaryBeatBuilder.reading(
+        from: [beat(1, "three", at: 5), beat(2, "four", at: 7)], turns: [at(4), at(6)]))
+    #expect(summary.currentPass == 4)
   }
 
   /// A reader whose tail window has moved past a pass must not be able to rewrite what the
@@ -59,9 +103,11 @@ struct SummaryStoreTests {
   func aPassRollsUpOnceAndIsNeverRewritten() {
     var summary = LoopSummary()
     summary.merge(
-      SummaryBeatBuilder.reading(from: [beat(1, "First answer", at: 1), beat(2, "now", at: 2)]))
+      SummaryBeatBuilder.reading(
+        from: [beat(1, "First answer", at: 1), beat(2, "now", at: 3)], turns: [at(0), at(2)]))
     summary.merge(
-      SummaryBeatBuilder.reading(from: [beat(1, "Rewritten answer", at: 1), beat(2, "now", at: 2)]))
+      SummaryBeatBuilder.reading(
+        from: [beat(1, "Rewritten answer", at: 1), beat(2, "now", at: 3)], turns: [at(0), at(2)]))
 
     #expect(summary.passes.map(\.text) == ["First answer"])
   }
@@ -70,9 +116,9 @@ struct SummaryStoreTests {
   func unseenCountsAgainstTheWindowsOwnWatermark() {
     var summary = LoopSummary()
     summary.merge(
-      SummaryBeatBuilder.reading(from: [
-        beat(1, "one", at: 1), beat(1, "two", at: 2), beat(1, "three", at: 3),
-      ]))
+      SummaryBeatBuilder.reading(
+        from: [beat(1, "one", at: 1), beat(1, "two", at: 2), beat(1, "three", at: 3)],
+        turns: [at(0)]))
 
     #expect(summary.unseenCount(since: summary.beats.first?.id) == 2)
     #expect(summary.unseenCount(since: summary.beats.last?.id) == 0)
@@ -220,14 +266,31 @@ struct SummaryStoreTests {
     node.summary = LoopSummary(
       beats: [beat(7, "Working out why cached tokens double-count", at: 1)],
       passes: [PassSummary(pass: 6, text: "Trimmed the system preamble", delta: "1.4k → 1.3k")],
-      earlierPasses: 5)
+      currentPass: 7, lastTurnAt: at(1))
 
     let data = try JSONEncoder().encode(node)
     let decoded = try JSONDecoder().decode(LoopNode.self, from: data)
 
     #expect(decoded.summary?.current?.text == "Working out why cached tokens double-count")
     #expect(decoded.summary?.passes.first?.delta == "1.4k → 1.3k")
+    // Where the count picks up from after a relaunch — without it every restart would
+    // renumber the run from whatever the next tail read happened to reach.
+    #expect(decoded.summary?.currentPass == 7)
+    #expect(decoded.summary?.lastTurnAt == at(1))
     #expect(decoded.summary?.earlierPasses == 5)
+  }
+
+  /// A summary written by a build that numbered passes differently must still load: a
+  /// `LoopSummary` that throws takes the whole graph file with it.
+  @Test
+  func aSummaryFromAnOlderBuildStillLoads() throws {
+    let older = Data(
+      """
+      {"beats":[],"passes":[],"earlierPasses":5}
+      """.utf8)
+    let decoded = try JSONDecoder().decode(LoopSummary.self, from: older)
+    #expect(decoded.currentPass == 0)
+    #expect(decoded.earlierPasses == 0)
   }
 
   /// A graph saved before the field existed must still load — `ProjectPersistence` turns

--- a/graphcode/Tests/SummaryStoreTests.swift
+++ b/graphcode/Tests/SummaryStoreTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// The bounded per-node store the beats are folded into, the settings that gate the whole
+/// feature, and the optional model pass.
+///
+/// Split from `SummaryRailTests` — which reads transcripts — because these assert what
+/// happens to a reading *after* it is taken, and the two have no fixtures in common.
+@Suite
+struct SummaryStoreTests {
+
+  private func beat(_ pass: Int, _ text: String, at seconds: Int) -> SummaryBeat {
+    SummaryBeat(
+      id: "p\(pass)-\(seconds)", at: Date(timeIntervalSince1970: Double(seconds)), pass: pass,
+      kind: .reading, text: text)
+  }
+
+  @Test
+  func aPassBoundaryCollapsesItsBeatsToOneLineAndDropsTheRest() {
+    let reading = SummaryBeatBuilder.reading(from: [
+      beat(1, "Read the probe", at: 1),
+      beat(1, "Traced totalTokens", at: 2),
+      beat(1, "Trimmed the system preamble", at: 3),
+      beat(2, "Working out why cached tokens double-count", at: 4),
+    ])
+
+    #expect(reading.finishedPasses.map(\.text) == ["Trimmed the system preamble"])
+    #expect(reading.beats.map(\.text) == ["Working out why cached tokens double-count"])
+
+    var summary = LoopSummary()
+    summary.merge(reading)
+    #expect(summary.passes.map(\.pass) == [1])
+    #expect(summary.beats.count == 1)
+  }
+
+  /// The bounding claim the whole design rests on: a six-hour loop and a six-minute one
+  /// are the same height.
+  @Test
+  func theStoreStaysBoundedAcrossAFiveHundredBeatRun() {
+    var summary = LoopSummary()
+    var beats: [SummaryBeat] = []
+    for index in 0..<500 {
+      beats.append(beat(index / 5 + 1, "beat \(index)", at: index))
+      // Merge each poll's view of the tail, the way `GraphStore.refreshSummary` does.
+      summary.merge(SummaryBeatBuilder.reading(from: Array(beats.suffix(40))))
+      #expect(summary.beats.count <= LoopSummary.maxBeats)
+      #expect(summary.passes.count <= LoopSummary.maxPassSummaries)
+    }
+    #expect(summary.earlierPasses > 90)
+    // Everything ever seen is still accounted for, as a number rather than as rows.
+    #expect(summary.earlierPasses + summary.passes.count == 99)
+  }
+
+  /// A reader whose tail window has moved past a pass must not be able to rewrite what the
+  /// store already recorded for it.
+  @Test
+  func aPassRollsUpOnceAndIsNeverRewritten() {
+    var summary = LoopSummary()
+    summary.merge(
+      SummaryBeatBuilder.reading(from: [beat(1, "First answer", at: 1), beat(2, "now", at: 2)]))
+    summary.merge(
+      SummaryBeatBuilder.reading(from: [beat(1, "Rewritten answer", at: 1), beat(2, "now", at: 2)]))
+
+    #expect(summary.passes.map(\.text) == ["First answer"])
+  }
+
+  @Test
+  func unseenCountsAgainstTheWindowsOwnWatermark() {
+    var summary = LoopSummary()
+    summary.merge(
+      SummaryBeatBuilder.reading(from: [
+        beat(1, "one", at: 1), beat(1, "two", at: 2), beat(1, "three", at: 3),
+      ]))
+
+    #expect(summary.unseenCount(since: summary.beats.first?.id) == 2)
+    #expect(summary.unseenCount(since: summary.beats.last?.id) == 0)
+    // No watermark is a first look, not a section full of unread marks.
+    #expect(summary.unseenCount(since: nil) == 0)
+    // A watermark naming a beat that has rolled out counts as nothing unseen.
+    #expect(summary.unseenCount(since: "p0-0") == 0)
+  }
+
+  // MARK: - The setting
+
+  @Test
+  func theProducerIsOffUntilSomeoneAsksForIt() throws {
+    #expect(GraphcodeSettings().summarisesLoops == false)
+    // A settings file written before the rail existed is a machine that never opted in.
+    let older = Data(
+      """
+      {"defaultBackend":"claudeCode","showsActivityStrip":true}
+      """.utf8)
+    let decoded = try JSONDecoder().decode(GraphcodeSettings.self, from: older)
+    #expect(decoded.summarisesLoops == false)
+    #expect(decoded.showsActivityStrip == true)
+  }
+
+  // MARK: - The optional model pass
+
+  @Test
+  func theModelPassIsOffEvenWhenSummariesAreOn() throws {
+    #expect(GraphcodeSettings().summaryUsesModel == false)
+    // Turning the rail on must not start spending money on a machine whose owner only
+    // asked to see what their loops were doing.
+    let older = Data(
+      """
+      {"summarisesLoops":true}
+      """.utf8)
+    let decoded = try JSONDecoder().decode(GraphcodeSettings.self, from: older)
+    #expect(decoded.summarisesLoops == true)
+    #expect(decoded.summaryUsesModel == false)
+  }
+
+  /// Flags checked against each CLI's own `--help`, not assumed — the rule
+  /// `BackendCapabilities.isSpiked` exists for.
+  @Test
+  func eachBackendIsAskedThroughItsOwnNonInteractiveFlag() {
+    #expect(
+      SummaryModelWriter.invocation(forBackend: .claudeCode, prompt: "p")
+        == ["claude", "-p", "p", "--model", "haiku"])
+    #expect(
+      SummaryModelWriter.invocation(forBackend: .copilotCLI, prompt: "p")
+        == ["copilot", "-p", "p", "--model", "haiku"])
+    // Codex spells the same flag `-m`, and its non-interactive mode is a subcommand.
+    #expect(
+      SummaryModelWriter.invocation(forBackend: .codex, prompt: "p")
+        == ["codex", "exec", "p", "-m", "haiku"])
+    // The standard tier passes no model flag at all, as everywhere else in the app.
+    #expect(
+      SummaryModelWriter.invocation(forBackend: .claudeCode, prompt: "p", tier: .standard)
+        == ["claude", "-p", "p"])
+  }
+
+  @Test
+  func theBeatCarriesTheFactsAndTheInstructionRefusesInvention() {
+    let prompt = SummaryModelWriter.prompt(
+      beat: SummaryBeat(
+        id: "p7-1", at: Date(), pass: 7, kind: .reading,
+        text: "Tracing totalTokens through the probe",
+        evidence: "UsageProbe.swift · 3 files read"))
+
+    #expect(prompt.contains("Tracing totalTokens through the probe"))
+    #expect(prompt.contains("UsageProbe.swift · 3 files read"))
+    #expect(prompt.contains("Invent nothing"))
+    // One sentence and one line of evidence — never the transcript.
+    #expect(prompt.count < 800)
+  }
+
+  @Test
+  func onlyOneShortLineIsAcceptedBackFromAModel() {
+    #expect(
+      SummaryModelWriter.accepted("Tracing totalTokens through the probe")
+        == "Tracing totalTokens through the probe")
+    // Print mode still prints banners; the answer is the last line.
+    #expect(
+      SummaryModelWriter.accepted("warning: no config\nFound the double count")
+        == "Found the double count")
+    #expect(SummaryModelWriter.accepted("\"Found the double count\"") == "Found the double count")
+    // Anything that isn't one short line is refused, so the derived beat stands.
+    #expect(SummaryModelWriter.accepted("```swift\nlet x = 1\n```") == nil)
+    #expect(
+      SummaryModelWriter.accepted(
+        "Here is a summary of everything the agent has been doing across this pass and "
+          + "the previous one as well") == nil)
+    #expect(SummaryModelWriter.accepted("   \n  ") == nil)
+  }
+
+  @Test
+  func nothingIsSentWhenTheHumanHasNotAskedForIt() async {
+    var node = LoopNode(title: "Usage")
+    let reading = SummaryBeatBuilder.reading(from: [beat(1, "Reading the probe", at: 1)])
+
+    // Producer on, model off: the reading comes back untouched rather than shelling out.
+    let unchanged = await SummaryModelWriter.applied(
+      to: reading, node: node, projectPath: nil,
+      settings: GraphcodeSettings(summarisesLoops: true, summaryUsesModel: false))
+    #expect(unchanged == reading)
+
+    // Model on, but this beat is already the one on the node — nothing has changed, so
+    // there is nothing to pay for.
+    node.summary = LoopSummary(beats: reading.beats)
+    let deduped = await SummaryModelWriter.applied(
+      to: reading, node: node, projectPath: nil,
+      settings: GraphcodeSettings(summarisesLoops: true, summaryUsesModel: true))
+    #expect(deduped == reading)
+  }
+
+  @Test
+  func aSummaryOnANodeSurvivesASaveAndReload() throws {
+    var node = LoopNode(title: "Usage")
+    node.summary = LoopSummary(
+      beats: [beat(7, "Working out why cached tokens double-count", at: 1)],
+      passes: [PassSummary(pass: 6, text: "Trimmed the system preamble", delta: "1.4k → 1.3k")],
+      earlierPasses: 5)
+
+    let data = try JSONEncoder().encode(node)
+    let decoded = try JSONDecoder().decode(LoopNode.self, from: data)
+
+    #expect(decoded.summary?.current?.text == "Working out why cached tokens double-count")
+    #expect(decoded.summary?.passes.first?.delta == "1.4k → 1.3k")
+    #expect(decoded.summary?.earlierPasses == 5)
+  }
+
+  /// A graph saved before the field existed must still load — `ProjectPersistence` turns
+  /// any decode failure into "no saved graph", which would throw away someone's loops.
+  @Test
+  func aNodeSavedBeforeSummariesExistedStillLoads() throws {
+    let older = Data(
+      """
+      {"id":"\(UUID().uuidString)","title":"Usage"}
+      """.utf8)
+    let decoded = try JSONDecoder().decode(LoopNode.self, from: older)
+    #expect(decoded.summary == nil)
+  }
+}

--- a/graphcode/Tests/SummaryStoreTests.swift
+++ b/graphcode/Tests/SummaryStoreTests.swift
@@ -187,6 +187,33 @@ struct SummaryStoreTests {
     #expect(deduped == reading)
   }
 
+  /// A quiet loop must cost a `stat` and no read, or dropping the `busy` guard would put
+  /// a tail parse per idle loop on every poll.
+  @Test
+  func aTranscriptIsOnlyReReadAfterItHasBeenWritten() async throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("freshness-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let url = root.appendingPathComponent("session.jsonl")
+    try "one\n".write(to: url, atomically: true, encoding: .utf8)
+    let node = UUID()
+
+    // First sight of a file is always a read.
+    #expect(await TranscriptFreshness.shared.hasChanged(url, forNode: node) == true)
+    #expect(await TranscriptFreshness.shared.hasChanged(url, forNode: node) == false)
+
+    // A write moves it, and only the node that has already looked is spared.
+    try "one\ntwo\n".write(to: url, atomically: true, encoding: .utf8)
+    #expect(await TranscriptFreshness.shared.hasChanged(url, forNode: node) == true)
+    #expect(await TranscriptFreshness.shared.hasChanged(url, forNode: UUID()) == true)
+
+    // A file that cannot be read at all is read rather than assumed unchanged: freezing
+    // the rail silently is the worse failure.
+    #expect(
+      await TranscriptFreshness.shared.hasChanged(
+        root.appendingPathComponent("missing.jsonl"), forNode: node) == true)
+  }
+
   @Test
   func aSummaryOnANodeSurvivesASaveAndReload() throws {
     var node = LoopNode(title: "Usage")


### PR DESCRIPTION
A new section at the top of the workspace rail — what the loop is doing now in one sentence, the two beats before it receding up a flowing spine, a pass line where the metric moved, and one row per finished pass down to a count. Built from `design review/summary_rail_handoff`.

## The producer calls no model

All three backends narrate before they act, and all three write that narration to disk. A beat is a tail read of a file graphcode is already reading for `activity` — zero tokens, zero subprocesses.

| Backend | File | Narration → beat text | Tools → kind + evidence |
| --- | --- | --- | --- |
| Claude Code | `~/.claude/projects/<p>/<session-id>.jsonl`, found by the id already banked for `--resume` | `assistant` → `text` blocks | `tool_use` |
| Codex | `~/.codex/sessions/**/rollout-*.jsonl` | `agent_reasoning`'s `**bolded header**` | `function_call` |
| Copilot | `~/.copilot/session-state/<id>/events.jsonl` | `assistant.message.content` | `tool.execution_start` |

Tool phrases come through each backend's existing `phrase` mapping, so a beat's evidence names exactly what the card's live line would have. A new narration closes the open beat — that is what makes twenty greps in a row one beat, and a pass is a user turn (a human typing, or `/loop` waking the session).

Bounded by construction: three beats, three pass summaries, a count for the rest. A six-hour loop and a six-minute one are the same height and the same bytes in the graph file.

## Two settings, both off

- **Summarise what loops are doing (experimental)** — the producer. Off, nothing is read, no node carries a summary, and the card's live line falls back to what the loop was handed, exactly as before.
- **Let a model write the summaries** — the optional second pass: one `claude -p` / `copilot -p` / `codex exec` at the fast tier, per *changed* beat of a *working* loop, over one sentence and one line of evidence — never the transcript. Its own process, so its tokens never land on the loop's own budget line; every failure path leaves the agent's own wording standing. Flags checked against each CLI's `--help`, not assumed.

## What the section does

Four states — starting, working, asking, resolved. `asking` is read off `displayState`, never off the summary, so attention keeps one source of truth. Folding keeps one truncated line; ⌥G hides the rail and leaves a 26pt gutter that still turns amber when the loop wants a human. `SINCE YOU LOOKED` is per window, set on the way out, so coming back is what shows it.

The spine's upward flow is the one `repeatForever` animation in the app, guarded the way `StateIndicator`'s removed pulse was not: one per window, only while the session is busy and the section is open.

## Checks

- 838 tests pass (34 new across three suites), `swiftlint lint` and `swift format lint --strict` clean.
- Store bounding asserted across a 500-beat run; pass rollup asserted to happen once and never be rewritten; card fallback asserted with the producer off; old graph files and old settings files asserted to still decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)