### PR TITLE
The rail reads turn ends off the transcript, and passes read oldest-first

### DIFF
--- a/GraphcodeKit/Sources/Domain/LoopSummary.swift
+++ b/GraphcodeKit/Sources/Domain/LoopSummary.swift
@@ -54,9 +54,19 @@ public struct SummaryBeat: Codable, Equatable, Sendable, Identifiable {
   public let text: String
   /// `"UsageProbe.swift · 3 files read"` — where the beat came from, one line, mono.
   public let evidence: String?
+  /// Whether the backend said the turn ended here — Claude Code's `stop_reason:
+  /// end_turn`, Copilot's `assistant.turn_end`, Codex's `task_complete`.
+  ///
+  /// The rail used to take that from `presence`, and presence is a *reading* — a hook
+  /// that may not have fired, a label that may be a poll behind. So a session that had
+  /// delivered its answer and gone quiet still wore `DOING NOW` over the word `THINKING`,
+  /// which is the one claim in the section that has to be true. The transcript says it
+  /// outright, in the same record the beat itself came from.
+  public let endsTurn: Bool
 
   public init(
-    id: String, at: Date, pass: Int, kind: BeatKind, text: String, evidence: String? = nil
+    id: String, at: Date, pass: Int, kind: BeatKind, text: String, evidence: String? = nil,
+    endsTurn: Bool = false
   ) {
     self.id = id
     self.at = at
@@ -64,6 +74,30 @@ public struct SummaryBeat: Codable, Equatable, Sendable, Identifiable {
     self.kind = kind
     self.text = text
     self.evidence = evidence
+    self.endsTurn = endsTurn
+  }
+
+  /// The same beat, with the backend's word that the turn stopped here.
+  func endingTurn() -> SummaryBeat {
+    SummaryBeat(
+      id: id, at: at, pass: pass, kind: kind, text: text, evidence: evidence, endsTurn: true)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id, at, pass, kind, text, evidence, endsTurn
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    at = try container.decode(Date.self, forKey: .at)
+    pass = try container.decode(Int.self, forKey: .pass)
+    kind = try container.decode(BeatKind.self, forKey: .kind)
+    text = try container.decode(String.self, forKey: .text)
+    evidence = try container.decodeIfPresent(String.self, forKey: .evidence)
+    // Absent in every beat banked before the backends were asked — and "we were never
+    // told the turn ended" is exactly what `false` means.
+    endsTurn = try container.decodeIfPresent(Bool.self, forKey: .endsTurn) ?? false
   }
 }
 

--- a/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
@@ -127,6 +127,12 @@ public enum ClaudeSessionLog {
         guard isUserTurn(message) else { continue }
         builder.noteUserTurn(at: at)
       case "assistant":
+        // `end_turn` is the model saying it has finished and is handing back; `tool_use`
+        // is it pausing for a call it is about to make. Read after the blocks, so it lands
+        // on the beat this record opened.
+        defer {
+          if message["stop_reason"] as? String == "end_turn" { builder.noteTurnEnd() }
+        }
         for block in message["content"] as? [[String: Any]] ?? [] {
           switch block["type"] as? String {
           case "text":

--- a/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
@@ -226,6 +226,9 @@ public enum CodexSessionLog {
           builder.noteUserTurn(at: at)
         case "agent_reasoning", "agent_message":
           builder.noteNarration(payload["text"] as? String ?? "", at: at)
+        // Codex's own end-of-turn event, the one its `notify` hook fires on.
+        case "task_complete":
+          builder.noteTurnEnd()
         default:
           continue
         }

--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -238,6 +238,10 @@ public enum CopilotSessionLog {
             forTool: name, arguments: data["arguments"] as? [String: Any] ?? [:])
         else { continue }
         builder.noteTool(phrase, at: at)
+      // Copilot marks its turn boundaries outright, which is why its presence reader was
+      // the one that never had to infer them.
+      case "assistant.turn_end":
+        builder.noteTurnEnd()
       default:
         continue
       }

--- a/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
@@ -23,6 +23,7 @@ struct SummaryBeatBuilder {
     var pass: Int
     var text: String?
     var phrases: [String] = []
+    var endsTurn = false
   }
 
   private var pass = 0
@@ -60,6 +61,22 @@ struct SummaryBeatBuilder {
   /// narration takes the first phrase as its own text: that is the tool call restated, not
   /// a summary invented over it, and it is exactly what `LoopNode.activity` has always put
   /// on the card.
+  /// The backend saying this turn is over: Claude Code's `stop_reason: end_turn`,
+  /// Copilot's `assistant.turn_end`, Codex's `task_complete`.
+  ///
+  /// Marks the beat the record belongs to — the open one, or the last closed one when the
+  /// record that ended the turn carried nothing a beat is made of (Claude stamps
+  /// `end_turn` on a bare thinking block too). Anything narrated afterwards opens a fresh
+  /// beat, which starts un-ended, so this cannot stick to a session that went back to
+  /// work.
+  mutating func noteTurnEnd() {
+    if open != nil {
+      open?.endsTurn = true
+    } else if let last = closed.indices.last {
+      closed[last] = closed[last].endingTurn()
+    }
+  }
+
   mutating func noteTool(_ phrase: String, at date: Date) {
     let clean = phrase.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !clean.isEmpty else { return }
@@ -81,7 +98,8 @@ struct SummaryBeatBuilder {
         pass: open.pass,
         kind: kind,
         text: text,
-        evidence: Self.evidence(kind: kind, phrases: open.phrases)))
+        evidence: Self.evidence(kind: kind, phrases: open.phrases),
+        endsTurn: open.endsTurn))
     self.open = nil
   }
 

--- a/graphcode/Resources/Localizable.xcstrings
+++ b/graphcode/Resources/Localizable.xcstrings
@@ -1601,6 +1601,70 @@
         }
       }
     },
