### PR TITLE
Widen the Settings window to 540pt

### DIFF
--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -19,7 +19,7 @@ struct SettingsView: View {
   /// nothing is worse than no tab.
   var body: some View {
     sessions
-      .frame(width: 460)
+      .frame(width: 540)
       .padding(.vertical, 4)
   }
 


### PR DESCRIPTION
The Settings window (⌘,) was a cramped 460pt wide for a six-section form whose picker labels and explanation footers want more room. 540pt gives it that breathing space; height still auto-sizes to content as before. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)