### PR TITLE
Terminate a composite's sub-graph sessions when it is deleted

### DIFF
--- a/GraphcodeKit/Sources/Domain/LoopGraph.swift
+++ b/GraphcodeKit/Sources/Domain/LoopGraph.swift
@@ -63,6 +63,16 @@ public struct LoopGraph: Identifiable, Codable, Equatable, Sendable {
     nodes.contains { $0.id == nodeID || ($0.subGraph?.containsAtAnyDepth(nodeID) ?? false) }
   }
 
+  /// Every node in this graph and, recursively, inside any composite's sub-graph.
+  ///
+  /// The enumeration counterpart to `containsAtAnyDepth`, for teardown: a piloted
+  /// composite's workers have real sessions and memory of their own, so anything that
+  /// discards loops wholesale has to be able to visit them without knowing how deep
+  /// the nesting goes.
+  public var nodesAtAnyDepth: [LoopNode] {
+    nodes.flatMap { [$0] + ($0.subGraph?.nodesAtAnyDepth ?? []) }
+  }
+
   /// A structural copy with brand-new identities throughout — same loops, same wiring,
   /// nothing shared with the original.
   ///

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -842,6 +842,16 @@ public actor GraphStore {
     // memory goes the same way — a log for a loop that no longer exists is litter.
     terminateSession(node)
     onRemoveMemory?(node.id)
+
+    // A composite's workers live in its sub-graph, on this node rather than in
+    // `graph.nodes` — the same blind spot `requestStop` covers when stopping, and the
+    // sessions `pilotComposite` and `spawnInstance` started for them are just as real.
+    // Killed rather than asked, unlike a stop: the nodes cease to exist with their
+    // parent, so there is nothing left for a polite stop request to resolve.
+    for worker in node.subGraph?.nodesAtAnyDepth ?? [] {
+      terminateSession(worker)
+      onRemoveMemory?(worker.id)
+    }
   }
 
   /// The fan-out descendants of a node — the loops it created, theirs, and so on,

--- a/graphcode/Tests/GraphStoreDeletionTests.swift
+++ b/graphcode/Tests/GraphStoreDeletionTests.swift
@@ -92,6 +92,37 @@ struct GraphStoreDeletionTests {
   }
 
   @Test
+  func deletingACompositeEndsItsSubGraphWorkersSessions() async {
+    // A piloted composite's workers have real sessions, but their nodes live in the
+    // composite's sub-graph rather than in `graph.nodes` — so the plain deletion walk
+    // never saw them, and deleting a running composite orphaned every worker session.
+    // Nested composites included: the inner worker is two levels down.
+    let innerWorker = LoopNode(
+      title: "Deep worker", loopType: .timeBased, triggerPrompt: "/loop 1h deep")
+    let inner = LoopNode(
+      title: "Inner", loopType: .composite,
+      subGraph: LoopGraph(
+        project: ProjectRef(path: "inner", name: "inner"),
+        nodes: [innerWorker]))
+    let worker = LoopNode(
+      title: "Worker", loopType: .timeBased, triggerPrompt: "/loop 1h Check")
+    let composite = LoopNode(
+      title: "Routine", loopType: .composite,
+      subGraph: LoopGraph(
+        project: ProjectRef(path: "sub", name: "sub"),
+        nodes: [worker, inner]),
+      pilotState: .piloted)
+    let killed = LockIsolated<Set<UUID>>([])
+    let store = GraphStore(
+      graph: LoopGraph(project: ProjectRef(path: "/tmp/p", name: "p"), nodes: [composite]),
+      onTerminateSession: { node, _ in _ = killed.withValue { $0.insert(node.id) } })
+
+    await store.handle(.deleteNode(composite.id))
+
+    #expect(killed.value == [composite.id, worker.id, inner.id, innerWorker.id])
+  }
+
+  @Test
   func deletingAnEdgeUnblocksItsTarget() async {
     let store = GraphStore()
     await store.handle(


### PR DESCRIPTION
Fixes #116

Deleting a running composite orphaned every worker session its pilot had started: the workers' nodes live in the composite's sub-graph on the parent node, not in `graph.nodes`, so the deletion walk never visited them. `requestStop` already covers this blind spot when stopping; `removeSingleNode` now does the equivalent for deletion — a new `LoopGraph.nodesAtAnyDepth` enumerates the sub-graph at any nesting depth, and each worker's session is killed (not asked — the nodes cease to exist with their parent) and its memory removed.

Regression test: `deletingACompositeEndsItsSubGraphWorkersSessions` builds a composite with a worker and a nested composite holding a second worker two levels down, deletes the composite, and expects all four sessions terminated. Full suite passes.

Companion to #114 (zmx foreground-group kill) and #117 (deleteProjectGraph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)