+    "ANSWERED": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GEANTWORTET"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RESPONDIÓ"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A RÉPONDU"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HA RISPOSTO"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回答済み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "답변함"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RESPONDEU"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ОТВЕТИЛ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已回答"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已回答"
+          }
+        }
+      }
+    },
     "ASKING YOU": {
       "localizations": {
         "de": {
@@ -5181,6 +5245,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在下載更新…"
+          }
+        }
+      }
+    },
+    "EDITED": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BEARBEITET"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EDITÓ"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MODIFIÉ"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MODIFICATO"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編集完了"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집함"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EDITOU"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ИЗМЕНЕНО"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已编辑"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已編輯"
           }
         }
       }
@@ -10813,6 +10941,134 @@
           "stringUnit": {
             "state": "translated",
             "value": "快速對話"
+          }
+        }
+      }
+    },
+    "RAN": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AUSGEFÜHRT"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EJECUTÓ"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EXÉCUTÉ"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ESEGUITO"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行完了"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행함"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EXECUTOU"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ВЫПОЛНЕНО"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已运行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已執行"
+          }
+        }
+      }
+    },
+    "READ": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GELESEN"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LEYÓ"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LU"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LETTO"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み取り完了"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "읽음"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LEU"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ПРОЧИТАНО"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已读取"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已讀取"
           }
         }
       }

