### PR TITLE
Promote a sketch into a shape

### DIFF
--- a/GraphcodeKit/Sources/Domain/LoopType.swift
+++ b/GraphcodeKit/Sources/Domain/LoopType.swift
@@ -1,5 +1,7 @@
-/// The five loop primitives graphcode orchestrates — see docs/01-loop-taxonomy.md for
-/// the full definitions.
+/// The four loop primitives graphcode orchestrates — see docs/01-loop-taxonomy.md for
+/// the full definitions — plus sketch, which is deliberately not a fifth kind: it is
+/// the starting point before the work has a shape, and `SketchPromotion` is how it
+/// becomes one of the four once it does.
 ///
 /// Declared in the order a human should consider them, because that is the order
 /// `allCases` walks and the order every picker shows. The axis is how much you have to
@@ -14,7 +16,7 @@
 /// exactly as before.
 public enum LoopType: String, Codable, CaseIterable, Sendable {
   /// The zero-commitment type: no goal, no cadence, no checkpoint. A bare session that
-  /// works with you until you close it.
+  /// works with you until you promote it or close it.
   case sketch
   case goalBased
   case timeBased

--- a/GraphcodeKit/Sources/Domain/SketchPromotion.swift
+++ b/GraphcodeKit/Sources/Domain/SketchPromotion.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// The shape a sketch takes when it turns out to matter — the reason the type is worth
+/// having. A sketch that produced something real must not have to be re-created: keep
+/// the session, add a shape.
+///
+/// Each case carries **exactly one decision** — the thing the target type needs and a
+/// sketch never asked for. Never a re-brief: the transcript so far is the loop's
+/// context, and a promoted goal loop starts already knowing what was found.
+///
+/// Promotion is one-way by construction. There is no case that lands on `.sketch`, so
+/// demotion — which would silently drop a done check or a cadence — is unrepresentable
+/// rather than merely refused.
+public enum SketchPromotion: Codable, Equatable, Sendable {
+  /// Goal asks for a done check: what done looks like, in the promoter's words.
+  case goal(GoalSpec)
+  /// Turn asks where to pause: after every turn, or only before writes.
+  case turn(pausesBeforeWritesOnly: Bool)
+  /// Timed asks for a cadence, carried the way every time-based loop carries one — a
+  /// `/loop` directive the session runs on itself (`LoopNode.triggerPrompt`).
+  case timed(triggerPrompt: String)
+
+  /// The `LoopType` this promotion lands on.
+  public var targetType: LoopType {
+    switch self {
+    case .goal: .goalBased
+    case .turn: .turnBased
+    case .timed: .timeBased
+    }
+  }
+}

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -269,6 +269,9 @@ public actor GraphStore {
     case .updateNode(let nodeID, let update):
       updateNode(nodeID, with: update)
 
+    case .promoteNode(let nodeID, let promotion):
+      promoteNode(nodeID, promotion: promotion)
+
     case .memoNode(let nodeID, let text, let from):
       memoNode(nodeID, text: text, from: from)
 
@@ -748,6 +751,80 @@ public actor GraphStore {
           "[graphcode] Your instructions were revised: "
             + sessionFacing.joined(separator: "; ")
         ))
+    }
+  }
+
+  /// Gives a sketch a shape — `GraphCommand.promoteNode`.
+  ///
+  /// A mutation on the existing node, deliberately not a create + delete: the id is the
+  /// zmx session name, the memory key, and every edge's endpoint, so keeping it is what
+  /// makes "keep the session, add a shape" literally true. Only `loopType` and the one
+  /// field the new type needs change.
+  ///
+  /// The live session (if any) is nudged the same way `updateNode` nudges — its
+  /// transcript is the loop's context now, and a shape it was never told about would
+  /// make the canvas lie about what the loop is doing.
+  private func promoteNode(_ nodeID: UUID, promotion: SketchPromotion) {
+    guard var node = graph.nodes[id: nodeID] else {
+      announceError("no loop \(nodeID) in this graph")
+      return
+    }
+    guard node.loopType == .sketch else {
+      announceError(
+        "promotion refused: \(node.title) already has a shape — only a sketch can be promoted")
+      return
+    }
+
+    let nudge: String
+    switch promotion {
+    case .goal(var spec):
+      spec.summary = spec.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !spec.summary.isEmpty else {
+        announceError("promotion refused: a goal loop needs what done looks like")
+        return
+      }
+      node.loopType = .goalBased
+      node.goal = spec
+      // What creation gives a goal loop, promotion gives it too: born `.running`,
+      // because its session works toward the goal with no human turn in between.
+      node.state = .running
+      nudge = "You are now a goal loop. Work toward this and stop when it's met: \(spec.summary)"
+
+    case .turn(let beforeWritesOnly):
+      node.loopType = .turnBased
+      node.pausesBeforeWritesOnly = beforeWritesOnly
+      nudge =
+        beforeWritesOnly
+        ? "You are now a turn-based loop. Stop for a human's review before anything that "
+          + "changes files or state; reading and reasoning can run straight through."
+        : "You are now a turn-based loop. Work in turns, stopping after each one for a "
+          + "human's review before you continue."
+
+    case .timed(let prompt):
+      let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else {
+        announceError("promotion refused: a time-based loop needs a cadence to run on")
+        return
+      }
+      node.loopType = .timeBased
+      node.triggerPrompt = trimmed
+      nudge = "You are now a time-based loop. Adopt this cadence by running it now: \(trimmed)"
+    }
+
+    graph.nodes[id: nodeID] = node
+    recordMemory(
+      nodeID, "promoted from sketch to \(promotion.targetType.rawValue) — \(nudge)")
+    pendingNudges.append((nodeID, "[graphcode] \(nudge)"))
+
+    // What creation does for the type, promotion does too: an unattended loop's session
+    // must exist whether or not anyone has the app open, and a goal loop's stop
+    // condition needs its poller.
+    if node.runsUnattended {
+      ensureSession(node)
+    }
+    if node.loopType == .goalBased {
+      cancelGoalPoller(nodeID)
+      armGoalPoller(for: node)
     }
   }
 

