### PR TITLE
fix: deleting a project's loops left every session running (#117)

### DIFF
--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -844,6 +844,31 @@ public actor GraphStore {
     onRemoveMemory?(node.id)
   }
 
+  /// Ends every session this graph holds a handle on — the whole-graph counterpart of the
+  /// kill in `removeSingleNode`, for when the graph itself is being discarded rather than
+  /// one node (`ProjectRegistry`'s `.deleteProjectGraph`).
+  ///
+  /// Same reasoning one level up: the graph was the only handle on these sessions, so
+  /// throwing it away without this leaves one agent per loop running with nothing left
+  /// pointing at them. A composite's workers are killed from *this* store rather than by
+  /// descending into a child one, matching `pilotComposite`, which starts them from here —
+  /// so both ends route through the same project path. A sub-graph's own
+  /// `project.path` is a synthetic `"<title>-subgraph"` (`NodeDraft.makeNode`) and would
+  /// not reach the zmx daemon that owns the session.
+  public func terminateAllSessions() {
+    for node in graph.nodes { terminateSessionTree(node) }
+  }
+
+  /// A node's session and, for a composite, every session beneath it. Recursive because a
+  /// sub-graph node lives on its parent node rather than in `graph.nodes`, nested
+  /// composites included.
+  private func terminateSessionTree(_ node: LoopNode) {
+    terminateSession(node)
+    if node.loopType == .composite, let subGraph = node.subGraph {
+      for child in subGraph.nodes { terminateSessionTree(child) }
+    }
+  }
+
   /// The fan-out descendants of a node — the loops it created, theirs, and so on,
   /// walked through `LoopNode.createdBy`.
   private func spawnedDescendants(of nodeID: UUID) -> [LoopNode] {

--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -222,9 +222,18 @@ public actor ProjectRegistry {
       await close(canonicalPath, for: connectionID)
       persistence.forgetProject(path: canonicalPath)
       // Drop the in-memory store too, or a later reopen would resurrect the graph we
-      // just deleted from the one still sitting in `stores`.
-      stores.removeValue(forKey: canonicalPath)
+      // just deleted from the one still sitting in `stores`. Held onto rather than
+      // dropped outright, because it is the last thing that knows which sessions this
+      // project had — and the removal and the delete stay back to back with nothing
+      // awaited between them, so no command can arrive mid-deletion and be routed to a
+      // store that is on its way out.
+      let deletedStore = stores.removeValue(forKey: canonicalPath)
       persistence.deleteGraph(path: canonicalPath)
+      // Discarding the loops has to end them. This is the irreversible verb of the three,
+      // and afterwards nothing — no store, no file, no card — points at those sessions,
+      // so any left running runs on unreachable. Deleting a single node already kills its
+      // session for exactly this reason; deleting every loop is the same act, in bulk.
+      await deletedStore?.terminateAllSessions()
 
     case .graphCommand(let path, let inner):
       guard let store = stores[Self.canonicalize(path)] else { return }

--- a/graphcode/Tests/ProjectRegistryTests.swift
+++ b/graphcode/Tests/ProjectRegistryTests.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import Foundation
 import GraphcodeKit
 import Testing
@@ -252,6 +253,52 @@ struct ProjectRegistryTests {
     // it would persist the graph we just deleted straight back to disk.
     await registry.handle(.openProject(path: "/tmp/project-e"), connectionID: connectionID)
     #expect(persistence.loadGraph(path: "/tmp/project-e")?.nodes.isEmpty != false)
+  }
+
+  @Test
+  func deletingAProjectsLoopsEndsEverySessionTheyHeld() async throws {
+    // Discarding the loops has to end them: after this there is no store, no file and no
+    // card pointing at those sessions, so any left running runs forever unreachable. A
+    // composite's workers count — their nodes live on the composite rather than in the
+    // graph's own `nodes`, which is exactly how they get missed.
+    let killed = LockIsolated<[String]>([])
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("graphcode-tests-\(UUID().uuidString)", isDirectory: true)
+    let registry = ProjectRegistry(
+      persistenceDirectory: directory,
+      ensureSession: nil,
+      terminateSession: { node, _ in killed.withValue { $0.append(node.title) } })
+    let persistence = ProjectPersistence(baseDirectory: directory)
+
+    let connectionID = UUID()
+    await registry.addConnection(id: connectionID, fileDescriptor: -1)
+    await registry.handle(.openProject(path: "/tmp/project-c"), connectionID: connectionID)
+    await registry.handle(
+      .graphCommand(
+        projectPath: "/tmp/project-c",
+        command: .createNode(
+          NodeDraft(title: "Poll inbox", loopType: .timeBased, triggerPrompt: "/loop 1h Check"))),
+      connectionID: connectionID)
+    await registry.handle(
+      .graphCommand(
+        projectPath: "/tmp/project-c",
+        command: .createNode(NodeDraft(title: "Triage", loopType: .composite))),
+      connectionID: connectionID)
+    let compositeID = try #require(
+      persistence.loadGraph(path: "/tmp/project-c")?
+        .nodes.first(where: { $0.loopType == .composite })?.id)
+    await registry.handle(
+      .graphCommand(
+        projectPath: "/tmp/project-c",
+        command: .subGraphCommand(
+          nodeID: compositeID,
+          command: .createNode(
+            NodeDraft(title: "Worker", loopType: .timeBased, triggerPrompt: "/loop 1h work")))),
+      connectionID: connectionID)
+
+    await registry.handle(.deleteProjectGraph(path: "/tmp/project-c"), connectionID: connectionID)
+
+    #expect(Set(killed.value) == ["Poll inbox", "Triage", "Worker"])
   }
 
   /// Paths round-trip through `resolvingSymlinksInPath()`, so compare the leaf rather


### PR DESCRIPTION
Fixes #117

## Summary

`.deleteProjectGraph` discarded a project's loops for good without terminating any of their sessions, orphaning every running loop's `zmx` session and agent process. This adds the whole-graph counterpart of the kill that deleting a single node already does.

**Root cause.** `ProjectRegistry.handle`'s `.deleteProjectGraph` case (`ProjectRegistry.swift:220`) closed the project, forgot it from recents, dropped the in-memory store and deleted the persisted graph — four steps that between them destroy every remaining handle on the project's loops — but never called `terminateSession` for any of them. The registry has held that closure since it was written (`ProjectRegistry.swift:27`), and `GraphStore.removeSingleNode` already kills a single deleted node's session on exactly this reasoning ("the graph was the only handle on a detached session"). The bulk path simply never got the same treatment, so after "Delete Loops…" every loop in the project kept running with no graph, no store and no card pointing at it — and therefore no way to reach it and stop it.

## Changes

- **`GraphStore.terminateAllSessions()`** — new, the whole-graph counterpart of `removeSingleNode`'s kill. Walks `graph.nodes` and, for composites, recurses into `subGraph` (nested composites included), since those nodes live on the composite rather than in `graph.nodes` and are otherwise invisible to any walk over the graph's own nodes.
- **`ProjectRegistry`'s `.deleteProjectGraph`** — takes the store out of `stores` and calls `terminateAllSessions()` on it. `stores.removeValue` and `persistence.deleteGraph` are kept back to back with nothing awaited between them, so the new suspension point sits after the deletion is complete rather than inside it.
- One regression test.

Two notes on why it is shaped this way, both deliberate and minimal:

- The sub-graph walk runs from the **owning** store rather than by descending into child stores. `pilotComposite` starts those worker sessions from the parent store, so killing them from there routes both ends through the same project path. A sub-graph's own `project.path` is a synthetic `"<title>-subgraph"` (`NodeDraft.makeNode:181`) and would not reach the zmx daemon that owns the session.
- Only sessions are ended. Node memory (`onRemoveMemory`) is left alone — `.deleteProjectGraph` does not remove it today either, and that is a separate question from the orphaned processes this issue reports.

## Test plan

`graphcode/Tests/ProjectRegistryTests.swift` — `deletingAProjectsLoopsEndsEverySessionTheyHeld`: builds a registry with an injected `terminateSession`, creates a time-based loop plus a composite with a worker in its sub-graph, deletes the project's graph, and asserts all three sessions were terminated. Fails before this change (nothing is terminated at all).

### Verified in cloud (static only — no Xcode/macOS SDK in this sandbox)

- Every symbol referenced checked against its declaration: `terminateSession(_:)` (`GraphStore.swift:143`), `LoopNode.subGraph: LoopGraph?` (`LoopNode.swift:59`), `LoopGraph.nodes: IdentifiedArrayOf<LoopNode>`, `LoopType.composite`, `GraphStore.graph` (`public private(set)`), `ProjectRegistry.init(persistenceDirectory:ensureSession:terminateSession:…)`, `ProjectPersistence.loadGraph(path:)`, `DaemonCommand.{openProject,graphCommand,deleteProjectGraph}`, `GraphCommand.{createNode,subGraphCommand}`, `NodeDraft(title:loopType:triggerPrompt:)`.
- `terminateAllSessions` / `terminateSessionTree` grepped repo-wide: no existing declarations or call sites, so nothing is shadowed or overridden.
- Nothing existing was modified beyond the `.deleteProjectGraph` case body, so there are no other call sites to break; both new methods are additions.
- Draft validity confirmed against `NodeDraft.isValid` — `.composite` needs a non-empty title, `.timeBased` a `triggerPrompt`; both drafts in the test mirror shapes already used in `CompositeAndGlobalGraphTests`.
- `LockIsolated` idiom and `#expect(Set(...) == [...])` copied from `GraphStoreDeletionTests` / `CreatedByLoopTests`; `graphcode/Tests` is one target (`Project.swift:84`), so the `ComposableArchitecture` import is already available there.
- Formatting checked by hand against `.swift-format`: 2-space indent, no added line over 100 columns.

### NOT verified — needs the maintainer's Mac

- [ ] `make build-app` — nothing here can compile Swift (no Xcode, no macOS SDK, no toolchain at all).
- [ ] `make test` — in particular the new `deletingAProjectsLoopsEndsEverySessionTheyHeld` and the existing `deletingAProjectsLoopsDiscardsThemForGood`.
- [ ] `make check` — swift-format was not runnable here; formatting was matched by eye.
- [ ] Manual repro for #117: open a project, start two loops (one plain, one **composite that has been piloted** so its workers hold real sessions), confirm `zmx list` shows their sessions, then right-click the project → **Delete Loops…** → confirm. `zmx list` should show none of those sessions afterwards, and no orphaned `claude`/`codex`/`copilot` process should survive. Before this change all of them do.
- [ ] Same check via the sidebar's **Delete "<project>"…** → delete from disk, which sends the same command.

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have signed off my commits (`git commit -s`) per the DCO
- [ ] Tests pass locally (`make test`) — **cannot run in this environment**
- [ ] Code follows the existing style (`make check`) — **cannot run in this environment**

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzJRpLzKbRQQ44uRHP5kFu)_