### PR TITLE
Make the Settings window resizable and wider

### DIFF
--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -19,7 +19,7 @@ struct SettingsView: View {
   /// nothing is worse than no tab.
   var body: some View {
     sessions
-      .frame(width: 540)
+      .frame(minWidth: 620, maxWidth: .infinity)
       .padding(.vertical, 4)
   }
 

--- a/graphcode/Sources/GraphcodeApp.swift
+++ b/graphcode/Sources/GraphcodeApp.swift
@@ -98,5 +98,9 @@ struct GraphcodeApp: App {
     Settings {
       SettingsView()
     }
+    // Settings scenes default to `.contentSize`, which pins the window to its content
+    // and leaves it un-resizable. Min-size keeps the form's own minimum as the floor
+    // while letting anyone drag it larger.
+    .windowResizability(.contentMinSize)
   }
 }


### PR DESCRIPTION
Follow-up to #121: 540pt was still tight, and the window couldn't be resized at all.

- `SettingsView` frame goes from a fixed `width: 540` to `minWidth: 620, maxWidth: .infinity`.
- The `Settings` scene gets `.windowResizability(.contentMinSize)` — Settings scenes default to `.contentSize`, which pins the window to its content and is why dragging its edges did nothing. With min-size, the form's minimum stays the floor and the window drags larger in both axes.

Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)