### PR TITLE
Give untargeted sketches a sidebar row

### DIFF
--- a/GraphcodeKit/Sources/Domain/LoopGraph.swift
+++ b/GraphcodeKit/Sources/Domain/LoopGraph.swift
@@ -207,6 +207,20 @@ public struct LoopGraph: Identifiable, Codable, Equatable, Sendable {
     return nodes.map(\.id).filter(anchored.contains)
   }
 
+  /// The sidebar's top-level rows: `startAnchors`, then any sketch nothing points at.
+  ///
+  /// A sketch is deliberately never a canvas entry port — that is what `startAnchors`
+  /// excludes it for — but a row is not a port: a loop the sidebar cannot show is a
+  /// loop that effectively doesn't exist. Untargeted sketches append after the anchored
+  /// roots, the sidebar's echo of the canvas's "sketches sit below the lanes"; a sketch
+  /// something points at already lists as that node's child.
+  public var sidebarRoots: [UUID] {
+    let targeted = Set(edges.map(\.to))
+    let sketches = nodes.filter { $0.loopType == .sketch && !targeted.contains($0.id) }
+      .map(\.id)
+    return startAnchors + sketches
+  }
+
   // MARK: - Coding
 
   private enum CodingKeys: String, CodingKey {

--- a/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
@@ -203,7 +203,7 @@ extension AppSidebarView {
 
   /// This project's top-level rows, in the human's arrangement (`sidebarNodeOrder`).
   func orderedRootNodes(in project: ProjectFeature.State) -> [LoopNode] {
-    let roots = project.graph.startAnchors.compactMap { project.graph.nodes[id: $0] }
+    let roots = project.graph.sidebarRoots.compactMap { project.graph.nodes[id: $0] }
     let order = project.sidebarNodeOrder
     return roots.sorted { a, b in
       (order.firstIndex(of: a.id) ?? .max) < (order.firstIndex(of: b.id) ?? .max)

--- a/graphcode/Tests/StartAnchorTests.swift
+++ b/graphcode/Tests/StartAnchorTests.swift
@@ -166,4 +166,20 @@ struct StartAnchorTests {
     #expect(mixed.startAnchors == [worker.id])
     #expect(graph(nodes: [sketch], edges: []).startAnchors.isEmpty)
   }
+
+  /// No entry port is not the same as no row: the sidebar lists untargeted sketches
+  /// after the anchored roots, or a fresh sketch simply doesn't exist anywhere but the
+  /// canvas. A sketch something points at lists as that node's child instead.
+  @Test
+  func theSidebarStillRowsAnUntargetedSketch() {
+    let sketch = LoopNode(title: "Poke around", loopType: .sketch)
+    let worker = node("Worker")
+    let mixed = graph(nodes: [sketch, worker], edges: [])
+    #expect(mixed.sidebarRoots == [worker.id, sketch.id])
+    #expect(graph(nodes: [sketch], edges: []).sidebarRoots == [sketch.id])
+
+    let child = graph(
+      nodes: [worker, sketch], edges: [LoopEdge(from: worker.id, to: sketch.id)])
+    #expect(child.sidebarRoots == [worker.id])
+  }
 }


### PR DESCRIPTION
## What

Fixes a user-visible hole from the Sketch introduction: **sketch loops didn't appear in the sidebar**. The sidebar's top-level rows came from `startAnchors`, which excludes sketches on purpose (a fresh sketch must never claim a canvas entry port) — but a row is not a port, and an edgeless sketch was simply invisible outside the canvas.

- New `LoopGraph.sidebarRoots`: `startAnchors` plus any sketch nothing points at, appended after the anchored roots (the sidebar's echo of "sketches sit below the lanes").
- A sketch something points at already lists as that node's child — unchanged.
- The canvas was never affected: `LaneLayout` places every unplaced node via its catch-all.

## Tests

880 pass, including the new regression test: an untargeted sketch rows after the roots, a lone sketch still rows, and a targeted sketch lists as a child rather than a root. `swiftlint` + `swift format lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)