### PR TITLE
End every loop's session before deleting a project's graph

### DIFF
--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -221,6 +221,18 @@ public actor ProjectRegistry {
       let canonicalPath = Self.canonicalize(path)
       await close(canonicalPath, for: connectionID)
       persistence.forgetProject(path: canonicalPath)
+      // The graph is the only handle on every loop's detached session, so its deletion
+      // has to end them first — dropping it with the sessions alive left every agent in
+      // the project running forever with nothing pointing at it. Read from the resident
+      // store when there is one, else straight from disk: going through
+      // `store(forProjectPath:)` would run its load-time `ensureUnattendedSessions`,
+      // *starting* sessions on the way to killing them. Memory goes with each loop, the
+      // same as single-node deletion.
+      let graph = await stores[canonicalPath]?.graph ?? persistence.loadGraph(path: canonicalPath)
+      for node in graph?.nodesAtAnyDepth ?? [] {
+        terminateSession?(node, canonicalPath)
+        NodeMemory.remove(projectPath: canonicalPath, nodeID: node.id)
+      }
       // Drop the in-memory store too, or a later reopen would resurrect the graph we
       // just deleted from the one still sitting in `stores`.
       stores.removeValue(forKey: canonicalPath)

--- a/graphcode/Tests/ProjectRegistryTests.swift
+++ b/graphcode/Tests/ProjectRegistryTests.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import Foundation
 import GraphcodeKit
 import Testing
@@ -20,7 +21,9 @@ struct ProjectRegistryTests {
   /// have to be there. They were not, and the tests passed anyway — which is exactly how
   /// `/tmp/x` and a folder called "/" ended up as real projects with real stores.
   init() throws {
-    for name in ["project-a", "project-b", "project-c", "project-d", "project-e"] {
+    for name in [
+      "project-a", "project-b", "project-c", "project-d", "project-e", "project-f", "project-g",
+    ] {
       try FileManager.default.createDirectory(
         atPath: "/tmp/\(name)", withIntermediateDirectories: true)
     }
@@ -252,6 +255,92 @@ struct ProjectRegistryTests {
     // it would persist the graph we just deleted straight back to disk.
     await registry.handle(.openProject(path: "/tmp/project-e"), connectionID: connectionID)
     #expect(persistence.loadGraph(path: "/tmp/project-e")?.nodes.isEmpty != false)
+  }
+
+  @Test
+  func deletingAProjectsLoopsEndsEverySessionFirst() async {
+    // The graph is the only handle on the loops' detached sessions — deleting it with
+    // them alive left every agent in the project running forever, invisible to any UI.
+    // The composite's worker is the deep case: its node lives in a sub-graph, so a walk
+    // of `graph.nodes` alone would miss its session.
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("graphcode-tests-\(UUID().uuidString)", isDirectory: true)
+    let killed = LockIsolated<Set<UUID>>([])
+    let registry = ProjectRegistry(
+      persistenceDirectory: directory,
+      ensureSession: { _, _ in },
+      terminateSession: { node, _ in _ = killed.withValue { $0.insert(node.id) } })
+    let persistence = ProjectPersistence(baseDirectory: directory)
+    let connectionID = UUID()
+    await registry.addConnection(id: connectionID, fileDescriptor: -1)
+    await registry.handle(.openProject(path: "/tmp/project-f"), connectionID: connectionID)
+    await registry.handle(
+      .graphCommand(
+        projectPath: "/tmp/project-f",
+        command: .createNode(
+          NodeDraft(title: "Watcher", loopType: .timeBased, triggerPrompt: "/loop 1h Check"))),
+      connectionID: connectionID)
+    await registry.handle(
+      .graphCommand(
+        projectPath: "/tmp/project-f",
+        command: .createNode(NodeDraft(title: "Routine", loopType: .composite))),
+      connectionID: connectionID)
+    let saved = persistence.loadGraph(path: "/tmp/project-f")
+    let compositeID = saved?.nodes.first { $0.loopType == .composite }?.id
+    await registry.handle(
+      .graphCommand(
+        projectPath: "/tmp/project-f",
+        command: .subGraphCommand(
+          nodeID: compositeID ?? UUID(),
+          command: .createNode(
+            NodeDraft(title: "Worker", loopType: .timeBased, triggerPrompt: "/loop 1h work")))),
+      connectionID: connectionID)
+    let everyLoop = Set(
+      persistence.loadGraph(path: "/tmp/project-f")?.nodesAtAnyDepth.map(\.id) ?? [])
+    #expect(everyLoop.count == 3)
+
+    await registry.handle(.deleteProjectGraph(path: "/tmp/project-f"), connectionID: connectionID)
+
+    #expect(killed.value == everyLoop)
+  }
+
+  @Test
+  func deletingAClosedProjectsLoopsStillEndsTheirSessions() async {
+    // A graph can be deleted while its project is closed and its loops still running —
+    // a fresh daemon has no resident store for it, so the nodes come off disk. And they
+    // must come off disk *without* loading a real store: `store(forProjectPath:)` runs
+    // `ensureUnattendedSessions` on load, which would start sessions on the way to
+    // killing them.
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("graphcode-tests-\(UUID().uuidString)", isDirectory: true)
+    let firstRun = ProjectRegistry(
+      persistenceDirectory: directory, ensureSession: { _, _ in }, terminateSession: { _, _ in })
+    let connectionID = UUID()
+    await firstRun.addConnection(id: connectionID, fileDescriptor: -1)
+    await firstRun.handle(.openProject(path: "/tmp/project-g"), connectionID: connectionID)
+    await firstRun.handle(
+      .graphCommand(
+        projectPath: "/tmp/project-g",
+        command: .createNode(
+          NodeDraft(title: "Watcher", loopType: .timeBased, triggerPrompt: "/loop 1h Check"))),
+      connectionID: connectionID)
+    let persistence = ProjectPersistence(baseDirectory: directory)
+    let nodeID = persistence.loadGraph(path: "/tmp/project-g")?.nodes.first?.id
+
+    let killed = LockIsolated<Set<UUID>>([])
+    let started = LockIsolated<Set<UUID>>([])
+    let secondRun = ProjectRegistry(
+      persistenceDirectory: directory,
+      ensureSession: { node, _ in _ = started.withValue { $0.insert(node.id) } },
+      terminateSession: { node, _ in _ = killed.withValue { $0.insert(node.id) } })
+    let freshConnection = UUID()
+    await secondRun.addConnection(id: freshConnection, fileDescriptor: -1)
+    await secondRun.handle(
+      .deleteProjectGraph(path: "/tmp/project-g"), connectionID: freshConnection)
+
+    #expect(killed.value == Set([nodeID].compactMap { $0 }))
+    #expect(started.value.isEmpty)
+    #expect(persistence.loadGraph(path: "/tmp/project-g") == nil)
   }
 
   /// Paths round-trip through `resolvingSymlinksInPath()`, so compare the leaf rather


### PR DESCRIPTION
Fixes #117

`.deleteProjectGraph` discarded a project's saved loops without terminating any of their sessions — every running loop in the project kept its zmx session and agent process alive forever, with no graph left pointing at them. The registry now walks the graph via `LoopGraph.nodesAtAnyDepth` (so a piloted composite's workers are covered too, per #116) and terminates each session and its memory log before dropping the store and the persisted graph.

Two deliberate choices:
- **Not routed through `store(forProjectPath:)`**: its load-time `ensureUnattendedSessions` would *start* sessions on the way to killing them. The graph is read from the resident store when one exists, else straight from disk.
- **Works for closed projects**: a graph can be deleted while its project is closed and its loops still running (e.g. a fresh daemon) — the disk read covers that case.

Tests: `deletingAProjectsLoopsEndsEverySessionFirst` (resident store, includes a composite worker two levels down) and `deletingAClosedProjectsLoopsStillEndsTheirSessions` (fresh registry, no resident store, asserts no session is started during the delete). Full suite passes; `make check` clean for the touched files.

Companion to #114 (zmx foreground-group kill) and #116 (composite delete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)