--- a/graphcode/Sources/Features/LoopWorkspace/FlowingSpine.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/FlowingSpine.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// The 1pt spine behind the receding beats, with a gradient segment travelling *up* it.
+///
+/// **Why an animation exists here at all.** `StateIndicator` documents why the running
+/// dot's pulse was removed: a `repeatForever` animation never settles, and that one was
+/// attached to every card and every sidebar row, so the app could not reach an idle frame
+/// while any loop ran. This is the opposite case on every count that mattered there. There
+/// is exactly **one** of these in a window — the workspace shows one loop — it is drawn
+/// only when the rail is open and unfolded, and `isFlowing` stops it the moment the
+/// session is not busy or there is nothing behind the current beat. A canvas of forty
+/// cards animates nothing.
+///
+/// It earns its place by saying the one thing no static rail can: that beats are still
+/// arriving. A spinner says "something is happening"; this says "the thing you are reading
+/// is moving", which is what a rail of receding text is for.
+struct FlowingSpine: View {
+  let isFlowing: Bool
+
+  @State private var phase: CGFloat = 0
+
+  var body: some View {
+    GeometryReader { proxy in
+      let height = proxy.size.height
+      Rectangle()
+        .fill(.white.opacity(0.1))
+        .overlay(alignment: .top) {
+          if isFlowing {
+            RoundedRectangle(cornerRadius: 1)
+              .fill(
+                LinearGradient(
+                  colors: [
+                    Theme.paneFocusTint.opacity(0), Theme.paneFocusTint,
+                    Theme.paneFocusTint.opacity(0),
+                  ],
+                  startPoint: .top, endPoint: .bottom)
+              )
+              .frame(width: 2, height: 26)
+              .offset(x: -0.5, y: (height + 26) * (1 - phase) - 26)
+              .onAppear {
+                phase = 0
+                withAnimation(.linear(duration: 2.6).repeatForever(autoreverses: false)) {
+                  phase = 1
+                }
+              }
+          }
+        }
+        .clipped()
+    }
+  }
+}

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummaryPresentation.swift
@@ -119,7 +119,13 @@ struct LoopSummaryPresentation: Equatable {
       evidence = current?.evidence
     }
 
-    isLive = node.presence?.presence == .busy && !node.isResolved
+    // **The transcript has the last word on whether the loop is still going.** Presence is
+    // a reading — a hook that may not have fired, a label a poll behind — and a beat whose
+    // own record says the turn ended is not something the session is still doing, whatever
+    // presence claims. Reported on a real session: `DOING NOW` over `THINKING`, on an
+    // agent that had delivered its answer and gone quiet.
+    isLive =
+      node.presence?.presence == .busy && !node.isResolved && current?.endsTurn != true
     elapsed = current.map { LoopCardPresentation.duration(now.timeIntervalSince($0.at)) }
     receding = summary.receding
     // Counted against every beat, including the current one, and clamped to the rows the
