### PR TITLE
Add the Sketch loop type

### DIFF
--- a/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
+++ b/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
@@ -43,7 +43,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
     USAGE
       graphcode projects
       graphcode status <project-path>
-      graphcode node create <project-path> --title <t> --type <turn|goal|time|composite> [options]
+      graphcode node create <project-path> --title <t> --type <sketch|turn|goal|time|composite> [options]
       graphcode node stop <project-path> <node-id>
       graphcode node delete <project-path> <node-id>   removes it, its edges, session
                            and memory — irreversible; stop is the reversible verb
@@ -74,7 +74,8 @@ public enum GraphcodeCommand: Equatable, Sendable {
       --check <text>       what a human verifies each turn; optional
       --goal <text>        required for --type goal
       --predicate <cmd>    optional stop condition for --type goal (exit 0 = met)
-      --prompt <text>      required for --type time; put the cadence in it (/loop 1h …)
+      --prompt <text>      required for --type time; put the cadence in it (/loop 1h …).
+                           For --type sketch it is the optional starting note
       --backend <name>     claudeCode | copilotCLI | codex — default: run from inside a
                            loop, the creating loop's backend; otherwise claudeCode
       --model <tier>       fast | standard | capable           (default: by loop type)
@@ -249,6 +250,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
 
     let loopType: LoopType
     switch rawType {
+    case "sketch": loopType = .sketch
     case "turn", "turnBased": loopType = .turnBased
     case "goal", "goalBased": loopType = .goalBased
     case "time", "timeBased": loopType = .timeBased
@@ -294,7 +296,8 @@ public enum GraphcodeCommand: Equatable, Sendable {
       // A turn-based loop needs something to do. `--prompt` is what a caller already
       // types for a timed loop's opening instruction, so it means the same thing here
       // rather than making them learn a second flag for the same idea.
-      firstInstruction: loopType == .turnBased ? flags["prompt"] : nil,
+      // A sketch's `--prompt` is its optional starting note, the same reuse.
+      firstInstruction: loopType == .turnBased || loopType == .sketch ? flags["prompt"] : nil,
       goal: flags["goal"].map {
         GoalSpec(
           summary: $0, predicate: flags["predicate"],

--- a/GraphcodeKit/Sources/Domain/BackendCapabilities.swift
+++ b/GraphcodeKit/Sources/Domain/BackendCapabilities.swift
@@ -161,6 +161,9 @@ extension CLISessionBackendKind {
     // Nothing graphcode can't actually launch may host anything.
     guard isSpiked else { return false }
     switch loopType {
+    case .sketch:
+      // A bare session — the least demanding type. Every launchable backend hosts it.
+      return true
     case .turnBased:
       return true
     case .goalBased:

--- a/GraphcodeKit/Sources/Domain/LoopGraph.swift
+++ b/GraphcodeKit/Sources/Domain/LoopGraph.swift
@@ -173,9 +173,14 @@ public struct LoopGraph: Identifiable, Codable, Equatable, Sendable {
   }
 
   /// Returned in `nodes` order, so the canvas's lines don't reshuffle between renders.
+  ///
+  /// Sketches are excluded before roots are picked: a sketch is not a graph beginning,
+  /// and a fresh one — edgeless by construction — would otherwise claim an entry port
+  /// the moment it was created.
   public var startAnchors: [UUID] {
     let targeted = Set(edges.map(\.to))
-    let entries = nodes.map(\.id).filter { !targeted.contains($0) }
+    let entries = nodes.filter { $0.loopType != .sketch }.map(\.id)
+      .filter { !targeted.contains($0) }
 
     var anchored = Set(entries)
     // Walk out from the entry points; whatever the walk never reaches is a cycle-only
@@ -188,7 +193,7 @@ public struct LoopGraph: Identifiable, Codable, Equatable, Sendable {
         frontier.append(edge.to)
       }
     }
-    for node in nodes where !reached.contains(node.id) {
+    for node in nodes where !reached.contains(node.id) && node.loopType != .sketch {
       anchored.insert(node.id)
       var frontier = [node.id]
       reached.insert(node.id)

--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -183,6 +183,11 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
   /// sequence, so a person opening it is what should begin it.
   public var sessionPrompt: String? {
     switch loopType {
+    case .sketch:
+      // The starting note, when there is one. A blank note means the session opens
+      // quiet and waits — asking nothing up front is what the type is for.
+      let note = firstInstruction?.trimmingCharacters(in: .whitespaces) ?? ""
+      return note.isEmpty ? nil : note
     case .timeBased: return triggerPrompt
     case .goalBased: return goal?.sessionPrompt
     case .turnBased:

--- a/GraphcodeKit/Sources/Domain/LoopType.swift
+++ b/GraphcodeKit/Sources/Domain/LoopType.swift
@@ -1,16 +1,21 @@
-/// The four loop primitives graphcode orchestrates — see docs/01-loop-taxonomy.md for
+/// The five loop primitives graphcode orchestrates — see docs/01-loop-taxonomy.md for
 /// the full definitions.
 ///
 /// Declared in the order a human should consider them, because that is the order
-/// `allCases` walks and the order every picker shows: goal-based first, since a loop that
-/// knows when it is finished is what most work wants and the only kind that both starts
-/// itself and ends itself; then time-based, which starts itself but never ends; then
-/// turn-based, which does neither without a person; then composite, which is a graph
-/// rather than a session and belongs at the end for that reason alone.
+/// `allCases` walks and the order every picker shows. The axis is how much you have to
+/// decide before the loop can start: sketch first, because it demands nothing at all —
+/// it opens and you start working; then goal-based, since a loop that knows when it is
+/// finished is what most work wants and the only kind that both starts itself and ends
+/// itself; then time-based, which starts itself but never ends; then turn-based, which
+/// does neither without a person; then composite, which is a graph rather than a
+/// session and belongs at the end for that reason alone.
 ///
 /// Raw values are unchanged by that ordering, so every graph already on disk decodes
 /// exactly as before.
 public enum LoopType: String, Codable, CaseIterable, Sendable {
+  /// The zero-commitment type: no goal, no cadence, no checkpoint. A bare session that
+  /// works with you until you close it.
+  case sketch
   case goalBased
   case timeBased
   case turnBased

--- a/GraphcodeKit/Sources/Domain/ModelTier.swift
+++ b/GraphcodeKit/Sources/Domain/ModelTier.swift
@@ -74,6 +74,7 @@ extension LoopType {
   /// Opt-in rather than the standing behaviour — see `ModelTier.resolved`.
   public var defaultModelTier: ModelTier {
     switch self {
+    case .sketch: return .standard
     case .turnBased: return .capable
     case .goalBased: return .standard
     case .timeBased: return .fast

--- a/GraphcodeKit/Sources/Domain/NodeDraft.swift
+++ b/GraphcodeKit/Sources/Domain/NodeDraft.swift
@@ -35,6 +35,7 @@ public struct NodeDraft: Codable, Equatable, Sendable {
   /// piloted and armed.
   public var triggerPrompt: String?
   /// `.turnBased`: what the session should actually do. See `LoopNode.firstInstruction`.
+  /// `.sketch`: the optional starting note — blank means the session opens quiet.
   public var firstInstruction: String?
   /// `.turnBased`: pause only before writes rather than after every turn.
   public var pausesBeforeWritesOnly: Bool
@@ -109,6 +110,10 @@ public struct NodeDraft: Codable, Equatable, Sendable {
     // to something its backend can actually manage.
     guard effectiveBackend.canHost(loopType) else { return false }
     switch loopType {
+    case .sketch:
+      // Valid while completely empty — the whole point of the type. `⏎` on an untouched
+      // dialog is a complete action; the starting note is the one field, and optional.
+      return true
     case .turnBased:
       // The *criterion* stays optional, for the reason it always was: a turn-based
       // loop's hand-off is a human watching it, and that human exists whether or not

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -716,7 +716,7 @@ public actor GraphStore {
         sessionFacing.append("each turn is now verified against: \(check)")
       }
 
-    case .composite:
+    case .sketch, .composite:
       break
     }
 

--- a/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
@@ -373,7 +373,8 @@ public enum RemoteGraphAccess {
             fail("missing --title")
         if not flags.get("type"):
             fail("missing --type")
-        types = {"turn": "turnBased", "turnBased": "turnBased",
+        types = {"sketch": "sketch",
+                 "turn": "turnBased", "turnBased": "turnBased",
                  "goal": "goalBased", "goalBased": "goalBased",
                  "time": "timeBased", "timeBased": "timeBased",
                  "composite": "proactive", "proactive": "proactive"}
@@ -394,7 +395,7 @@ public enum RemoteGraphAccess {
             draft["checkDescription"] = flags["check"]
         if flags.get("prompt"):
             draft["triggerPrompt"] = flags["prompt"]
-            if loop_type == "turnBased":
+            if loop_type in ("turnBased", "sketch"):
                 draft["firstInstruction"] = flags["prompt"]
         if flags.get("goal"):
             direction = flags.get("direction", "maximize")

--- a/graphcode/Sources/Features/App/LoopTypeAppearance.swift
+++ b/graphcode/Sources/Features/App/LoopTypeAppearance.swift
@@ -27,6 +27,10 @@ extension LoopType {
   /// which keeps its own ink so the colour beside it is what carries identity.
   var accent: Color {
     switch self {
+    // Deliberately colourless: the four committed types keep the saturated slots, and
+    // grey reads as *provisional* — a canvas of half-finished pokes shouldn't compete
+    // with work that matters.
+    case .sketch: Color(red: 0.486, green: 0.529, blue: 0.580)  // grey  #7c8794
     case .goalBased: Color(red: 0.098, green: 0.620, blue: 0.439)  // aqua  #199e70
     case .timeBased: Color(red: 0.788, green: 0.522, blue: 0.000)  // yellow #c98500
     case .turnBased: Color(red: 0.835, green: 0.318, blue: 0.506)  // magenta #d55181
@@ -46,6 +50,7 @@ extension LoopType {
   /// app admitting it had two vocabularies.
   var displayName: String {
     switch self {
+    case .sketch: "Sketch"
     case .goalBased: "Goal"
     case .timeBased: "Timed"
     case .turnBased: "Turn"
@@ -58,6 +63,7 @@ extension LoopType {
   /// waits for a person, and a composite one is a stack of loops rather than a session.
   var glyph: String {
     switch self {
+    case .sketch: "scribble"
     case .goalBased: "target"
     case .timeBased: "clock"
     case .turnBased: "person"

--- a/graphcode/Sources/Features/Canvas/LoopCardPresentation.swift
+++ b/graphcode/Sources/Features/Canvas/LoopCardPresentation.swift
@@ -104,6 +104,7 @@ struct LoopCardPresentation: Equatable {
 
   private static func handedLine(_ node: LoopNode) -> String? {
     switch node.loopType {
+    case .sketch: collapsed(node.firstInstruction)
     case .goalBased: collapsed(node.goal?.summary)
     case .timeBased: collapsed(node.triggerPrompt)
     case .turnBased: collapsed(node.checkDescription)

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
@@ -229,7 +229,7 @@ struct LoopWorkspaceView: View {
     switch store.node.loopType {
     case .timeBased: return "Loop"
     case .goalBased: return "Goal"
-    case .turnBased, .composite: return "Claude Code"
+    case .sketch, .turnBased, .composite: return "Claude Code"
     }
   }
 

--- a/graphcode/Sources/Features/Project/BackendPicker.swift
+++ b/graphcode/Sources/Features/Project/BackendPicker.swift
@@ -79,6 +79,10 @@ struct BackendPicker: View {
         + "loops running inside one node. Claude Code can host this one."
     case .turnBased:
       return "\(name) can't host a turn-based loop."
+    case .sketch:
+      // Unreachable while every spiked backend hosts a bare session, but the compiler
+      // rightly wants the sentence written down.
+      return "\(name) can't host a sketch."
     }
   }
 }

--- a/graphcode/Sources/Features/Project/LoopTypeChooser.swift
+++ b/graphcode/Sources/Features/Project/LoopTypeChooser.swift
@@ -1,7 +1,7 @@
 import GraphcodeKit
 import SwiftUI
 
-/// The four kinds of loop, as tiles that explain themselves.
+/// The five kinds of loop, as tiles that explain themselves.
 ///
 /// It was a four-segment picker, and the problem with that wasn't the shape — it was
 /// that four segments can only *name* the types. A control that names four things reads
@@ -10,7 +10,13 @@ import SwiftUI
 /// Proactive" also asks the reader to already know the taxonomy the dialog exists to
 /// teach.
 ///
-/// Shared with onboarding page 3, which teaches the same four things and would otherwise
+/// The axis the chooser is ordered on is how much you have to decide before the loop
+/// can start. Sketch demands nothing, so it sits above the grid as a full-width band —
+/// deliberately not a fifth tile: an orphan tile in a 2×2 rhythm reads as an
+/// afterthought, and a five-wide row shrinks every explanation to one truncated line.
+/// The labelled rule between them ("or commit to something") is the taxonomy lesson.
+///
+/// Shared with onboarding page 3, which teaches the same five things and would otherwise
 /// draw its own version of them.
 struct LoopTypeChooser: View {
   @Binding var selection: LoopType
@@ -20,50 +26,116 @@ struct LoopTypeChooser: View {
 
   private let columns = [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)]
 
+  /// ⌘1 Sketch · ⌘2 Goal · ⌘3 Timed · ⌘4 Turn · ⌘5 Composite — `allCases` order, which
+  /// the enum keeps in chooser order on purpose.
+  private static let shortcuts = Dictionary(
+    uniqueKeysWithValues: LoopType.allCases.enumerated().map { ($1, "\($0 + 1)") })
+
   var body: some View {
-    LazyVGrid(columns: columns, spacing: 8) {
-      ForEach(LoopType.allCases, id: \.self) { type in
-        tile(type)
+    VStack(alignment: .leading, spacing: 10) {
+      sketchBand
+      committedRule
+      LazyVGrid(columns: columns, spacing: 8) {
+        ForEach(LoopType.allCases.filter { $0 != .sketch }, id: \.self) { type in
+          tile(type)
+        }
       }
+    }
+  }
+
+  private var sketchBand: some View {
+    let isSelected = selection == .sketch
+    return Button {
+      selection = .sketch
+    } label: {
+      HStack(spacing: 10) {
+        RoundedRectangle(cornerRadius: 3)
+          .fill(LoopType.sketch.accent)
+          .frame(width: 10, height: 10)
+        Text(LoopType.sketch.displayName)
+          .font(.system(size: 12.5, weight: .semibold))
+          .foregroundStyle(.white.opacity(isSelected ? 0.95 : 0.8))
+        Text(explanation(.sketch))
+          .font(.system(size: 11))
+          .foregroundStyle(.white.opacity(0.6))
+          .lineLimit(1)
+        Spacer(minLength: 8)
+        Text("⌘1")
+          .font(.system(size: 10.5, design: .monospaced))
+          .foregroundStyle(.white.opacity(0.4))
+      }
+      .padding(.vertical, 11)
+      .padding(.horizontal, 12)
+      .background(
+        isSelected ? LoopType.sketch.accent.opacity(0.16) : Color.white.opacity(0.035),
+        in: RoundedRectangle(cornerRadius: 9)
+      )
+      .overlay {
+        RoundedRectangle(cornerRadius: 9)
+          .stroke(
+            isSelected ? LoopType.sketch.accent.opacity(0.72) : Color.white.opacity(0.08),
+            lineWidth: 1)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .keyboardShortcut("1", modifiers: .command)
+  }
+
+  private var committedRule: some View {
+    HStack(spacing: 8) {
+      Rectangle().fill(Color.white.opacity(0.08)).frame(height: 1)
+      Text("OR COMMIT TO SOMETHING")
+        .font(.system(size: 10.5, weight: .bold))
+        .kerning(0.7)
+        .foregroundStyle(.white.opacity(0.4))
+        .fixedSize()
+      Rectangle().fill(Color.white.opacity(0.08)).frame(height: 1)
     }
   }
 
   private func tile(_ type: LoopType) -> some View {
     let isSelected = type == selection
-    return VStack(alignment: .leading, spacing: 4) {
-      HStack(spacing: 7) {
-        RoundedRectangle(cornerRadius: 2.5)
-          .fill(type.accent)
-          .frame(width: 8, height: 8)
-        Text(type.displayName)
-          .font(.system(size: 12.5, weight: .semibold))
-          .foregroundStyle(.white.opacity(isSelected ? 0.95 : 0.8))
+    return Button {
+      selection = type
+    } label: {
+      VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: 7) {
+          RoundedRectangle(cornerRadius: 2.5)
+            .fill(type.accent)
+            .frame(width: 8, height: 8)
+          Text(type.displayName)
+            .font(.system(size: 12.5, weight: .semibold))
+            .foregroundStyle(.white.opacity(isSelected ? 0.95 : 0.8))
+        }
+        Text(explanation(type))
+          .font(.system(size: 11))
+          .foregroundStyle(.white.opacity(isSelected ? 0.55 : 0.58))
+          .fixedSize(horizontal: false, vertical: true)
+          .multilineTextAlignment(.leading)
       }
-      Text(explanation(type))
-        .font(.system(size: 11))
-        .foregroundStyle(.white.opacity(isSelected ? 0.55 : 0.58))
-        .fixedSize(horizontal: false, vertical: true)
-        .multilineTextAlignment(.leading)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.vertical, 9)
+      .padding(.horizontal, 10)
+      .background(
+        isSelected ? type.accent.opacity(0.12) : Color.white.opacity(0.035),
+        in: RoundedRectangle(cornerRadius: 9)
+      )
+      .overlay {
+        RoundedRectangle(cornerRadius: 9)
+          .stroke(
+            isSelected ? type.accent.opacity(0.6) : Color.white.opacity(0.08), lineWidth: 1)
+      }
+      .contentShape(Rectangle())
     }
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .padding(.vertical, 9)
-    .padding(.horizontal, 10)
-    .background(
-      isSelected ? type.accent.opacity(0.12) : Color.white.opacity(0.035),
-      in: RoundedRectangle(cornerRadius: 9)
-    )
-    .overlay {
-      RoundedRectangle(cornerRadius: 9)
-        .stroke(
-          isSelected ? type.accent.opacity(0.6) : Color.white.opacity(0.08), lineWidth: 1)
-    }
-    .contentShape(Rectangle())
-    .onTapGesture { selection = type }
+    .buttonStyle(.plain)
+    .modifier(TypeShortcut(key: Self.shortcuts[type]))
   }
 
   /// What the type *does* — the dialog's reading.
   static func whatItDoes(_ type: LoopType) -> String {
     switch type {
+    case .sketch: "Just start. No goal, no schedule, nothing to fill in."
     case .goalBased: "Works until a condition is met"
     case .timeBased: "Runs again on a schedule"
     case .turnBased: "Pauses for you each turn"
@@ -75,10 +147,25 @@ struct LoopTypeChooser: View {
   /// question a person actually has about an agent that runs on its own.
   static func whatStopsIt(_ type: LoopType) -> String {
     switch type {
+    case .sketch: "Never on its own — you close it when you're done"
     case .goalBased: "Stops when your check passes"
     case .timeBased: "Never — it runs again each interval"
     case .turnBased: "Stops after every turn, for you"
     case .composite: "Doesn't run until you arm it"
+    }
+  }
+}
+
+/// A ⌘-digit shortcut when the type has one; `keyboardShortcut` has no conditional
+/// form, so absence needs a modifier rather than an optional argument.
+private struct TypeShortcut: ViewModifier {
+  let key: String?
+
+  func body(content: Content) -> some View {
+    if let key, let character = key.first {
+      content.keyboardShortcut(KeyEquivalent(character), modifiers: .command)
+    } else {
+      content
     }
   }
 }

--- a/graphcode/Sources/Features/Project/NodeDraftForm.swift
+++ b/graphcode/Sources/Features/Project/NodeDraftForm.swift
@@ -52,8 +52,11 @@ struct NodeDraftForm: View {
     .padding(.horizontal, 22)
     .padding(.top, 20)
     .padding(.bottom, 18)
-    .frame(width: 520)
-    .frame(maxHeight: 680)
+    // Flexible on both axes so the sheet can be dragged larger — a fixed frame is what
+    // pinned it. The ideal height grew with the chooser, which is a band and a rule
+    // taller now that Sketch sits above the grid.
+    .frame(minWidth: 520, idealWidth: 520, maxWidth: .infinity)
+    .frame(minHeight: 560, idealHeight: 760, maxHeight: .infinity)
     .background(Theme.sheet)
   }
 
@@ -69,6 +72,7 @@ struct NodeDraftForm: View {
   @ViewBuilder
   private var typeFields: some View {
     switch store.draftLoopType {
+    case .sketch: SketchDraftFields(store: store)
     case .goalBased: GoalDraftFields(store: store)
     case .timeBased: TimedDraftFields(store: store)
     case .turnBased: TurnDraftFields(store: store)
@@ -107,6 +111,15 @@ struct NodeDraftForm: View {
       }
       if store.draftWorktree == .newBranch {
         DraftTextField(placeholder: "branch name", text: $store.draftBranch, isMono: true)
+      }
+      if store.draftLoopType == .sketch {
+        Text(
+          "Sketch loops don't cut a worktree by default — most of them read rather than "
+            + "write. Pick a branch here if this one will."
+        )
+        .font(.system(size: 11))
+        .foregroundStyle(.white.opacity(0.6))
+        .fixedSize(horizontal: false, vertical: true)
       }
       // The capability logic stays exactly where it was — this only shows what it says.
       if !store.draftBackend.canHost(store.draftLoopType) {
@@ -149,7 +162,7 @@ struct NodeDraftForm: View {
       store.send(.createNodeConfirmed)
     } label: {
       HStack(spacing: 6) {
-        Text(store.draftLoopType == .composite ? "Create & open" : "Create loop")
+        Text(createLabel)
           .font(.system(size: 13, weight: .semibold))
         Text("⏎").font(.system(size: 11, design: .monospaced)).opacity(0.7)
       }
@@ -167,6 +180,16 @@ struct NodeDraftForm: View {
     .disabled(!store.draft.isValid)
   }
 
+  /// A sketch *starts* rather than being created — asking for nothing and opening a
+  /// session is the whole type, and "Create loop" would overstate the ceremony.
+  private var createLabel: String {
+    switch store.draftLoopType {
+    case .sketch: "Start"
+    case .composite: "Create & open"
+    case .goalBased, .timeBased, .turnBased: "Create loop"
+    }
+  }
+
   /// Which field is missing, in the words of the thing that is missing.
   private var disabledReason: String? {
     guard !store.draft.isValid else { return nil }
@@ -174,6 +197,7 @@ struct NodeDraftForm: View {
       return "This agent can't host this kind of loop"
     }
     switch store.draftLoopType {
+    case .sketch: return nil  // Never incomplete — an empty sketch is a valid one.
     case .goalBased: return "Say what done looks like to continue"
     case .timeBased: return "Say what to do each time to continue"
     case .turnBased: return "Add a first instruction to continue"

--- a/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
+++ b/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
@@ -2,6 +2,25 @@ import ComposableArchitecture
 import GraphcodeKit
 import SwiftUI
 
+/// A sketch's one field — the shortest form in the app. `⏎` on an untouched dialog is
+/// a valid, complete action; that is the point of the type. No done check, no cadence,
+/// no name field: the loop names itself from the first exchange, and the starting note
+/// seeds that name when there is one.
+struct SketchDraftFields: View {
+  @Bindable var store: StoreOf<ProjectFeature>
+
+  var body: some View {
+    DraftField(
+      label: "Starting note", qualifier: "optional — leave it blank and it opens quiet",
+      help: "No done check, no cadence — it works with you until you close it."
+    ) {
+      DraftProseField(
+        placeholder: "e.g. where does the usage cap get read from?",
+        text: $store.draftSketchNote)
+    }
+  }
+}
+
 /// A goal loop's fields: what done looks like, optionally how to check it, optionally
 /// how to score it.
 ///
@@ -352,6 +371,10 @@ struct NodeDraftRecap: View {
 
   private var sentence: String {
     switch draft.loopType {
+    case .sketch:
+      return
+        "Opens a session\(location) and waits for you. Nothing is scheduled and nothing "
+        + "resolves on its own — it works with you until you close it."
     case .goalBased:
       let check =
         draft.goal?.effectivePredicate == nil

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -62,6 +62,9 @@ struct ProjectFeature {
     /// `.turnBased`: what the session is asked to do, and where it pauses.
     var draftFirstInstruction = ""
     var draftPausesBeforeWritesOnly = false
+    /// `.sketch`: the optional starting note. Its own field rather than sharing
+    /// `draftFirstInstruction`, so flipping between types never carries text across.
+    var draftSketchNote = ""
     /// `.timeBased`: how often, and what to do each time. GraphCode composes the `/loop`
     /// directive from the two — see `ProjectFeature.State.composedTriggerPrompt`.
     var draftInterval: IntervalChoice = .hourly
@@ -296,6 +299,7 @@ struct ProjectFeature {
         // simply doesn't submit — the Create button is disabled on it too, and this is
         // the backstop for the keyboard shortcut path.
         guard draft.isValid else { return .none }
+        UserDefaults.standard.set(draft.loopType.rawValue, forKey: Self.lastLoopTypeKey)
         let projectPath = state.graph.project.path
         // A form opened from a node card's + handle also wires the new loop up: a
         // default hand-off edge from the parent, created right after the node so the
@@ -356,9 +360,12 @@ struct ProjectFeature {
           // draft's id *is* the node's id (see `NodeDraft.id`); no answer just means
           // the fallback name stays.
           guard draft.title.trimmingCharacters(in: .whitespaces).isEmpty,
-            let basis = [draft.checkDescription, draft.triggerPrompt, draft.goal?.summary]
-              .compactMap({ $0 })
-              .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }),
+            let basis = [
+              draft.checkDescription, draft.triggerPrompt, draft.goal?.summary,
+              draft.firstInstruction,
+            ]
+            .compactMap({ $0 })
+            .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }),
             let title = await titleSuggestionClient.suggest(
               draft.effectiveBackend, basis, loopTitleDirectory.allTitles())
           else { return }
@@ -574,18 +581,33 @@ struct ProjectFeature {
 }
 
 extension ProjectFeature {
+  /// The loop type the form opens on: the last one a loop was actually created with.
+  ///
+  /// Set at creation rather than at selection — browsing the chooser is not a
+  /// preference, pressing Create is. App-side `UserDefaults` like the other UI
+  /// memories (`hasSeenOnboarding`, the rail width): which type someone reaches for
+  /// is not a setting the daemon or another machine has any use for.
+  static let lastLoopTypeKey = "lastCreatedLoopType"
+
+  static var rememberedLoopType: LoopType {
+    UserDefaults.standard.string(forKey: lastLoopTypeKey)
+      .flatMap(LoopType.init(rawValue:)) ?? .goalBased
+  }
+
   /// Resets the draft fields and opens the node form — the shared half of
   /// `.addNodeButtonTapped` and `.addChildNodeTapped`.
   ///
-  /// Goal-based by default, matching `LoopType`'s own ordering and the segmented
-  /// control's first segment: a loop that starts itself and knows when it is finished
-  /// is what most work wants, where the old turn-based default made a loop that sits
-  /// idle until a human opens it — surprising as the *default* outcome of Create.
+  /// The type defaults to whatever was chosen last (`rememberedLoopType`): someone who
+  /// always makes goal loops shouldn't re-pick Goal every time. Goal-based before
+  /// anything has been created, because a loop that starts itself and knows when it is
+  /// finished is what most work wants, where the old turn-based default made a loop
+  /// that sits idle until a human opens it — surprising as the *default* outcome of
+  /// Create.
   private func openNodeForm(
     _ state: inout State, backend: CLISessionBackendKind?, parentNodeID: UUID?
   ) -> Effect<Action> {
     state.draftID = UUID()
-    state.draftLoopType = .goalBased
+    state.draftLoopType = Self.rememberedLoopType
     state.draftTitle = ""
     state.draftCheck = ""
     state.draftPrompt = ""
@@ -598,6 +620,7 @@ extension ProjectFeature {
     state.isTestingDoneCheck = false
     state.draftFirstInstruction = ""
     state.draftPausesBeforeWritesOnly = false
+    state.draftSketchNote = ""
     state.draftInterval = .hourly
     state.draftCustomInterval = ""
     state.draftTimedTask = ""

--- a/graphcode/Sources/Features/Project/ProjectFeatureState.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeatureState.swift
@@ -48,7 +48,13 @@ extension ProjectFeature.State {
       loopType: draftLoopType,
       checkDescription: draftLoopType == .turnBased ? draftCheck : nil,
       triggerPrompt: composedTriggerPrompt,
-      firstInstruction: draftLoopType == .turnBased ? draftFirstInstruction : nil,
+      firstInstruction: {
+        switch draftLoopType {
+        case .turnBased: return draftFirstInstruction
+        case .sketch: return draftSketchNote.isEmpty ? nil : draftSketchNote
+        case .goalBased, .timeBased, .composite: return nil
+        }
+      }(),
       pausesBeforeWritesOnly: draftLoopType == .turnBased && draftPausesBeforeWritesOnly,
       goal: draftLoopType == .goalBased
         ? GoalSpec(
@@ -86,7 +92,7 @@ extension ProjectFeature.State {
       return directive
     case .composite:
       return "Intended schedule: \(draftSchedule.summary(at: draftScheduleTime))"
-    case .goalBased, .turnBased:
+    case .sketch, .goalBased, .turnBased:
       return nil
     }
   }

--- a/graphcode/Sources/Features/Welcome/OnboardingPages.swift
+++ b/graphcode/Sources/Features/Welcome/OnboardingPages.swift
@@ -184,20 +184,20 @@ struct OnboardingReadingPage: View {
   }
 }
 
-/// Page 3 — the four kinds, subtitled by what makes each one *stop*, with the edge
+/// Page 3 — the five kinds, subtitled by what makes each one *stop*, with the edge
 /// lesson folded in underneath.
 ///
 /// Two pages became one, which is what freed the room for page 2. The tiles are the
 /// dialog's own `LoopTypeChooser`, so what is taught here is literally what is chosen
 /// there.
 struct OnboardingLoopTypesPage: View {
-  /// Nothing is being chosen on this page — the tiles are showing four things, not
+  /// Nothing is being chosen on this page — the tiles are showing five things, not
   /// asking for one. The selection is fixed on the type most people meet first.
   @State private var shown: LoopType = .goalBased
 
   var body: some View {
     VStack(spacing: 16) {
-      Text("Four kinds of loop")
+      Text("Five kinds of loop")
         .font(.system(size: 25, weight: .bold))
         .tracking(-0.25)
       Text("They differ in what makes them stop.")

--- a/graphcode/Tests/NodeDraftTests.swift
+++ b/graphcode/Tests/NodeDraftTests.swift
@@ -331,4 +331,48 @@ struct NodeDraftTests {
       BackendPicker.unsupportedReason(backend: .codex, loopType: .timeBased)
         .contains("run once and stop"))
   }
+
+  @Test
+  func aSketchDraftIsValidWhileCompletelyEmpty() {
+    // The regression guard for the whole idea: `⏎` on an untouched dialog is a
+    // complete action. No goal, no worktree, no prompt — it opens quiet and waits.
+    let draft = NodeDraft(title: "", loopType: .sketch)
+    #expect(draft.isValid)
+
+    let node = draft.makeNode()
+    #expect(node.goal == nil)
+    #expect(node.worktreeBinding == nil)
+    #expect(node.sessionPrompt == nil)
+    #expect(node.state == .idle)
+    #expect(!node.runsUnattended)
+  }
+
+  @Test
+  func aSketchOpensWithItsStartingNoteWhenThereIsOne() {
+    let node = NodeDraft(
+      title: "", loopType: .sketch,
+      firstInstruction: "where does the usage cap get read from?"
+    ).makeNode()
+    #expect(node.sessionPrompt == "where does the usage cap get read from?")
+    // Whitespace is not a note.
+    #expect(
+      NodeDraft(title: "", loopType: .sketch, firstInstruction: "   ")
+        .makeNode().sessionPrompt == nil)
+  }
+
+  @Test
+  func everyBackendHostsASketch() {
+    // A bare session is the least demanding type — nothing to refuse over.
+    for backend in CLISessionBackendKind.allCases {
+      #expect(backend.canHost(.sketch))
+    }
+  }
+
+  @Test
+  func theChooserOrdersTypesByCommitmentSketchFirst() {
+    // `allCases` is the chooser's order and the ⌘1–⌘5 shortcut order; a reshuffle
+    // silently rebinds every shortcut.
+    #expect(
+      LoopType.allCases == [.sketch, .goalBased, .timeBased, .turnBased, .composite])
+  }
 }

--- a/graphcode/Tests/StartAnchorTests.swift
+++ b/graphcode/Tests/StartAnchorTests.swift
@@ -154,4 +154,16 @@ struct StartAnchorTests {
     #expect(lasso.entryPoints == [head.id])
     #expect(lasso.cycleOnlyNodeIDs.isEmpty)
   }
+
+  /// A sketch is not a graph beginning. Edgeless by construction, it would otherwise
+  /// claim an entry port the moment it was created — re-creating the starburst the
+  /// entry-point work removed.
+  @Test
+  func aSketchNeverClaimsAnEntryPort() {
+    let sketch = LoopNode(title: "Poke around", loopType: .sketch)
+    let worker = node("Worker")
+    let mixed = graph(nodes: [sketch, worker], edges: [])
+    #expect(mixed.startAnchors == [worker.id])
+    #expect(graph(nodes: [sketch], edges: []).startAnchors.isEmpty)
+  }
 }


### PR DESCRIPTION
## What

Introduces **Sketch** — the fifth loop type, per the design handoff's `SKETCH_LOOP.md`: the zero-commitment loop you make before you know what you're doing. This PR covers introducing the type itself plus the New-loop dialog work; promote, expiry and the sketch lane are follow-ups.

- **Type chooser**: Sketch sits above the 2×2 grid as a full-width band, separated by an *"or commit to something"* rule. Shortcuts ⌘1 Sketch · ⌘2 Goal · ⌘3 Timed · ⌘4 Turn · ⌘5 Composite. Grey `#7c8794` accent — provisional, never competing with committed work.
- **The shortest form in the app**: one optional starting note. `⏎` on an untouched dialog is valid and complete; the button reads **Start**. The note is the session's opening prompt and seeds the suggested name.
- **Dialog is now resizable** and its ideal height grew to fit the fifth type (min 520×560, ideal 520×760).
- **Remembers your last loop type**: the form opens on whatever type you last actually created with (stored in `UserDefaults`, set at Create — browsing the chooser is not a preference).
- Sketches never claim a start anchor or entry port; every spiked backend hosts one; no worktree by default (with the design's help line explaining why).
- CLI and remote access accept `--type sketch`, with `--prompt` as the optional note.

## Tests

872 tests pass, including new ones: an empty sketch draft is valid (the regression guard for the whole idea), the note becomes the session prompt, every backend hosts a sketch, `allCases` keeps Sketch first (shortcut stability), and a sketch never claims an entry port. `swiftlint` + `swift format lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)