--- a/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
+++ b/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
@@ -76,6 +76,12 @@ public indirect enum GraphCommand: Codable, Sendable, Equatable {
   /// summary, prompt, check) are nudged into a live session and recorded in the node's
   /// memory for its next wake. A loop may not change its *own* stop condition.
   case updateNode(UUID, update: NodeUpdate)
+  /// Give a sketch a shape — goal, turn or timed — keeping everything else it is:
+  /// same id, same session, same edges, same memory. A mutation on the existing node,
+  /// never a create + delete, so anything keyed on the node's id survives untouched.
+  /// Refused for any node that isn't a sketch; demotion has no wire shape at all
+  /// (`SketchPromotion` carries no `.sketch` case).
+  case promoteNode(UUID, promotion: SketchPromotion)
   /// Append a learned note to a node's memory log (`NodeMemory`) — what `graphcode
   /// node memo` rides on. `from` is attributed the same way `messageNode`'s is.
   case memoNode(UUID, text: String, from: UUID?)

--- a/graphcode/Sources/Features/Project/LoopTypeChooser.swift
+++ b/graphcode/Sources/Features/Project/LoopTypeChooser.swift
@@ -1,7 +1,8 @@
 import GraphcodeKit
 import SwiftUI
 
-/// The five kinds of loop, as tiles that explain themselves.
+/// The four kinds of loop as tiles that explain themselves, with Sketch — the
+/// starting point that isn't yet any of them — banded above.
 ///
 /// It was a four-segment picker, and the problem with that wasn't the shape — it was
 /// that four segments can only *name* the types. A control that names four things reads
@@ -147,7 +148,7 @@ struct LoopTypeChooser: View {
   /// question a person actually has about an agent that runs on its own.
   static func whatStopsIt(_ type: LoopType) -> String {
     switch type {
-    case .sketch: "Never on its own — you close it when you're done"
+    case .sketch: "Never on its own — you close it, or promote it into a kind"
     case .goalBased: "Stops when your check passes"
     case .timeBased: "Never — it runs again each interval"
     case .turnBased: "Stops after every turn, for you"

--- a/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
+++ b/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
@@ -12,7 +12,7 @@ struct SketchDraftFields: View {
   var body: some View {
     DraftField(
       label: "Starting note", qualifier: "optional — leave it blank and it opens quiet",
-      help: "No done check, no cadence — it works with you until you close it."
+      help: "No done check, no cadence — it works with you until you promote it or close it."
     ) {
       DraftProseField(
         placeholder: "e.g. where does the usage cap get read from?",
@@ -374,7 +374,7 @@ struct NodeDraftRecap: View {
     case .sketch:
       return
         "Opens a session\(location) and waits for you. Nothing is scheduled and nothing "
-        + "resolves on its own — it works with you until you close it."
+        + "resolves on its own — it works with you until you promote it or close it."
     case .goalBased:
       let check =
         draft.goal?.effectivePredicate == nil

--- a/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
@@ -64,6 +64,23 @@ extension ProjectCanvasView {
       Button("Arm Schedule") { store.send(.armCompositeTapped(node.id)) }
         .disabled(!node.pilotState.canArm)
     }
+    if node.loopType == .sketch {
+      // The reason the type is worth having: a sketch that turned out to matter keeps
+      // its session and gains a shape — each target asks for exactly one thing.
+      Menu("Promote to…") {
+        Section("Keep the session, add a shape") {
+          Button("Goal — asks for a done check") {
+            store.send(.promoteNodeRequested(node.id, to: .goalBased))
+          }
+          Button("Turn — asks where to pause") {
+            store.send(.promoteNodeRequested(node.id, to: .turnBased))
+          }
+          Button("Timed — asks for a cadence") {
+            store.send(.promoteNodeRequested(node.id, to: .timeBased))
+          }
+        }
+      }
+    }
     // Available on a resolved loop too: a finished loop is still something you read the
     // graph by, and its name is what you read.
     Button("Rename…") { store.send(.renameNodeRequested(node.id)) }

--- a/graphcode/Sources/Features/Project/ProjectCanvasView.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasView.swift
@@ -125,6 +125,13 @@ struct ProjectCanvasView: View {
     .sheet(item: $store.pendingEdge) { _ in
       edgeForm
     }
+    .sheet(
+      isPresented: Binding(
+        get: { store.nodePendingPromotion != nil },
+        set: { if !$0 { store.send(.promotionCancelled) } })
+    ) {
+      SketchPromotionForm(store: store)
+    }
     // The delete confirmation is deliberately *not* here — it's hosted by `AppView`, so
     // it can also present for a deletion started from the sidebar while this canvas
     // isn't the visible detail pane. See `AppFeature.State.pendingLoopDeletion`.

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -104,6 +104,16 @@ struct ProjectFeature {
     var nodePendingRename: UUID?
     var draftRenameTitle = ""
 
+    /// Set while a sketch's promotion form is up: which sketch, which shape it is
+    /// taking, and the one field that shape asks for. Flat fields to match how the
+    /// rename prompt and the creation form's `draft*` fields already work here.
+    var nodePendingPromotion: UUID?
+    var promotionTarget: LoopType = .goalBased
+    var promotionGoal = ""
+    var promotionPausesBeforeWritesOnly = false
+    var promotionInterval: IntervalChoice = .hourly
+    var promotionCustomInterval = ""
+
     /// Loops a human said really are a beginning, despite having no edges — the answer
     /// to a card's "Mark as entry". View state, not graph state: the graph's own answer
     /// to "does this start something" is its edges, and a stored flag would be a second
@@ -185,6 +195,10 @@ struct ProjectFeature {
     case renameTitleChanged(String)
     case renameNodeConfirmed
     case renameNodeCancelled
+    /// "Promote to…" on a sketch card: opens the one-field form for the chosen target.
+    case promoteNodeRequested(UUID, to: LoopType)
+    case promotionConfirmed
+    case promotionCancelled
     case deleteEdgeTapped(UUID)
     /// The sidebar dropped a drag-to-reorder: the moved ids in their new order, which
     /// take the front of `sidebarNodeOrder`; ids not in the list keep their relative
@@ -510,6 +524,16 @@ struct ProjectFeature {
             .graphCommand(projectPath: projectPath, command: .deleteNode(nodeID)))
         }
 
+      case .promoteNodeRequested(let nodeID, let target):
+        return openPromotionForm(&state, nodeID: nodeID, target: target)
+
+      case .promotionCancelled:
+        state.nodePendingPromotion = nil
+        return .none
+
+      case .promotionConfirmed:
+        return confirmPromotion(&state)
+
       case .renameNodeRequested(let nodeID):
         guard let node = state.graph.nodes[id: nodeID] else { return .none }
         state.nodePendingRename = nodeID
@@ -592,6 +616,30 @@ extension ProjectFeature {
   static var rememberedLoopType: LoopType {
     UserDefaults.standard.string(forKey: lastLoopTypeKey)
       .flatMap(LoopType.init(rawValue:)) ?? .goalBased
+  }
+
+  /// Resets the promotion form's one field and opens it for the chosen target — only
+  /// ever for a sketch; anything already shaped has nothing to promote.
+  private func openPromotionForm(
+    _ state: inout State, nodeID: UUID, target: LoopType
+  ) -> Effect<Action> {
+    guard state.graph.nodes[id: nodeID]?.loopType == .sketch else { return .none }
+    state.nodePendingPromotion = nodeID
+    state.promotionTarget = target
+    state.promotionGoal = ""
+    state.promotionPausesBeforeWritesOnly = false
+    state.promotionInterval = .hourly
+    state.promotionCustomInterval = ""
+    return .none
+  }
+
+  /// Sends the promotion the form currently means; a nil `promotion` (empty required
+  /// field) leaves the form up, matching the disabled Promote button beside it.
+  private func confirmPromotion(_ state: inout State) -> Effect<Action> {
+    guard let nodeID = state.nodePendingPromotion, let promotion = state.promotion
+    else { return .none }
+    state.nodePendingPromotion = nil
+    return send(state, .promoteNode(nodeID, promotion: promotion))
   }
 
   /// Resets the draft fields and opens the node form — the shared half of

--- a/graphcode/Sources/Features/Project/ProjectFeatureState.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeatureState.swift
@@ -101,6 +101,38 @@ extension ProjectFeature.State {
   /// is visible before it is written.
   var triggerPreview: String { composedTriggerPrompt ?? "" }
 
+  /// What the promotion form currently means — nil while its one required field is
+  /// empty. Computed like `draft`, so there is exactly one definition of it.
+  ///
+  /// A timed promotion asks only for the cadence; the work it repeats is what the
+  /// session is already doing, seeded by the sketch's own note when there is one.
+  var promotion: SketchPromotion? {
+    switch promotionTarget {
+    case .goalBased:
+      let summary = promotionGoal.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !summary.isEmpty else { return nil }
+      return .goal(GoalSpec(summary: summary))
+    case .turnBased:
+      return .turn(pausesBeforeWritesOnly: promotionPausesBeforeWritesOnly)
+    case .timeBased:
+      let note =
+        nodePendingPromotion
+        .flatMap { graph.nodes[id: $0]?.firstInstruction }?
+        .trimmingCharacters(in: .whitespaces) ?? ""
+      let task = note.isEmpty ? "Carry on with what this session has been doing." : note
+      let cadence = promotionInterval.directiveValue(custom: promotionCustomInterval)
+      return .timed(triggerPrompt: "/loop \(cadence) \(task)")
+    case .sketch, .composite:
+      return nil
+    }
+  }
+
+  /// The composed `/loop` line the promotion form shows before it is written.
+  var promotionTriggerPreview: String {
+    guard promotionTarget == .timeBased, case .timed(let prompt)? = promotion else { return "" }
+    return prompt
+  }
+
   /// The `git worktree add` to run before creating the node, if the human asked for a
   /// new branch. The worktree lands next to the repository rather than inside it, so
   /// it never shows up as untracked content in the project the loops are working on.

--- a/graphcode/Sources/Features/Project/SketchPromotionForm.swift
+++ b/graphcode/Sources/Features/Project/SketchPromotionForm.swift
@@ -1,0 +1,169 @@
+import ComposableArchitecture
+import GraphcodeKit
+import SwiftUI
+
+/// The one-field form a sketch's "Promote to…" opens — never a re-brief.
+///
+/// The dialog asks for exactly what the target type needs and a sketch never did:
+/// a done check for Goal, where to pause for Turn, a cadence for Timed. Everything
+/// else the loop already is — its session, its transcript, its edges — travels
+/// untouched, which is the sentence the header says.
+struct SketchPromotionForm: View {
+  @Bindable var store: StoreOf<ProjectFeature>
+
+  private var node: LoopNode? {
+    store.nodePendingPromotion.flatMap { store.graph.nodes[id: $0] }
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      header
+      field
+      NodeDraftRecap(draft: recapDraft, worktree: .none)
+      footer
+    }
+    .padding(.horizontal, 22)
+    .padding(.top, 20)
+    .padding(.bottom, 18)
+    .frame(minWidth: 460, maxWidth: .infinity)
+    .background(Theme.sheet)
+  }
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      HStack(spacing: 8) {
+        RoundedRectangle(cornerRadius: 2.5)
+          .fill(store.promotionTarget.accent)
+          .frame(width: 9, height: 9)
+        Text("Promote to \(store.promotionTarget.displayName)")
+          .font(.system(size: 16, weight: .semibold))
+      }
+      Text(
+        "Keep the session, add a shape — \(node?.title ?? "this sketch") stays "
+          + "exactly where it is."
+      )
+      .font(.system(size: 12))
+      .foregroundStyle(.white.opacity(0.45))
+    }
+  }
+
+  @ViewBuilder
+  private var field: some View {
+    switch store.promotionTarget {
+    case .goalBased:
+      DraftField(
+        label: "What does done look like?",
+        help: "The loop is told this, and works toward it with everything the session "
+          + "already knows."
+      ) {
+        DraftProseField(
+          placeholder: "the flake is reproduced and fixed", text: $store.promotionGoal)
+      }
+    case .turnBased:
+      DraftField(label: "Where should it pause?") {
+        VStack(alignment: .leading, spacing: 6) {
+          pauseChoice(
+            "After every turn", isOn: !store.promotionPausesBeforeWritesOnly
+          ) { store.promotionPausesBeforeWritesOnly = false }
+          pauseChoice(
+            "Only before it writes files", isOn: store.promotionPausesBeforeWritesOnly
+          ) { store.promotionPausesBeforeWritesOnly = true }
+        }
+      }
+    case .timeBased:
+      DraftField(
+        label: "How often?",
+        help: "The work it repeats is what the session is already doing."
+      ) {
+        VStack(alignment: .leading, spacing: 8) {
+          Picker("", selection: $store.promotionInterval) {
+            ForEach(ProjectFeature.IntervalChoice.allCases, id: \.self) { choice in
+              Text(choice.displayName).tag(choice)
+            }
+          }
+          .pickerStyle(.segmented)
+          .labelsHidden()
+          if store.promotionInterval == .custom {
+            DraftTextField(
+              placeholder: "30m, 2h, 3d…", text: $store.promotionCustomInterval, isMono: true)
+          }
+          if !store.promotionTriggerPreview.isEmpty {
+            Text(store.promotionTriggerPreview)
+              .font(.system(size: 11, design: .monospaced))
+              .foregroundStyle(.white.opacity(0.7))
+              .lineLimit(2)
+          }
+        }
+      }
+    case .sketch, .composite:
+      // Unreachable: the menu only offers the three committed session types.
+      EmptyView()
+    }
+  }
+
+  private var footer: some View {
+    HStack(spacing: 12) {
+      Button("Cancel") { store.send(.promotionCancelled) }
+        .buttonStyle(.plain)
+        .font(.system(size: 12.5))
+        .foregroundStyle(.white.opacity(0.7))
+      Spacer(minLength: 8)
+      if store.promotion == nil, store.promotionTarget == .goalBased {
+        Text("Say what done looks like to continue")
+          .font(.system(size: 11.5))
+          .foregroundStyle(.white.opacity(0.62))
+          .lineLimit(1)
+      }
+      promoteButton
+    }
+  }
+
+  private var promoteButton: some View {
+    let isValid = store.promotion != nil
+    return Button {
+      store.send(.promotionConfirmed)
+    } label: {
+      HStack(spacing: 6) {
+        Text("Promote")
+          .font(.system(size: 13, weight: .semibold))
+        Text("⏎").font(.system(size: 11, design: .monospaced)).opacity(0.7)
+      }
+      .foregroundStyle(isValid ? .white : .white.opacity(0.42))
+      .padding(.horizontal, 14)
+      .frame(height: 32)
+      .background(
+        Theme.paneFocusTint.opacity(isValid ? 1 : 0.28),
+        in: RoundedRectangle(cornerRadius: 7))
+    }
+    .buttonStyle(.plain)
+    .keyboardShortcut(.defaultAction)
+    .disabled(!isValid)
+  }
+
+  /// What Promote will do, in `NodeDraftRecap`'s own voice — the same strip the
+  /// creation dialog shows, built from a draft shaped like the promoted loop.
+  private var recapDraft: NodeDraft {
+    NodeDraft(
+      title: node?.title ?? "",
+      loopType: store.promotionTarget,
+      triggerPrompt: store.promotionTriggerPreview.isEmpty ? nil : store.promotionTriggerPreview,
+      pausesBeforeWritesOnly: store.promotionPausesBeforeWritesOnly,
+      goal: store.promotionGoal.isEmpty ? nil : GoalSpec(summary: store.promotionGoal))
+  }
+
+  private func pauseChoice(
+    _ title: String, isOn: Bool, action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      HStack(spacing: 8) {
+        Image(systemName: isOn ? "largecircle.fill.circle" : "circle")
+          .font(.system(size: 13))
+          .foregroundStyle(isOn ? Theme.paneFocusTint : .white.opacity(0.35))
+        Text(title).font(.system(size: 12.5)).foregroundStyle(.white.opacity(0.85))
+        Spacer(minLength: 0)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+}

--- a/graphcode/Sources/Features/Welcome/OnboardingPages.swift
+++ b/graphcode/Sources/Features/Welcome/OnboardingPages.swift
@@ -184,25 +184,29 @@ struct OnboardingReadingPage: View {
   }
 }
 
-/// Page 3 — the five kinds, subtitled by what makes each one *stop*, with the edge
-/// lesson folded in underneath.
+/// Page 3 — the four kinds, subtitled by what makes each one *stop*, with the edge
+/// lesson folded in underneath. Sketch shows above them as what it is: not a fifth
+/// kind, the place you start before the work has a shape.
 ///
 /// Two pages became one, which is what freed the room for page 2. The tiles are the
 /// dialog's own `LoopTypeChooser`, so what is taught here is literally what is chosen
 /// there.
 struct OnboardingLoopTypesPage: View {
-  /// Nothing is being chosen on this page — the tiles are showing five things, not
+  /// Nothing is being chosen on this page — the tiles are showing four things, not
   /// asking for one. The selection is fixed on the type most people meet first.
   @State private var shown: LoopType = .goalBased
 
   var body: some View {
     VStack(spacing: 16) {
-      Text("Five kinds of loop")
+      Text("Four kinds of loop")
         .font(.system(size: 25, weight: .bold))
         .tracking(-0.25)
-      Text("They differ in what makes them stop.")
-        .font(.system(size: 14))
-        .foregroundStyle(.white.opacity(0.65))
+      Text(
+        "They differ in what makes them stop — and a sketch is where you start "
+          + "before choosing one."
+      )
+      .font(.system(size: 14))
+      .foregroundStyle(.white.opacity(0.65))
 
       LoopTypeChooser(selection: $shown, explanation: LoopTypeChooser.whatStopsIt)
         .frame(maxWidth: 440)

--- a/graphcode/Tests/SketchPromotionTests.swift
+++ b/graphcode/Tests/SketchPromotionTests.swift
@@ -1,0 +1,139 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// Promotion is the reason the sketch type is worth having: a sketch that turned out
+/// to matter keeps its session and gains a shape. What these guard is the identity
+/// rule — same id, same edges, same memory key — and the one-field contract: each
+/// target asks for exactly the thing it needs, and refuses without it.
+@Suite
+struct SketchPromotionTests {
+  private func sketchDraft(_ title: String = "Poke around", note: String? = nil) -> NodeDraft {
+    NodeDraft(title: title, loopType: .sketch, firstInstruction: note)
+  }
+
+  @Test
+  func promotingToGoalKeepsIdentityAndStartsRunning() async {
+    let store = GraphStore()
+    let sketch = sketchDraft()
+    let parent = NodeDraft(title: "Parent", loopType: .turnBased, firstInstruction: "Work")
+    await store.handle(.createNode(parent))
+    await store.handle(.createNode(sketch))
+    await store.handle(.createEdge(from: parent.id, to: sketch.id, spec: EdgeSpec()))
+
+    await store.handle(
+      .promoteNode(sketch.id, promotion: .goal(GoalSpec(summary: "the flake is fixed"))))
+
+    let graph = await store.graph
+    let promoted = graph.nodes[id: sketch.id]
+    // Same node, not a create + delete: the count is unchanged and the edge still
+    // points at the same id.
+    #expect(graph.nodes.count == 2)
+    #expect(promoted?.loopType == .goalBased)
+    #expect(promoted?.goal?.summary == "the flake is fixed")
+    #expect(promoted?.state == .running)
+    #expect(graph.edges.contains { $0.from == parent.id && $0.to == sketch.id })
+  }
+
+  @Test
+  func promotingToGoalWithoutADoneCheckIsRefused() async {
+    let store = GraphStore()
+    let sketch = sketchDraft()
+    await store.handle(.createNode(sketch))
+
+    await store.handle(.promoteNode(sketch.id, promotion: .goal(GoalSpec(summary: "   "))))
+
+    let graph = await store.graph
+    #expect(graph.nodes[id: sketch.id]?.loopType == .sketch)
+    #expect(graph.nodes[id: sketch.id]?.goal == nil)
+  }
+
+  @Test
+  func onlyASketchCanBePromoted() async {
+    let store = GraphStore()
+    let turn = NodeDraft(title: "Review", loopType: .turnBased, firstInstruction: "Work")
+    await store.handle(.createNode(turn))
+
+    await store.handle(.promoteNode(turn.id, promotion: .goal(GoalSpec(summary: "done"))))
+
+    let graph = await store.graph
+    #expect(graph.nodes[id: turn.id]?.loopType == .turnBased)
+    #expect(graph.nodes[id: turn.id]?.goal == nil)
+  }
+
+  @Test
+  func promotingToTimedSetsTheCadenceAndStartsItsSession() async {
+    let started = LockIsolated<[LoopNode]>([])
+    let store = GraphStore(onEnsureSession: { node, _ in
+      started.withValue { $0.append(node) }
+    })
+    let sketch = sketchDraft(note: "watch the crash reports")
+    await store.handle(.createNode(sketch))
+
+    await store.handle(
+      .promoteNode(sketch.id, promotion: .timed(triggerPrompt: "/loop 1h watch the crash reports")))
+
+    let graph = await store.graph
+    let promoted = graph.nodes[id: sketch.id]
+    #expect(promoted?.loopType == .timeBased)
+    #expect(promoted?.triggerPrompt == "/loop 1h watch the crash reports")
+    // A promoted unattended loop's session must exist whether or not the app is open —
+    // the same guarantee creation gives the type.
+    #expect(started.value.contains { $0.id == sketch.id })
+  }
+
+  @Test
+  func promotingToTurnSetsWhereItPauses() async {
+    let store = GraphStore()
+    let sketch = sketchDraft()
+    await store.handle(.createNode(sketch))
+
+    await store.handle(.promoteNode(sketch.id, promotion: .turn(pausesBeforeWritesOnly: true)))
+
+    let graph = await store.graph
+    let promoted = graph.nodes[id: sketch.id]
+    #expect(promoted?.loopType == .turnBased)
+    #expect(promoted?.pausesBeforeWritesOnly == true)
+    // A turn loop starts when a human opens it — promotion doesn't set it running.
+    #expect(promoted?.state == .idle)
+  }
+
+  @Test
+  func theFormBuildsThePromotionFromItsOneField() {
+    var state = ProjectFeature.State(
+      graph: LoopGraph(project: ProjectRef(path: "/tmp/p", name: "p")))
+    let sketch = LoopNode(title: "Poke", loopType: .sketch, firstInstruction: "read the RFC")
+    state.graph.nodes.append(sketch)
+    state.nodePendingPromotion = sketch.id
+
+    state.promotionTarget = .goalBased
+    #expect(state.promotion == nil)  // empty done check → nothing to send
+    state.promotionGoal = "the RFC is summarised"
+    #expect(state.promotion == .goal(GoalSpec(summary: "the RFC is summarised")))
+
+    // The cadence is the only asked-for field; the work it repeats is the sketch's own
+    // note when there is one.
+    state.promotionTarget = .timeBased
+    state.promotionInterval = .hourly
+    #expect(state.promotion == .timed(triggerPrompt: "/loop 1h read the RFC"))
+
+    state.promotionTarget = .turnBased
+    state.promotionPausesBeforeWritesOnly = true
+    #expect(state.promotion == .turn(pausesBeforeWritesOnly: true))
+  }
+
+  /// Demotion is unrepresentable rather than refused: no `SketchPromotion` case lands
+  /// on `.sketch` or `.composite`, so the wire cannot carry one.
+  @Test
+  func everyPromotionLandsOnACommittedSessionType() {
+    let targets: [LoopType] = [
+      SketchPromotion.goal(GoalSpec(summary: "x")).targetType,
+      SketchPromotion.turn(pausesBeforeWritesOnly: false).targetType,
+      SketchPromotion.timed(triggerPrompt: "/loop 1h x").targetType,
+    ]
+    #expect(targets == [.goalBased, .turnBased, .timeBased])
+  }
+}


### PR DESCRIPTION
## What

The follow-up `SKETCH_LOOP.md` calls the reason the type is worth building: **Promote**. A sketch that turned out to matter keeps its session and gains a shape — never re-created, never re-briefed.

- **"Promote to…"** on a sketch card's context menu, captioned *"Keep the session, add a shape"*: Goal (asks for a done check) · Turn (asks where to pause) · Timed (asks for a cadence).
- **Exactly one field per target.** The form asks for the single thing the new type needs; `promotion` is computed state, so an empty done check simply disables Promote with the reason beside it.
- **Same node identity**: `GraphStore.promoteNode` mutates the existing node — same id (which is the zmx session name, the memory key, and every edge endpoint), same position, same edges. The live session is nudged about its new shape, and the promoted loop gets what creation would have given it: a goal loop is born running with its poller armed; a timed loop's session is ensured.
- **Demotion is unrepresentable**: `SketchPromotion` has no case landing on `.sketch`, so the wire cannot carry one.
- A timed promotion asks only for the cadence — the composed `/loop` directive repeats what the session is already doing, seeded by the sketch's own starting note.
- **Copy reframed per product direction**: there are **four kinds of loop**; Sketch is the starting point before the work has a shape, not a fifth kind. Onboarding returns to "Four kinds of loop" with Sketch introduced as where you start.

Deferred (unchanged from the spec's larger scope): "Add to a composite…", the `promotable` meta-row hint heuristic, expiry, and the sketch lane.

## Tests

879 pass (7 new in `SketchPromotionTests`): identity preserved across promotion (count, edges), empty-done-check and non-sketch refusals, timed promotion sets the cadence and ensures the session, turn promotion sets the pause shape and stays idle, the form builds each promotion from its one field, and every promotion lands on a committed type. `swiftlint` + `swift format lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)