### PR TITLE
The summary rail reads remote loops

### DIFF
--- a/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/ClaudeSessionLog.swift
@@ -113,8 +113,14 @@ public enum ClaudeSessionLog {
   }
 
   private static func builder(inTranscriptAt url: URL) -> SummaryBeatBuilder {
+    builder(forLines: SummaryBeatBuilder.tailLines(of: url))
+  }
+
+  /// The same read over lines from anywhere — a local tail, or a remote one an ssh probe
+  /// brought back (`RemoteTranscriptProbe`). Nothing below this line knows which.
+  static func builder(forLines lines: [Data]) -> SummaryBeatBuilder {
     var builder = SummaryBeatBuilder()
-    for line in SummaryBeatBuilder.tailLines(of: url) {
+    for line in lines {
       guard let object = try? JSONSerialization.jsonObject(with: line),
         let record = object as? [String: Any],
         record["isSidechain"] as? Bool != true,
@@ -171,16 +177,53 @@ public enum ClaudeSessionLog {
     }
   }
 
+  /// The remote script's half: find the transcript the way this reader does locally, but
+  /// on the other machine.
+  ///
+  /// The session id is read from the file the remote host banks itself — the same one
+  /// `--resume` uses, written by the hooks graphcode installs there — so the lookup is the
+  /// local one expressed in `sh`, not a second rule about where transcripts live.
+  ///
+  /// The filter drops tool *results*, keyed on `toolUseResult` rather than on the string
+  /// `tool_result`: the second appears in prose the moment an agent talks about its own
+  /// transcript, and dropping that line would drop a beat. Results are most of a
+  /// transcript's bytes and are read by nothing here.
+  static func remoteSummaryInvocation(
+    forNode node: LoopNode, at location: RemoteProjectLocation, since stamp: String?
+  ) -> [String] {
+    let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: node.id)
+    let find =
+      "S=$(cat \(idFile) 2>/dev/null); F=''; "
+      + "[ -n \"$S\" ] && F=$(ls -t \"$HOME\"/.claude/projects/*/\"$S\".jsonl 2>/dev/null | head -1)"
+    let script = RemoteTranscriptProbe.script(
+      findingFileWith: find, filter: "grep -av toolUseResult", since: stamp)
+    return location.sshInvocation(remoteCommand: location.remoteLoginShellCommand(script))
+  }
+
+  static func remoteSummary(
+    of node: LoopNode, at location: RemoteProjectLocation, metricSamples: [MetricSample]
+  ) async -> SummaryReading? {
+    let stamp = await TranscriptFreshness.shared.remoteStamp(forNode: node.id)
+    let reply = await RemoteTranscriptProbe.run(
+      remoteSummaryInvocation(forNode: node, at: location, since: stamp))
+    guard case .lines(let newStamp, let lines) = reply else { return nil }
+    await TranscriptFreshness.shared.recordRemoteStamp(newStamp, forNode: node.id)
+    var builder = builder(forLines: lines)
+    let reading = SummaryBeatBuilder.reading(
+      from: builder.beats(), turns: builder.userTurns(), metricSamples: metricSamples)
+    return reading.isEmpty ? nil : reading
+  }
+
   /// What this node's Claude Code session has been doing, or `nil` when nothing says.
   ///
-  /// Local only, for the reason `CopilotSessionLog.activity` is: the transcript lives on
-  /// whichever machine ran the agent, and carrying beats back through a remote shell is a
-  /// larger change than this one. Remote loops keep the card line they already had.
+  /// A remote loop's transcript is on the other machine, so the tail is fetched over the
+  /// same multiplexed ssh connection every other reading uses — see
+  /// `RemoteTranscriptProbe` for what that costs and why it is usually nothing.
   public static func summary(of node: LoopNode, projectPath: String? = nil) async
     -> SummaryReading?
   {
-    if let projectPath, RemoteProjectLocation.parse(projectPath: projectPath) != nil {
-      return nil
+    if let projectPath, let remote = RemoteProjectLocation.parse(projectPath: projectPath) {
+      return await remoteSummary(of: node, at: remote, metricSamples: node.metricHistory)
     }
     guard let sessionID = SessionIDStore.load(forNodeID: node.id),
       let transcript = transcript(forSessionID: sessionID),

--- a/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CodexSessionLog.swift
@@ -212,8 +212,13 @@ public enum CodexSessionLog {
   }
 
   private static func builder(inRolloutAt url: URL) -> SummaryBeatBuilder {
+    builder(forLines: SummaryBeatBuilder.tailLines(of: url))
+  }
+
+  /// The same read over lines from anywhere — see `ClaudeSessionLog.builder(forLines:)`.
+  static func builder(forLines lines: [Data]) -> SummaryBeatBuilder {
     var builder = SummaryBeatBuilder()
-    for line in SummaryBeatBuilder.tailLines(of: url) {
+    for line in lines {
       guard let object = try? JSONSerialization.jsonObject(with: line),
         let record = object as? [String: Any],
         let payload = record["payload"] as? [String: Any]
@@ -242,13 +247,57 @@ public enum CodexSessionLog {
     return builder
   }
 
-  /// What this node's Codex session has been doing, or `nil` when nothing says. Local
-  /// only, for the reason `activity` is.
+  /// The remote script's half: the same match on the directory the session opened in that
+  /// `rollout(forWorkingDirectory:)` makes locally, expressed as a walk over the newest
+  /// rollouts. Codex has no `--name`, so the working directory is the only handle either
+  /// side has on which rollout is whose.
+  ///
+  /// Only the header of each candidate is read — `session_meta` is always the first line,
+  /// which is why the local reader reads 64 KB and stops.
+  static func remoteSummaryInvocation(
+    forNode node: LoopNode, at location: RemoteProjectLocation, workingDirectory: String,
+    since stamp: String?
+  ) -> [String] {
+    let quoted = RemoteProjectLocation.shellQuoted(workingDirectory)
+    let find =
+      "W=\(quoted); F=''; "
+      + "for f in $(ls -t \"$HOME\"/.codex/sessions/*/*/*/rollout-*.jsonl 2>/dev/null | head -40); do "
+      + "if head -c 65536 \"$f\" 2>/dev/null | grep -q \"\\\"cwd\\\":\\\"$W\\\"\"; then F=\"$f\"; break; fi; done"
+    let script = RemoteTranscriptProbe.script(
+      findingFileWith: find,
+      filter: "grep -avE '\"(function_call_output|custom_tool_call_output)\"'", since: stamp)
+    return location.sshInvocation(remoteCommand: location.remoteLoginShellCommand(script))
+  }
+
+  static func remoteSummary(
+    of node: LoopNode, at location: RemoteProjectLocation, workingDirectory: String,
+    metricSamples: [MetricSample]
+  ) async -> SummaryReading? {
+    let stamp = await TranscriptFreshness.shared.remoteStamp(forNode: node.id)
+    let reply = await RemoteTranscriptProbe.run(
+      remoteSummaryInvocation(
+        forNode: node, at: location, workingDirectory: workingDirectory, since: stamp))
+    guard case .lines(let newStamp, let lines) = reply else { return nil }
+    await TranscriptFreshness.shared.recordRemoteStamp(newStamp, forNode: node.id)
+    var builder = builder(forLines: lines)
+    let reading = SummaryBeatBuilder.reading(
+      from: builder.beats(), turns: builder.userTurns(), metricSamples: metricSamples)
+    return reading.isEmpty ? nil : reading
+  }
+
+  /// What this node's Codex session has been doing, or `nil` when nothing says. A remote
+  /// loop's rollout is fetched over the same multiplexed ssh connection every other
+  /// reading uses — see `RemoteTranscriptProbe`.
   public static func summary(of node: LoopNode, projectPath: String? = nil) async
     -> SummaryReading?
   {
-    if let projectPath, RemoteProjectLocation.parse(projectPath: projectPath) != nil {
-      return nil
+    if let projectPath, let remote = RemoteProjectLocation.parse(projectPath: projectPath) {
+      // The node's own worktree if it has one, and otherwise the folder the project
+      // names on that host. `ZmxSessionLauncher.workingDirectory` is the local answer and
+      // cannot be used here: it checks the path exists, and a remote one never does.
+      let directory = node.worktreeBinding?.worktreePath ?? remote.remotePath
+      return await remoteSummary(
+        of: node, at: remote, workingDirectory: directory, metricSamples: node.metricHistory)
     }
     guard
       let directory = ZmxSessionLauncher.workingDirectory(

--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -218,8 +218,13 @@ public enum CopilotSessionLog {
   }
 
   private static func builder(inLogAt url: URL) -> SummaryBeatBuilder {
+    builder(forLines: SummaryBeatBuilder.tailLines(of: url))
+  }
+
+  /// The same read over lines from anywhere — see `ClaudeSessionLog.builder(forLines:)`.
+  static func builder(forLines lines: [Data]) -> SummaryBeatBuilder {
     var builder = SummaryBeatBuilder()
-    for line in SummaryBeatBuilder.tailLines(of: url) {
+    for line in lines {
       guard let object = try? JSONSerialization.jsonObject(with: line),
         let event = object as? [String: Any],
         let type = event["type"] as? String
@@ -249,13 +254,51 @@ public enum CopilotSessionLog {
     return builder
   }
 
-  /// What this node's Copilot session has been doing, or `nil` when nothing says. Local
-  /// only, for the reason `activity` is.
+  /// The remote script's half: the same directory walk `remotePresenceInvocation` does —
+  /// Copilot's session-state directories are named by uuid and identified by the `--name`
+  /// graphcode launched them with — then the event log inside it.
+  ///
+  /// The filter is a keep-list rather than a drop-list, because Copilot's event log is the
+  /// one that carries whole tool *outputs* in a record type of its own: four event types
+  /// make beats and the rest is bytes over a network for nothing.
+  static func remoteSummaryInvocation(
+    forNode node: LoopNode, at location: RemoteProjectLocation, since stamp: String?
+  ) -> [String] {
+    let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
+    let find =
+      "F=''; for d in $(ls -t \"$HOME/.copilot/session-state/\" 2>/dev/null); do "
+      + "if grep -qx 'name: \(name)' \"$HOME/.copilot/session-state/$d/workspace.yaml\" 2>/dev/null; "
+      + "then F=\"$HOME/.copilot/session-state/$d/events.jsonl\"; break; fi; done"
+    let keep =
+      "grep -aE '\"type\":\"(user\\.message|assistant\\.message|tool\\.execution_start"
+      + "|assistant\\.turn_end)\"'"
+    let script = RemoteTranscriptProbe.script(
+      findingFileWith: find, filter: keep, since: stamp)
+    return location.sshInvocation(remoteCommand: location.remoteLoginShellCommand(script))
+  }
+
+  static func remoteSummary(
+    of node: LoopNode, at location: RemoteProjectLocation, metricSamples: [MetricSample]
+  ) async -> SummaryReading? {
+    let stamp = await TranscriptFreshness.shared.remoteStamp(forNode: node.id)
+    let reply = await RemoteTranscriptProbe.run(
+      remoteSummaryInvocation(forNode: node, at: location, since: stamp))
+    guard case .lines(let newStamp, let lines) = reply else { return nil }
+    await TranscriptFreshness.shared.recordRemoteStamp(newStamp, forNode: node.id)
+    var builder = builder(forLines: lines)
+    let reading = SummaryBeatBuilder.reading(
+      from: builder.beats(), turns: builder.userTurns(), metricSamples: metricSamples)
+    return reading.isEmpty ? nil : reading
+  }
+
+  /// What this node's Copilot session has been doing, or `nil` when nothing says. A remote
+  /// loop's log is fetched over the same multiplexed ssh connection its presence is —
+  /// see `RemoteTranscriptProbe`.
   public static func summary(of node: LoopNode, projectPath: String? = nil) async
     -> SummaryReading?
   {
-    if let projectPath, RemoteProjectLocation.parse(projectPath: projectPath) != nil {
-      return nil
+    if let projectPath, let remote = RemoteProjectLocation.parse(projectPath: projectPath) {
+      return await remoteSummary(of: node, at: remote, metricSamples: node.metricHistory)
     }
     let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
     guard let directory = directory(forSessionNamed: name) else { return nil }

--- a/GraphcodeKit/Sources/Sessions/RemoteTranscriptProbe.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteTranscriptProbe.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// One ssh round trip that brings a remote session's transcript tail back to be read.
+///
+/// **Why the rail could not see a remote loop at all.** The three readers work by tailing
+/// the file the agent writes, and for a remote project that file is on the other machine.
+/// Presence and activity solved the same problem by asking a *question* over ssh and
+/// bringing back one word; a summary needs the records themselves, which is a payload
+/// rather than an answer. So the probe does as much of the work as a shell can — find the
+/// file, decide whether it has moved, throw away everything a beat is never made from —
+/// and ships only what is left.
+///
+/// Three things keep that from being expensive:
+///
+/// 1. **One connection.** `sshInvocation` multiplexes over the same `ControlMaster` every
+///    other remote read uses, so this is a channel on a live master, not a dial.
+/// 2. **Nothing when nothing moved.** The last modification time comes back with the
+///    payload and goes out with the next request; a transcript that has not been written
+///    to answers `unchanged` in one short line. A quiet remote loop costs a `stat`.
+/// 3. **The big records never travel.** Tool *results* — a file's whole contents, a
+///    command's whole output — are most of a transcript's bytes and are read by nothing
+///    here. Each backend passes the filter that drops its own, and a line longer than
+///    64 KB is dropped whatever it is.
+enum RemoteTranscriptProbe {
+  /// The one line of the reply this side parses, for the reason
+  /// `ZmxSessionLauncher.remoteProbeMarker` exists: the remote login shell is interactive
+  /// and a `~/.zshrc` may print anything it likes first.
+  static let marker = "graphcode-summary:"
+
+  /// How much of the remote tail to consider before filtering. Half the local window: the
+  /// filter throws away most of what it reads, and the bytes here cross a network.
+  static let tailBytes = 256 * 1024
+
+  enum Reply: Equatable {
+    /// The transport failed, no session id was banked, or no transcript was found.
+    case nothing
+    /// The file has not been written to since the stamp we sent.
+    case unchanged
+    /// The tail, as whole lines, with the modification time to send next time.
+    case lines(stamp: String, lines: [Data])
+  }
+
+  /// The remote script: a backend's own way of finding the file, then the same three
+  /// steps for all of them.
+  ///
+  /// `stat` is spelled twice because the remote host may be either kind — `-c` is GNU and
+  /// `-f` is BSD, and a graphcode loop runs on Linux boxes and Macs alike.
+  static func script(findingFileWith find: String, filter: String, since stamp: String?) -> String {
+    let known = stamp ?? "-"
+    return [
+      find,
+      "if [ -z \"$F\" ]; then echo '\(marker) nothing'; exit 0; fi",
+      "M=$(stat -c %Y \"$F\" 2>/dev/null || stat -f %m \"$F\" 2>/dev/null)",
+      "if [ \"$M\" = '\(known)' ]; then echo '\(marker) unchanged'; exit 0; fi",
+      "echo \"\(marker) lines $M\"",
+      "tail -c \(tailBytes) \"$F\" 2>/dev/null | \(filter) | awk 'length($0) < 65536' | tail -n 300",
+    ].joined(separator: "; ")
+  }
+
+  static func run(_ invocation: [String]) async -> Reply {
+    RemoteProjectLocation.prepareControlSocketDirectory()
+    guard
+      let session = try? PTYProcessSession(
+        executable: invocation[0], arguments: Array(invocation.dropFirst()))
+    else { return .nothing }
+    let (succeeded, output) = await session.waitCollectingOutput()
+    return parse(succeeded: succeeded, output: output)
+  }
+
+  /// The marker line, then everything after it.
+  ///
+  /// Carried over a PTY, so every line arrives with a carriage return on it that JSON
+  /// tolerates and string comparison does not — trimmed here rather than everywhere
+  /// downstream. The *last* marker wins, for the reason `parseRemoteStatus` says: what
+  /// comes before it is shell chatter.
+  static func parse(succeeded: Bool, output: String) -> Reply {
+    guard succeeded else { return .nothing }
+    // `whereSeparator` rather than a `"\n"` literal, which took the whole reply as one
+    // line — the same call `parseRemoteStatus` makes, and now for the same measured reason.
+    let lines = output.split(whereSeparator: \.isNewline)
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    guard let index = lines.lastIndex(where: { $0.hasPrefix(marker) }) else { return .nothing }
+    let words = lines[index].dropFirst(marker.count).split(separator: " ").map(String.init)
+    switch words.first {
+    case "unchanged": return .unchanged
+    case "lines":
+      guard let stamp = words.dropFirst().first else { return .nothing }
+      let body = lines[(index + 1)...].filter { $0.hasPrefix("{") }.map { Data($0.utf8) }
+      return body.isEmpty ? .nothing : .lines(stamp: stamp, lines: body)
+    default: return .nothing
+    }
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/TranscriptFreshness.swift
+++ b/GraphcodeKit/Sources/Sessions/TranscriptFreshness.swift
@@ -45,8 +45,24 @@ actor TranscriptFreshness {
     return true
   }
 
+  /// The remote twin: the modification time a remote transcript had when this node last
+  /// read it, as the remote `stat` printed it.
+  ///
+  /// A string rather than a `Date` on purpose — it is the other machine's word, sent back
+  /// unparsed on the next request so the remote shell can answer `unchanged` without
+  /// shipping a byte. Parsing it here would be inventing a comparison that only the host
+  /// that wrote it can make.
+  private var remoteStamps: [UUID: String] = [:]
+
+  func remoteStamp(forNode nodeID: UUID) -> String? { remoteStamps[nodeID] }
+
+  func recordRemoteStamp(_ stamp: String, forNode nodeID: UUID) {
+    remoteStamps[nodeID] = stamp
+  }
+
   /// Forgets a node, so a deleted loop doesn't hold a date forever.
   func forget(_ nodeID: UUID) {
     seen[nodeID] = nil
+    remoteStamps[nodeID] = nil
   }
 }

--- a/graphcode/Tests/RemoteSummaryTests.swift
+++ b/graphcode/Tests/RemoteSummaryTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// The rail over ssh: a remote loop's transcript is on the other machine, and the beats
+/// have to come back over the same connection everything else about it does.
+///
+/// Asserted as a script and a parse rather than against a host, the way
+/// `RemoteLoopSurvivalTests` asserts the ensure dial: what can be got wrong here is the
+/// shell fragment and the framing, and both are values.
+@Suite
+struct RemoteSummaryTests {
+  private let location = RemoteProjectLocation(
+    user: "dev", host: "build-box", port: 2222, remotePath: "/home/dev/widget")
+
+  private func node(_ backend: CLISessionBackendKind) -> LoopNode {
+    LoopNode(title: "Usage", loopType: .goalBased, backend: backend)
+  }
+
+  private func remoteCommand(_ invocation: [String]) -> String {
+    invocation.last ?? ""
+  }
+
+  @Test
+  func theProbeIsOneMultiplexedDialThatFindsTheTranscriptItself() {
+    let invocation = ClaudeSessionLog.remoteSummaryInvocation(
+      forNode: node(.claudeCode), at: location, since: nil)
+
+    // The same multiplexed connection every other remote reading rides.
+    #expect(invocation.first == "/usr/bin/ssh")
+    #expect(invocation.contains("ControlMaster=auto"))
+    #expect(invocation.contains("-p"))
+    #expect(invocation.contains("2222"))
+    #expect(invocation.contains("dev@build-box"))
+
+    let script = remoteCommand(invocation)
+    // The id the host banks for `--resume` is the id the transcript is named after, so
+    // the lookup is the local rule in `sh` rather than a second rule.
+    #expect(script.contains(".graphcode/sessions"))
+    #expect(script.contains(".claude/projects"))
+    #expect(script.contains(RemoteTranscriptProbe.marker))
+    // Tool results are most of a transcript's bytes and make no beats — they never travel.
+    #expect(script.contains("grep -av toolUseResult"))
+    #expect(script.contains("tail -c 262144"))
+  }
+
+  /// A transcript that has not moved answers in one word, and that is what makes a poll
+  /// over a network affordable at all.
+  @Test
+  func aStampWeAlreadyHaveIsSentBackSoNothingShips() {
+    let script = remoteCommand(
+      ClaudeSessionLog.remoteSummaryInvocation(
+        forNode: node(.claudeCode), at: location, since: "1786700000"))
+
+    #expect(script.contains("1786700000"))
+    #expect(script.contains("unchanged"))
+    // Both spellings of stat: a loop's host is a Linux box or a Mac, and this runs on
+    // whichever it is.
+    #expect(script.contains("stat -c %Y"))
+    #expect(script.contains("stat -f %m"))
+  }
+
+  @Test
+  func copilotAndCodexBringBackTheirOwnFiles() {
+    let copilot = remoteCommand(
+      CopilotSessionLog.remoteSummaryInvocation(
+        forNode: node(.copilotCLI), at: location, since: nil))
+    #expect(copilot.contains(".copilot/session-state"))
+    #expect(copilot.contains("workspace.yaml"))
+    // A keep-list, spelled as the grep sees it: Copilot's log carries whole tool outputs
+    // in a type of their own, and they never travel.
+    #expect(copilot.contains(#"assistant\.message"#))
+    #expect(copilot.contains(#"assistant\.turn_end"#))
+    #expect(copilot.contains("tool.execution_complete") == false)
+
+    let codex = remoteCommand(
+      CodexSessionLog.remoteSummaryInvocation(
+        forNode: node(.codex), at: location, workingDirectory: "/home/dev/widget", since: nil))
+    #expect(codex.contains(".codex/sessions"))
+    // Codex has no `--name`; the directory the session opened in is the only handle.
+    #expect(codex.contains("/home/dev/widget"))
+    #expect(codex.contains("function_call_output"))
+  }
+
+  // MARK: - Framing
+
+  private func reply(_ lines: [String]) -> String {
+    // As it arrives: the remote login shell's own chatter first, and a carriage return on
+    // every line because the probe comes back over a PTY.
+    (["Welcome to build-box", "(reverse-i-search)"] + lines).joined(separator: "\r\n")
+  }
+
+  @Test
+  func theMarkerIsWhatIsRead() {
+    let record = #"{"type":"assistant","timestamp":"2026-08-13T22:39:28.418Z"}"#
+    let parsed = RemoteTranscriptProbe.parse(
+      succeeded: true, output: reply(["graphcode-summary: lines 1786700123", record]))
+
+    #expect(parsed == .lines(stamp: "1786700123", lines: [Data(record.utf8)]))
+
+    #expect(
+      RemoteTranscriptProbe.parse(
+        succeeded: true, output: reply(["graphcode-summary: unchanged"])) == .unchanged)
+    #expect(
+      RemoteTranscriptProbe.parse(
+        succeeded: true, output: reply(["graphcode-summary: nothing"])) == .nothing)
+    // ssh itself failing says nothing about the session, and a shell that printed no
+    // marker never ran the script.
+    #expect(RemoteTranscriptProbe.parse(succeeded: false, output: "") == .nothing)
+    #expect(
+      RemoteTranscriptProbe.parse(succeeded: true, output: reply(["some rc noise"]))
+        == .nothing)
+  }
+
+  /// The whole point of the round trip: records in, beats out, through the same reader the
+  /// local path uses.
+  @Test
+  func remoteRecordsBecomeTheSameBeatsLocalOnesDo() throws {
+    let stamp = "2026-08-13T22:39:28.418Z"
+    let user = #"{"type":"user","timestamp":"\#(stamp)","message":{"role":"user","content":"go"}}"#
+    let assistant =
+      #"{"type":"assistant","timestamp":"\#(stamp)","message":{"role":"assistant","#
+      + #""stop_reason":"end_turn","content":[{"type":"text","text":"Shipped the beta."}]}}"#
+
+    guard
+      case .lines(_, let lines) = RemoteTranscriptProbe.parse(
+        succeeded: true, output: reply(["graphcode-summary: lines 1786700123", user, assistant]))
+    else {
+      Issue.record("the probe did not frame a payload")
+      return
+    }
+
+    var builder = ClaudeSessionLog.builder(forLines: lines)
+    let beats = builder.beats()
+
+    #expect(beats.map(\.text) == ["Shipped the beta"])
+    #expect(beats.first?.endsTurn == true)
+    #expect(builder.userTurns().count == 1)
+  }
+}


### PR DESCRIPTION
The rail read nothing for a remote project — the transcript is on the other machine, and three doc comments said carrying beats back was a larger change than that PR. This is it.

Presence and activity ask a *question* over ssh and bring back one word. A summary needs the records, so the probe does as much as a shell can and ships only what is left, over the `ControlMaster` connection every other remote reading already rides:

| | |
| --- | --- |
| **Nothing when nothing moved** | The remote `stat` comes back with the payload and goes out with the next request. A quiet remote loop costs a `stat` and no bytes. Spelled `-c %Y` and `-f %m` — a loop's host is a Linux box or a Mac |
| **The big records never travel** | Claude's tool results are dropped on `toolUseResult` (not the string `tool_result`, which appears in prose the moment an agent discusses its own transcript); Copilot's by a keep-list of the four event types that make beats; Codex's on its two output types. Any line over 64 KB goes |
| **One dial** | A channel on a live master, not a handshake |

Each backend finds its own file the way it does locally — Claude by the id the remote host banks for `--resume`, Copilot by the `--name` in `workspace.yaml`, Codex by the directory the session opened in. What comes back goes through exactly the reader the local path uses.

856 tests pass, five new: the script fragments and the framing are values and are asserted as values, the way the ensure dial is.