### PR TITLE
Attribute promotions, and hold the stop-condition rule at that door too

### DIFF
--- a/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
+++ b/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
@@ -22,6 +22,10 @@ public enum GraphcodeCommand: Equatable, Sendable {
   case deleteNode(projectPath: String, nodeID: UUID)
   case sendMessage(projectPath: String, nodeID: UUID, text: String)
   case updateNode(projectPath: String, nodeID: UUID, update: NodeUpdate)
+  /// Give a sketch a shape — the CLI half of the canvas's "Promote to…" menu. The
+  /// promoter's identity is attributed at execution (`ZMX_SESSION`), not parsed here,
+  /// matching how `updateNode` fills `updatedBy`.
+  case promoteNode(projectPath: String, nodeID: UUID, promotion: SketchPromotion)
   case memoNode(projectPath: String, nodeID: UUID, text: String)
   case pilotComposite(projectPath: String, nodeID: UUID)
   case armComposite(projectPath: String, nodeID: UUID)
@@ -49,6 +53,8 @@ public enum GraphcodeCommand: Equatable, Sendable {
                            and memory — irreversible; stop is the reversible verb
       graphcode node send <project-path> <node-id> <message…>
       graphcode node update <project-path> <node-id> [options]
+      graphcode node promote <project-path> <node-id> --type <goal|turn|time> [options]
+                           give a sketch a shape, keeping its session, edges and memory
       graphcode node memo <project-path> <node-id> <note…>
       graphcode node pilot <project-path> <node-id>     dry-run a composite
       graphcode node arm <project-path> <node-id>       arm it (needs a pilot first)
@@ -90,6 +96,15 @@ public enum GraphcodeCommand: Equatable, Sendable {
       --stall <seconds>    stall bound; 0 clears it
       A loop may not change its own --predicate: the verifier stays outside the
       verified. Session-facing changes reach a live session as a [graphcode] notice.
+
+    PROMOTE OPTIONS (node promote; each target asks for its one decision)
+      --type goal          with --goal <text> (required); --predicate, --metric,
+                           --direction as above. A loop may not set its own
+                           --predicate through promotion, the same rule update holds.
+      --type turn          with --pause <every-turn|before-writes>  (default: every-turn)
+      --type time          with --prompt <text> (required); put the cadence in it
+      Promotion is one-way: a sketch gains a shape, never the reverse, and only a
+      sketch can be promoted.
 
     node memo appends a note to the loop's own memory log — what the next pass reads
     before starting. Record dead ends and decisions, not a transcript.
@@ -176,7 +191,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
           into = id
         }
         return .createNode(projectPath: path, draft: try parseDraft(arguments), into: into)
-      case "stop", "delete", "pilot", "arm", "send", "update", "memo":
+      case "stop", "delete", "pilot", "arm", "send", "update", "memo", "promote":
         let raw = try take(&arguments, name: "node-id")
         guard let nodeID = UUID(uuidString: raw) else {
           throw ParseError.invalidValue(argument: "node-id", value: raw)
@@ -185,6 +200,9 @@ public enum GraphcodeCommand: Equatable, Sendable {
         case "pilot": return .pilotComposite(projectPath: path, nodeID: nodeID)
         case "arm": return .armComposite(projectPath: path, nodeID: nodeID)
         case "delete": return .deleteNode(projectPath: path, nodeID: nodeID)
+        case "promote":
+          return .promoteNode(
+            projectPath: path, nodeID: nodeID, promotion: try parsePromotion(arguments))
         case "send":
           // Everything after the id is the message — joined rather than flagged, so
           // `graphcode node send <path> <id> tests are green, ship it` needs no quoting
@@ -359,6 +377,51 @@ public enum GraphcodeCommand: Equatable, Sendable {
       modelTier: modelTier)
     guard !update.isEmpty else { throw ParseError.missingArgument("an option to change") }
     return update
+  }
+
+  /// The one decision each target type needs — the same vocabulary `node create`
+  /// already taught: `--goal`/`--predicate`/`--metric`/`--direction` for goal,
+  /// `--prompt` for time. Turn's decision is where to pause, which create never asks
+  /// (`--pause every-turn|before-writes`), defaulting to every turn like the app's form.
+  private static func parsePromotion(_ arguments: [String]) throws -> SketchPromotion {
+    let flags = parseFlags(arguments)
+    if flags["help"] != nil { throw HelpRequested() }
+    guard let rawType = flags["type"] else { throw ParseError.missingArgument("--type") }
+
+    switch rawType {
+    case "goal", "goalBased":
+      guard let summary = flags["goal"] else { throw ParseError.missingArgument("--goal") }
+      var metricDirection = MetricDirection.maximize
+      if let raw = flags["direction"] {
+        guard let parsed = MetricDirection(rawValue: raw) else {
+          throw ParseError.invalidValue(argument: "--direction", value: raw)
+        }
+        metricDirection = parsed
+      }
+      return .goal(
+        GoalSpec(
+          summary: summary, predicate: flags["predicate"],
+          metricCommand: flags["metric"], metricDirection: metricDirection))
+
+    case "turn", "turnBased":
+      switch flags["pause"] {
+      case nil, "every-turn":
+        return .turn(pausesBeforeWritesOnly: false)
+      case "before-writes":
+        return .turn(pausesBeforeWritesOnly: true)
+      case .some(let raw):
+        throw ParseError.invalidValue(argument: "--pause", value: raw)
+      }
+
+    case "time", "timeBased":
+      guard let prompt = flags["prompt"] else { throw ParseError.missingArgument("--prompt") }
+      return .timed(triggerPrompt: prompt)
+
+    // `sketch` and `composite` are refused by shape, not by the daemon: demotion is
+    // unrepresentable and a composite is not one decision (see `SketchPromotion`).
+    default:
+      throw ParseError.invalidValue(argument: "--type", value: rawType)
+    }
   }
 
   /// `--name value` pairs. Bare positional arguments are ignored here; every caller has

--- a/GraphcodeKit/Sources/Domain/SketchPromotion.swift
+++ b/GraphcodeKit/Sources/Domain/SketchPromotion.swift
@@ -10,7 +10,10 @@ import Foundation
 ///
 /// Promotion is one-way by construction. There is no case that lands on `.sketch`, so
 /// demotion — which would silently drop a done check or a cadence — is unrepresentable
-/// rather than merely refused.
+/// rather than merely refused. `.composite` is absent deliberately too, not as an
+/// oversight: a composite is defined by its sub-graph, which is not "exactly one
+/// decision" — a sketch that grew into a pipeline is a new composite whose first loop
+/// the sketch may become, not a promotion.
 public enum SketchPromotion: Codable, Equatable, Sendable {
   /// Goal asks for a done check: what done looks like, in the promoter's words.
   case goal(GoalSpec)

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -269,8 +269,8 @@ public actor GraphStore {
     case .updateNode(let nodeID, let update):
       updateNode(nodeID, with: update)
 
-    case .promoteNode(let nodeID, let promotion):
-      promoteNode(nodeID, promotion: promotion)
+    case .promoteNode(let nodeID, let promotion, let promotedBy):
+      promoteNode(nodeID, promotion: promotion, promotedBy: promotedBy)
 
     case .memoNode(let nodeID, let text, let from):
       memoNode(nodeID, text: text, from: from)
@@ -728,7 +728,13 @@ public actor GraphStore {
       observerSide.append("model tier: \(tier.rawValue) (next launch)")
     }
     guard !sessionFacing.isEmpty || !observerSide.isEmpty else {
-      announceError("update refused: nothing in it applies to a \(node.loopType) loop")
+      // A sketch's refusal answers the obvious next question — "then what does?" —
+      // instead of leaving the caller to discover promotion exists.
+      announceError(
+        node.loopType == .sketch
+          ? "update refused: nothing in it applies to a sketch loop — give it a shape "
+            + "first with `graphcode node promote`"
+          : "update refused: nothing in it applies to a \(node.loopType) loop")
       return
     }
     graph.nodes[id: nodeID] = node
@@ -764,7 +770,7 @@ public actor GraphStore {
   /// The live session (if any) is nudged the same way `updateNode` nudges — its
   /// transcript is the loop's context now, and a shape it was never told about would
   /// make the canvas lie about what the loop is doing.
-  private func promoteNode(_ nodeID: UUID, promotion: SketchPromotion) {
+  private func promoteNode(_ nodeID: UUID, promotion: SketchPromotion, promotedBy: UUID?) {
     guard var node = graph.nodes[id: nodeID] else {
       announceError("no loop \(nodeID) in this graph")
       return
@@ -781,6 +787,15 @@ public actor GraphStore {
       spec.summary = spec.summary.trimmingCharacters(in: .whitespacesAndNewlines)
       guard !spec.summary.isEmpty else {
         announceError("promotion refused: a goal loop needs what done looks like")
+        return
+      }
+      // `updateNode`'s one rule with teeth, held at the other doorway: promotion is the
+      // only other command through which a loop could hand itself a stop condition, and
+      // a self-set predicate is a verifier inside the verified. Summary-only
+      // self-promotion stays allowed — prose states the goal, it doesn't pass it.
+      if spec.effectivePredicate != nil, promotedBy == nodeID {
+        announceError("promotion refused: \(node.title) may not set its own stop condition")
+        recordMemory(nodeID, "promotion refused: a loop may not set its own stop condition")
         return
       }
       node.loopType = .goalBased
@@ -812,8 +827,14 @@ public actor GraphStore {
     }
 
     graph.nodes[id: nodeID] = node
+    // Attributed the way `updateNode` attributes: the promoter's title when the command
+    // came from inside a loop, "a human" otherwise — except a self-promotion, which is
+    // worth naming as what it is rather than as a peer that happens to share the id.
+    let promoter =
+      promotedBy == nodeID
+      ? "itself" : promotedBy.flatMap { graph.nodes[id: $0]?.title } ?? "a human"
     recordMemory(
-      nodeID, "promoted from sketch to \(promotion.targetType.rawValue) — \(nudge)")
+      nodeID, "promoted from sketch to \(promotion.targetType.rawValue) by \(promoter) — \(nudge)")
     pendingNudges.append((nodeID, "[graphcode] \(nudge)"))
 
     // What creation does for the type, promotion does too: an unattended loop's session

--- a/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
+++ b/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
@@ -81,7 +81,14 @@ public indirect enum GraphCommand: Codable, Sendable, Equatable {
   /// never a create + delete, so anything keyed on the node's id survives untouched.
   /// Refused for any node that isn't a sketch; demotion has no wire shape at all
   /// (`SketchPromotion` carries no `.sketch` case).
-  case promoteNode(UUID, promotion: SketchPromotion)
+  ///
+  /// `promotedBy` is attributed the way `updateNode`'s `updatedBy` is (`ZMX_SESSION`,
+  /// honest-by-default) — and enforces the same rule with teeth: a goal promotion that
+  /// carries a predicate is refused when the promoter is the promoted, because a
+  /// promotion is the one other doorway through which a loop could hand itself its own
+  /// stop condition. Optional so frames from clients that predate the field decode as
+  /// an unattributed promotion rather than failing.
+  case promoteNode(UUID, promotion: SketchPromotion, promotedBy: UUID?)
   /// Append a learned note to a node's memory log (`NodeMemory`) — what `graphcode
   /// node memo` rides on. `from` is attributed the same way `messageNode`'s is.
   case memoNode(UUID, text: String, from: UUID?)

--- a/graphcode-cli/Sources/main.swift
+++ b/graphcode-cli/Sources/main.swift
@@ -215,6 +215,30 @@ do {
       print(GraphcodeCommand.render(graph))
     }
 
+  case .promoteNode(let projectPath, let nodeID, let promotion):
+    // Attributed like `node update` attributes `updatedBy` — which is also what lets
+    // the daemon refuse a loop handing itself a stop condition through promotion.
+    let promoter = SurfaceRef.nodeID(
+      fromZmxSessionName: ProcessInfo.processInfo.environment["ZMX_SESSION"] ?? "")
+    try client.send(.openProject(path: projectPath))
+    _ = try client.waitForEvent { if case .graphChanged = $0 { return true } else { return false } }
+    try client.send(
+      .graphCommand(
+        projectPath: projectPath,
+        command: .promoteNode(nodeID, promotion: promotion, promotedBy: promoter)))
+    // Same verdict pattern as `update`: a refusal arrives as an error, an applied
+    // promotion as the changed graph.
+    let promoteVerdict = try client.waitForEvent { event in
+      switch event {
+      case .graphChanged, .errorOccurred: return true
+      default: return false
+      }
+    }
+    if case .errorOccurred(let message) = promoteVerdict { fail(message) }
+    if case .graphChanged(let graph) = promoteVerdict {
+      print(GraphcodeCommand.render(graph))
+    }
+
   case .memoNode(let projectPath, let nodeID, let text):
     let author = SurfaceRef.nodeID(
       fromZmxSessionName: ProcessInfo.processInfo.environment["ZMX_SESSION"] ?? "")

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -639,7 +639,9 @@ extension ProjectFeature {
     guard let nodeID = state.nodePendingPromotion, let promotion = state.promotion
     else { return .none }
     state.nodePendingPromotion = nil
-    return send(state, .promoteNode(nodeID, promotion: promotion))
+    // `promotedBy: nil` — a human in the app, the same attribution the form's other
+    // commands carry.
+    return send(state, .promoteNode(nodeID, promotion: promotion, promotedBy: nil))
   }
 
   /// Resets the draft fields and opens the node form — the shared half of

--- a/graphcode/Tests/GraphcodeCommandPromoteTests.swift
+++ b/graphcode/Tests/GraphcodeCommandPromoteTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import GraphcodeKit
+import Testing
+
+/// `node promote` parsing — split from `GraphcodeCommandTests` only for size; the
+/// contract is the same: a malformed command earns a named error, never an exit 0
+/// that quietly did nothing.
+@Suite
+struct GraphcodeCommandPromoteTests {
+  @Test
+  func promoteParsesEachTargetsOneDecision() throws {
+    let id = UUID()
+    #expect(
+      try GraphcodeCommand.parse([
+        "node", "promote", "/tmp/x", id.uuidString, "--type", "goal",
+        "--goal", "the flake is fixed", "--predicate", "make test",
+      ])
+        == .promoteNode(
+          projectPath: "/tmp/x", nodeID: id,
+          promotion: .goal(GoalSpec(summary: "the flake is fixed", predicate: "make test"))))
+    #expect(
+      try GraphcodeCommand.parse([
+        "node", "promote", "/tmp/x", id.uuidString, "--type", "turn",
+        "--pause", "before-writes",
+      ])
+        == .promoteNode(
+          projectPath: "/tmp/x", nodeID: id, promotion: .turn(pausesBeforeWritesOnly: true)))
+    // Turn's default matches the app's form: pause after every turn.
+    #expect(
+      try GraphcodeCommand.parse(["node", "promote", "/tmp/x", id.uuidString, "--type", "turn"])
+        == .promoteNode(
+          projectPath: "/tmp/x", nodeID: id, promotion: .turn(pausesBeforeWritesOnly: false)))
+    #expect(
+      try GraphcodeCommand.parse([
+        "node", "promote", "/tmp/x", id.uuidString, "--type", "time",
+        "--prompt", "/loop 1h triage",
+      ])
+        == .promoteNode(
+          projectPath: "/tmp/x", nodeID: id, promotion: .timed(triggerPrompt: "/loop 1h triage")))
+  }
+
+  /// The decision each target needs is required at parse time, so the CLI can say
+  /// what's missing instead of sending a promotion the daemon must refuse.
+  @Test
+  func promoteWithoutItsDecisionIsRefused() {
+    let id = UUID().uuidString
+    #expect(throws: GraphcodeCommand.ParseError.missingArgument("--type")) {
+      _ = try GraphcodeCommand.parse(["node", "promote", "/tmp/x", id])
+    }
+    #expect(throws: GraphcodeCommand.ParseError.missingArgument("--goal")) {
+      _ = try GraphcodeCommand.parse(["node", "promote", "/tmp/x", id, "--type", "goal"])
+    }
+    #expect(throws: GraphcodeCommand.ParseError.missingArgument("--prompt")) {
+      _ = try GraphcodeCommand.parse(["node", "promote", "/tmp/x", id, "--type", "time"])
+    }
+    #expect(
+      throws: GraphcodeCommand.ParseError.invalidValue(argument: "--pause", value: "sometimes")
+    ) {
+      _ = try GraphcodeCommand.parse([
+        "node", "promote", "/tmp/x", id, "--type", "turn", "--pause", "sometimes",
+      ])
+    }
+  }
+
+  /// Demotion and composite have no CLI spelling for the same reason they have no wire
+  /// shape (`SketchPromotion`): refused at parse, before a daemon is even dialled.
+  @Test
+  func promoteRefusesTargetsThatAreNotAPromotion() {
+    let id = UUID().uuidString
+    for target in ["sketch", "composite"] {
+      #expect(
+        throws: GraphcodeCommand.ParseError.invalidValue(argument: "--type", value: target)
+      ) {
+        _ = try GraphcodeCommand.parse(["node", "promote", "/tmp/x", id, "--type", target])
+      }
+    }
+  }
+}

--- a/graphcode/Tests/SketchPromotionTests.swift
+++ b/graphcode/Tests/SketchPromotionTests.swift
@@ -25,7 +25,8 @@ struct SketchPromotionTests {
     await store.handle(.createEdge(from: parent.id, to: sketch.id, spec: EdgeSpec()))
 
     await store.handle(
-      .promoteNode(sketch.id, promotion: .goal(GoalSpec(summary: "the flake is fixed"))))
+      .promoteNode(
+        sketch.id, promotion: .goal(GoalSpec(summary: "the flake is fixed")), promotedBy: nil))
 
     let graph = await store.graph
     let promoted = graph.nodes[id: sketch.id]
@@ -44,7 +45,8 @@ struct SketchPromotionTests {
     let sketch = sketchDraft()
     await store.handle(.createNode(sketch))
 
-    await store.handle(.promoteNode(sketch.id, promotion: .goal(GoalSpec(summary: "   "))))
+    await store.handle(
+      .promoteNode(sketch.id, promotion: .goal(GoalSpec(summary: "   ")), promotedBy: nil))
 
     let graph = await store.graph
     #expect(graph.nodes[id: sketch.id]?.loopType == .sketch)
@@ -57,7 +59,8 @@ struct SketchPromotionTests {
     let turn = NodeDraft(title: "Review", loopType: .turnBased, firstInstruction: "Work")
     await store.handle(.createNode(turn))
 
-    await store.handle(.promoteNode(turn.id, promotion: .goal(GoalSpec(summary: "done"))))
+    await store.handle(
+      .promoteNode(turn.id, promotion: .goal(GoalSpec(summary: "done")), promotedBy: nil))
 
     let graph = await store.graph
     #expect(graph.nodes[id: turn.id]?.loopType == .turnBased)
@@ -74,7 +77,9 @@ struct SketchPromotionTests {
     await store.handle(.createNode(sketch))
 
     await store.handle(
-      .promoteNode(sketch.id, promotion: .timed(triggerPrompt: "/loop 1h watch the crash reports")))
+      .promoteNode(
+        sketch.id, promotion: .timed(triggerPrompt: "/loop 1h watch the crash reports"),
+        promotedBy: nil))
 
     let graph = await store.graph
     let promoted = graph.nodes[id: sketch.id]
@@ -91,7 +96,8 @@ struct SketchPromotionTests {
     let sketch = sketchDraft()
     await store.handle(.createNode(sketch))
 
-    await store.handle(.promoteNode(sketch.id, promotion: .turn(pausesBeforeWritesOnly: true)))
+    await store.handle(
+      .promoteNode(sketch.id, promotion: .turn(pausesBeforeWritesOnly: true), promotedBy: nil))
 
     let graph = await store.graph
     let promoted = graph.nodes[id: sketch.id]
@@ -123,6 +129,100 @@ struct SketchPromotionTests {
     state.promotionTarget = .turnBased
     state.promotionPausesBeforeWritesOnly = true
     #expect(state.promotion == .turn(pausesBeforeWritesOnly: true))
+  }
+
+  /// `updateNode`'s one rule with teeth, held at promotion too: a loop may not hand
+  /// *itself* a stop condition. Without this, self-promotion was the open back door —
+  /// promote yourself to goal with `predicate: "true"` and you have written and passed
+  /// your own verifier in one command.
+  @Test
+  func selfPromotionMayNotCarryAPredicate() async {
+    let entries = LockIsolated<[String]>([])
+    let store = GraphStore(onAppendMemory: { _, entry in
+      entries.withValue { $0.append(entry) }
+    })
+    let sketch = sketchDraft()
+    await store.handle(.createNode(sketch))
+
+    await store.handle(
+      .promoteNode(
+        sketch.id,
+        promotion: .goal(GoalSpec(summary: "done", predicate: "true")),
+        promotedBy: sketch.id))
+
+    let graph = await store.graph
+    #expect(graph.nodes[id: sketch.id]?.loopType == .sketch)
+    #expect(graph.nodes[id: sketch.id]?.goal == nil)
+    #expect(entries.value.contains { $0.contains("may not set its own stop condition") })
+  }
+
+  /// The refusal is about the predicate, not about self-promotion: prose states the
+  /// goal without passing it, so a loop giving itself a summary-only shape stays legal.
+  @Test
+  func summaryOnlySelfPromotionIsAllowed() async {
+    let store = GraphStore()
+    let sketch = sketchDraft()
+    await store.handle(.createNode(sketch))
+
+    await store.handle(
+      .promoteNode(
+        sketch.id, promotion: .goal(GoalSpec(summary: "the report is filed")),
+        promotedBy: sketch.id))
+
+    let graph = await store.graph
+    #expect(graph.nodes[id: sketch.id]?.loopType == .goalBased)
+    #expect(graph.nodes[id: sketch.id]?.goal?.summary == "the report is filed")
+  }
+
+  /// The verifier stays outside the verified — and anyone outside may set it: a peer
+  /// promoting a sketch can carry a predicate, exactly like a human's shell.
+  @Test
+  func aPeerMayPromoteWithAPredicate() async {
+    let store = GraphStore()
+    let reviewer = NodeDraft(title: "Reviewer", loopType: .turnBased, firstInstruction: "Judge")
+    let sketch = sketchDraft()
+    await store.handle(.createNode(reviewer))
+    await store.handle(.createNode(sketch))
+
+    await store.handle(
+      .promoteNode(
+        sketch.id,
+        promotion: .goal(GoalSpec(summary: "tests pass", predicate: "make test")),
+        promotedBy: reviewer.id))
+
+    let graph = await store.graph
+    #expect(graph.nodes[id: sketch.id]?.loopType == .goalBased)
+    #expect(graph.nodes[id: sketch.id]?.goal?.predicate == "make test")
+  }
+
+  /// Provenance reaches the diary the way `updateNode`'s does: the promoter's title
+  /// when a loop asked, "itself" for a self-promotion, "a human" otherwise.
+  @Test
+  func theDiaryNamesThePromoter() async {
+    let entries = LockIsolated<[String]>([])
+    let store = GraphStore(onAppendMemory: { _, entry in
+      entries.withValue { $0.append(entry) }
+    })
+    let parent = NodeDraft(title: "Coordinator", loopType: .turnBased, firstInstruction: "Run")
+    let bySelf = sketchDraft("Solo")
+    let byPeer = sketchDraft("Delegated")
+    let byHuman = sketchDraft("Handled")
+    await store.handle(.createNode(parent))
+    for draft in [bySelf, byPeer, byHuman] { await store.handle(.createNode(draft)) }
+
+    await store.handle(
+      .promoteNode(
+        bySelf.id, promotion: .goal(GoalSpec(summary: "a")), promotedBy: bySelf.id))
+    await store.handle(
+      .promoteNode(
+        byPeer.id, promotion: .goal(GoalSpec(summary: "b")), promotedBy: parent.id))
+    await store.handle(
+      .promoteNode(byHuman.id, promotion: .goal(GoalSpec(summary: "c")), promotedBy: nil))
+
+    let promotions = entries.value.filter { $0.contains("promoted from sketch") }
+    #expect(promotions.contains { $0.contains("by itself") })
+    #expect(promotions.contains { $0.contains("by Coordinator") })
+    #expect(promotions.contains { $0.contains("by a human") })
   }
 
   /// Demotion is unrepresentable rather than refused: no `SketchPromotion` case lands


### PR DESCRIPTION
## The gap

`updateNode` has one rule with teeth: a loop may not change its **own** stop condition (`updatedBy == nodeID` → refused). But `promoteNode` carried no provenance at all, and a promotion's `GoalSpec` accepts a `predicate` — so self-promotion was the open back door. A sketch loop could promote itself to goal with `predicate: "true"` and write-and-pass its own verifier in one command. (Found while promoting a live sketch loop from inside its own session.)

## What changed

- **`promoteNode` gains `promotedBy`**, attributed exactly like `updateNode.updatedBy` (`ZMX_SESSION`, honest-by-default). Optional, so frames from clients that predate the field decode as an unattributed promotion rather than failing.
- **The rule holds at this door too:** a goal promotion carrying a predicate is refused when the promoter is the promoted. Summary-only self-promotion stays legal — prose states the goal, it doesn't pass it. A peer or a human can still set a predicate: the verifier stays *outside* the verified, not unset.
- **The diary names the promoter** — a peer's title, `itself`, or `a human` — matching update's attribution.
- **`graphcode node promote <path> <id> --type goal|turn|time`** joins the CLI (the daemon spoke `promoteNode` since #126-era but no CLI verb existed; the app's context menu was the only surface). Goal reuses create's `--goal/--predicate/--metric/--direction`; time reuses `--prompt`; turn's one new flag is `--pause every-turn|before-writes` (default matches the app's form). Missing decisions are named at parse time; `sketch`/`composite` targets are refused by shape.
- A sketch's `update refused: nothing in it applies` now answers the obvious next question — it points at `node promote`.
- `SketchPromotion`'s doc states the composite omission is deliberate, not an oversight.

## Tests

- `SketchPromotionTests`: self-promotion with a predicate refused (and recorded in memory); summary-only self-promotion allowed; peer promotion with predicate allowed; diary attribution for all three promoter shapes.
- `GraphcodeCommandPromoteTests` (split from `GraphcodeCommandTests` for size limits): each target's one decision parses; missing decisions and bad `--pause` values are named; `sketch`/`composite` refused.
- Full suite green (`make test`), `make check` clean, CLI and daemon build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)