@@ -127,7 +133,11 @@ struct LoopSummaryPresentation: Equatable {
     // the current beat is not one of those. `LoopSummarySection` puts the leftover case —
     // only the now block is new — at the foot of the list, which is where it belongs.
     unseen = min(summary.unseenCount(since: seenBeatID), summary.beats.count)
-    passes = summary.passes.reversed()
+    // Oldest first, so the newest finished pass sits directly above the divider for the
+    // pass the loop is on — the same direction as the beats under it and the terminal
+    // beside it. Newest-first meant the rail's own history ran one way and everything
+    // else on the screen ran the other.
+    passes = summary.passes
     earlierPasses = summary.earlierPasses
     // The beat's own pass, which `LoopSummary.merge` has already put on the store's
     // absolute numbering; `currentPass` for a section that is all rollups and no beats.

--- a/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopSummarySection.swift
@@ -193,9 +193,18 @@ struct LoopSummarySection: View {
   /// value is a wire format, and a language whose uppercase is not a mechanical transform
   /// of its lowercase — or whose word for `running` is not one word — has nowhere to say
   /// so if the string never reaches the catalog.
+  /// Past tense once the turn is over. `THINKING` over an agent that had delivered its
+  /// final answer was reported from a real session, and it is the same fault the header's
+  /// `LAST DID` already fixed one line above: a word in the present tense is a claim that
+  /// something is still happening.
   private func kindWord(_ presentation: LoopSummaryPresentation) -> LocalizedStringKey {
     if presentation.mode == .asking { return "ASKING YOU" }
-    switch presentation.kind {
+    let isOver = presentation.mode == .working && !presentation.isLive
+    return isOver ? Self.pastWord(presentation.kind) : Self.presentWord(presentation.kind)
+  }
+
+  private static func presentWord(_ kind: BeatKind) -> LocalizedStringKey {
+    switch kind {
     case .reading: return "READING"
     case .editing: return "EDITING"
     case .running: return "RUNNING"
@@ -206,6 +215,25 @@ struct LoopSummarySection: View {
     }
   }
 
+  private static func pastWord(_ kind: BeatKind) -> LocalizedStringKey {
+    switch kind {
+    case .reading: return "READ"
+    case .editing: return "EDITED"
+    case .running: return "RAN"
+    // A beat with no tool calls under it, on a session that has stopped, *is* the answer.
+    case .thinking: return "ANSWERED"
+    case .found: return "FOUND"
+    case .asking: return "ASKING YOU"
+    case .done: return "DONE"
+    }
+  }
+}
+
+/// The history column and the rollups under it — everything behind the current
+/// beat. An extension for the reason `AppFeature`'s helpers are in one: the type's
+/// own body has a line budget, and a view built from small named pieces spends it
+/// fast.
+extension LoopSummarySection {
   // MARK: - History
 
   /// Everything behind the current beat, oldest at the top, on one spine: the finished
@@ -318,9 +346,19 @@ struct LoopSummarySection: View {
     .padding(.vertical, 5)
   }
 
-  /// One row per finished pass, then a count. Six hours of work stays six rows tall.
+  /// A count, then one row per finished pass — oldest at the top, so the newest sits
+  /// against the divider for the pass the loop is on. Six hours of work stays six rows.
   private func rollups(_ presentation: LoopSummaryPresentation) -> some View {
     VStack(alignment: .leading, spacing: 4) {
+      if presentation.earlierPasses > 0 {
+        Text(
+          presentation.earlierPasses == 1
+            ? "1 earlier pass" : "\(presentation.earlierPasses) earlier passes"
+        )
+        .font(.system(size: 10.5))
+        .foregroundStyle(.white.opacity(0.5))
+        .padding(.leading, 32)
+      }
       ForEach(presentation.passes) { pass in
         HStack(alignment: .firstTextBaseline, spacing: 6) {
           // The one string in the section with no catalog entry, and deliberately: a 26pt
@@ -336,65 +374,6 @@ struct LoopSummarySection: View {
             .fixedSize(horizontal: false, vertical: true)
         }
       }
-      if presentation.earlierPasses > 0 {
-        Text(
-          presentation.earlierPasses == 1
-            ? "1 earlier pass" : "\(presentation.earlierPasses) earlier passes"
-        )
-        .font(.system(size: 10.5))
-        .foregroundStyle(.white.opacity(0.5))
-        .padding(.leading, 32)
-      }
-    }
-  }
-}
-
-/// The 1pt spine behind the receding beats, with a gradient segment travelling *up* it.
-///
-/// **Why an animation exists here at all.** `StateIndicator` documents why the running
-/// dot's pulse was removed: a `repeatForever` animation never settles, and that one was
-/// attached to every card and every sidebar row, so the app could not reach an idle frame
-/// while any loop ran. This is the opposite case on every count that mattered there. There
-/// is exactly **one** of these in a window — the workspace shows one loop — it is drawn
-/// only when the rail is open and unfolded, and `isFlowing` stops it the moment the
-/// session is not busy or there is nothing behind the current beat. A canvas of forty
-/// cards animates nothing.
-///
-/// It earns its place by saying the one thing no static rail can: that beats are still
-/// arriving. A spinner says "something is happening"; this says "the thing you are reading
-/// is moving", which is what a rail of receding text is for.
-private struct FlowingSpine: View {
-  let isFlowing: Bool
-
-  @State private var phase: CGFloat = 0
-
-  var body: some View {
-    GeometryReader { proxy in
-      let height = proxy.size.height
-      Rectangle()
-        .fill(.white.opacity(0.1))
-        .overlay(alignment: .top) {
-          if isFlowing {
-            RoundedRectangle(cornerRadius: 1)
-              .fill(
-                LinearGradient(
-                  colors: [
-                    Theme.paneFocusTint.opacity(0), Theme.paneFocusTint,
-                    Theme.paneFocusTint.opacity(0),
-                  ],
-                  startPoint: .top, endPoint: .bottom)
-              )
-              .frame(width: 2, height: 26)
-              .offset(x: -0.5, y: (height + 26) * (1 - phase) - 26)
-              .onAppear {
-                phase = 0
-                withAnimation(.linear(duration: 2.6).repeatForever(autoreverses: false)) {
-                  phase = 1
-                }
-              }
-          }
-        }
-        .clipped()
     }
   }
 }

--- a/graphcode/Tests/LoopSummarySectionTests.swift
+++ b/graphcode/Tests/LoopSummarySectionTests.swift
@@ -13,11 +13,12 @@ import Testing
 @Suite
 struct LoopSummarySectionTests {
   private func beat(
-    _ pass: Int, _ text: String, kind: BeatKind = .reading, at seconds: Int
+    _ pass: Int, _ text: String, kind: BeatKind = .reading, at seconds: Int,
+    endsTurn: Bool = false
   ) -> SummaryBeat {
     SummaryBeat(
       id: "p\(pass)-\(seconds)", at: Date(timeIntervalSince1970: Double(seconds)), pass: pass,
-      kind: kind, text: text)
+      kind: kind, text: text, endsTurn: endsTurn)
   }
 
   private func node(
@@ -76,6 +77,49 @@ struct LoopSummarySectionTests {
 
     let working = LoopSummaryPresentation(node: node(summary: summary), now: now)
     #expect(working.mode == .working)
+  }
+
+  /// The second fault reported from a live loop: `DOING NOW` over `THINKING`, on an agent
+  /// that had delivered its final output.
+  ///
+  /// Presence still said busy — it is a reading, and the hook behind it can be a poll
+  /// late or not have fired at all. The record the beat came from says the turn ended, and
+  /// that outranks it.
+  @Test
+  func aTurnTheTranscriptSaysIsOverIsNotStillHappening() {
+    let answered = LoopSummary(beats: [
+      beat(4, "Running the release build", at: 100),
+      beat(4, "Shipped. 0.1.37-beta1 is live", kind: .thinking, at: 900, endsTurn: true),
+    ])
+    // Presence is `.busy` on this node — the default in `node(…)` — and it loses.
+    let presentation = LoopSummaryPresentation(node: node(summary: answered), now: now)
+
+    #expect(presentation.mode == .working)
+    #expect(presentation.isLive == false)
+
+    // Mid-turn, with the same presence, it is live.
+    let working = LoopSummary(beats: [beat(4, "Running the release build", at: 900)])
+    #expect(LoopSummaryPresentation(node: node(summary: working), now: now).isLive == true)
+  }
+
+  /// Oldest at the top, so the newest finished pass sits against the divider for the pass
+  /// the loop is on — the direction the beats under it and the terminal beside it run.
+  @Test
+  func finishedPassesReadOldestFirst() {
+    let summary = LoopSummary(
+      beats: [beat(7, "Working on it", at: 900)],
+      passes: [
+        PassSummary(pass: 4, text: "four"), PassSummary(pass: 5, text: "five"),
+        PassSummary(pass: 6, text: "six"),
+      ], currentPass: 7)
+
+    let presentation = LoopSummaryPresentation(node: node(summary: summary), now: now)
+
+    #expect(presentation.passes.map(\.pass) == [4, 5, 6])
+    #expect(presentation.pass == 7)
+    // Six named passes is the cap, and everything before them is a number.
+    #expect(LoopSummary.maxPassSummaries == 6)
+    #expect(presentation.earlierPasses == 3)
   }
 
   /// The fault this caught in the field: an amber block and an `Answer it` button over a

--- a/graphcode/Tests/SummaryRailTests.swift
+++ b/graphcode/Tests/SummaryRailTests.swift
@@ -55,16 +55,18 @@ struct SummaryRailTests {
 
   private func claudeAssistant(
     text: String? = nil, tools: [(String, [String: Any])] = [], at seconds: Int,
-    isSidechain: Bool = false
+    isSidechain: Bool = false, stopReason: String? = nil
   ) throws -> String {
     var content: [[String: Any]] = []
     if let text { content.append(["type": "text", "text": text]) }
     for (name, input) in tools {
       content.append(["type": "tool_use", "name": name, "input": input, "id": "t\(name)"])
     }
+    var message: [String: Any] = ["role": "assistant", "content": content]
+    if let stopReason { message["stop_reason"] = stopReason }
     return try line([
       "type": "assistant", "timestamp": stamp(seconds), "isSidechain": isSidechain,
-      "message": ["role": "assistant", "content": content],
+      "message": message,
     ])
   }
 
@@ -177,6 +179,33 @@ struct SummaryRailTests {
     #expect(beats[0].kind == .editing)
     // The first *edit*, and a count of the edits — not of the greps that led to them.
     #expect(beats[0].evidence == "UsageProbe.swift · 2 edits")
+  }
+
+  /// A session that has answered is not still thinking, whatever presence says.
+  ///
+  /// Reported off a live loop: `DOING NOW` over the word `THINKING`, on an agent that had
+  /// delivered its final output minutes earlier. Presence is a reading — a hook that may
+  /// not have fired, a label a poll behind — and the transcript says it outright in the
+  /// same record the beat came from.
+  @Test
+  func theRecordThatEndsATurnSaysSoOnTheBeat() throws {
+    let root = try temporaryRoot("claude-endturn")
+    let url = try log(
+      [
+        try claudeUser("ship it", at: 0),
+        try claudeAssistant(
+          text: "Building the release.", tools: [("Bash", ["command": "make release"])], at: 1,
+          stopReason: "tool_use"),
+        try claudeToolResult("tBash", at: 2),
+        try claudeAssistant(text: "Shipped. 0.1.37-beta1 is live.", at: 3, stopReason: "end_turn"),
+      ], named: "session.jsonl", in: root)
+
+    let beats = ClaudeSessionLog.beats(inTranscriptAt: url)
+
+    #expect(beats.map(\.text) == ["Building the release", "Shipped. 0.1.37-beta1 is live"])
+    // Mid-turn, the model stopped only to make a call.
+    #expect(beats[0].endsTurn == false)
+    #expect(beats[1].endsTurn == true)
   }
 
   @Test


### PR DESCRIPTION
Two faults reported from the 0.1.37-beta1 rail.

## `THINKING` over an agent that had answered

Liveness came from `presence` — a reading, not a fact: a hook that may not have fired, a label a poll behind. All three backends state it in the record the beat came from, so the beat carries it now:

| Backend | Says the turn ended |
| --- | --- |
| Claude Code | `message.stop_reason == "end_turn"` (vs `tool_use` mid-turn) |
| Copilot | `assistant.turn_end` |
| Codex | `event_msg` / `task_complete` |

A beat that ends a turn is not live, whatever presence says, and the kind word follows the tense the header already used: `READ` / `EDITED` / `RAN` / `ANSWERED` once it is over. Verified against this machine's transcripts — an answered session reads `endsTurn` on its last beat, two mid-turn ones do not.

## Passes read the wrong way up

Rollups ran newest-first while the beats under them and the terminal beside them run oldest-first. They are oldest-first now, so the newest finished pass sits directly against the `PASS n` divider, and `N earlier passes` moves to the top of the column with them. Six named passes was already the cap.

851 tests pass (three new), `make check` clean. `FlowingSpine` moves to its own file and the history column into an extension — the section had crossed swiftlint's length warnings.