### PR TITLE
Let the Settings window shrink as well as grow

### DIFF
--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -19,7 +19,9 @@ struct SettingsView: View {
   /// nothing is worse than no tab.
   var body: some View {
     sessions
-      .frame(minWidth: 620, maxWidth: .infinity)
+      // Resizable both ways: 620 stays the width the window opens at, but the floor
+      // sits at 480 — the grouped form's captions wrap, so narrow just means taller.
+      .frame(minWidth: 480, idealWidth: 620, maxWidth: .infinity)
       .padding(.vertical, 4)
   }
 


### PR DESCRIPTION
#123 made the Settings window resizable, but with a 620pt minimum the resizing was one-directional — it could only grow. This keeps 620 as the width the window opens at (`idealWidth`) and lowers the floor to 480 (`minWidth`), so it now shrinks too. The grouped form's captions already wrap (`fixedSize(horizontal: false, vertical: true)`), so a narrower window just gets taller.

Built (`make build-app`) and `make check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)