### PR TITLE
Goal token budgets, predicate failure feedback, and follow-up sends

### DIFF
--- a/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
+++ b/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
@@ -20,7 +20,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
   case createEdge(projectPath: String, from: UUID, to: UUID, spec: EdgeSpec)
   case stopNode(projectPath: String, nodeID: UUID)
   case deleteNode(projectPath: String, nodeID: UUID)
-  case sendMessage(projectPath: String, nodeID: UUID, text: String)
+  case sendMessage(projectPath: String, nodeID: UUID, text: String, followUp: Bool = false)
   case updateNode(projectPath: String, nodeID: UUID, update: NodeUpdate)
   /// Give a sketch a shape — the CLI half of the canvas's "Promote to…" menu. The
   /// promoter's identity is attributed at execution (`ZMX_SESSION`), not parsed here,
@@ -51,7 +51,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
       graphcode node stop <project-path> <node-id>
       graphcode node delete <project-path> <node-id>   removes it, its edges, session
                            and memory — irreversible; stop is the reversible verb
-      graphcode node send <project-path> <node-id> <message…>
+      graphcode node send <project-path> <node-id> [--follow-up] <message…>
       graphcode node update <project-path> <node-id> [options]
       graphcode node promote <project-path> <node-id> --type <goal|turn|time> [options]
                            give a sketch a shape, keeping its session, edges and memory
@@ -89,13 +89,28 @@ public enum GraphcodeCommand: Equatable, Sendable {
                            so it can score itself as it works, and sampled by graphcoded
                            once per cycle pass (last stdout line must be a number)
       --direction <d>      minimize | maximize                 (default: maximize)
+      --budget <tokens>    for --type goal: end the loop once its backend reports this
+                           many tokens spent (input + output). Reported, never
+                           estimated — a loop whose backend reports nothing is never
+                           stopped by a budget
+      --skip-unchanged     for --type goal: don't re-run the predicate while HEAD and
+                           the dirty file list are unchanged since its last failure.
+                           Only for predicates that depend on the tree — one that
+                           watches CI or a deploy would never be re-asked
 
     UPDATE OPTIONS (node update; pass only what changes)
       --goal, --predicate, --prompt, --check, --model, --metric, --direction as above
       --poll <seconds>     how often the predicate is polled
       --stall <seconds>    stall bound; 0 clears it
-      A loop may not change its own --predicate: the verifier stays outside the
-      verified. Session-facing changes reach a live session as a [graphcode] notice.
+      --budget <tokens>    token budget; 0 clears it
+      --skip-unchanged <true|false>
+      A loop may not change its own --predicate or --budget: the verifier stays outside
+      the verified. Session-facing changes reach a live session as a [graphcode] notice.
+
+    SEND OPTIONS (node send)
+      --follow-up          first word after the id: don't interrupt — the message is
+                           staged to the loop's memory and typed into its session when
+                           it next goes idle, instead of mid-turn
 
     PROMOTE OPTIONS (node promote; each target asks for its one decision)
       --type goal          with --goal <text> (required); --predicate, --metric,
@@ -204,12 +219,19 @@ public enum GraphcodeCommand: Equatable, Sendable {
           return .promoteNode(
             projectPath: path, nodeID: nodeID, promotion: try parsePromotion(arguments))
         case "send":
+          // `--follow-up` is recognised only as the first word after the id, so it can
+          // still be *sent* by putting it anywhere later in the message.
+          var followUp = false
+          if arguments.first == "--follow-up" {
+            followUp = true
+            arguments.removeFirst()
+          }
           // Everything after the id is the message — joined rather than flagged, so
           // `graphcode node send <path> <id> tests are green, ship it` needs no quoting
           // gymnastics from the agent typing it.
           let text = arguments.joined(separator: " ").trimmingCharacters(in: .whitespaces)
           guard !text.isEmpty else { throw ParseError.missingArgument("message") }
-          return .sendMessage(projectPath: path, nodeID: nodeID, text: text)
+          return .sendMessage(projectPath: path, nodeID: nodeID, text: text, followUp: followUp)
         case "update":
           return .updateNode(projectPath: path, nodeID: nodeID, update: try parseUpdate(arguments))
         case "memo":
@@ -306,6 +328,15 @@ public enum GraphcodeCommand: Equatable, Sendable {
       metricDirection = parsed
     }
 
+    var tokenBudget: Int?
+    if let raw = flags["budget"] {
+      guard let value = Int(raw), value > 0 else {
+        throw ParseError.invalidValue(argument: "--budget", value: raw)
+      }
+      tokenBudget = value
+    }
+    let skipsUnchanged = try parseSkipUnchanged(flags) ?? false
+
     let draft = NodeDraft(
       title: title,
       loopType: loopType,
@@ -319,7 +350,8 @@ public enum GraphcodeCommand: Equatable, Sendable {
       goal: flags["goal"].map {
         GoalSpec(
           summary: $0, predicate: flags["predicate"],
-          metricCommand: flags["metric"], metricDirection: metricDirection)
+          metricCommand: flags["metric"], metricDirection: metricDirection,
+          tokenBudget: tokenBudget, skipsUnchangedWorkspace: skipsUnchanged)
       },
       backend: backend,
       modelTier: modelTier)
@@ -365,6 +397,14 @@ public enum GraphcodeCommand: Equatable, Sendable {
       modelTier = parsed
     }
 
+    var tokenBudget: Int?
+    if let raw = flags["budget"] {
+      guard let value = Int(raw) else {
+        throw ParseError.invalidValue(argument: "--budget", value: raw)
+      }
+      tokenBudget = value
+    }
+
     let update = NodeUpdate(
       goalSummary: flags["goal"],
       goalPredicate: flags["predicate"],
@@ -372,11 +412,24 @@ public enum GraphcodeCommand: Equatable, Sendable {
       stallAfterSeconds: stallAfterSeconds,
       metricCommand: flags["metric"],
       metricDirection: metricDirection,
+      tokenBudget: tokenBudget,
+      skipsUnchangedWorkspace: try parseSkipUnchanged(flags),
       triggerPrompt: flags["prompt"],
       checkDescription: flags["check"],
       modelTier: modelTier)
     guard !update.isEmpty else { throw ParseError.missingArgument("an option to change") }
     return update
+  }
+
+  /// `--skip-unchanged` — bare or `true` opts in, `false` opts back out, absent means
+  /// "leave it alone" (create's caller defaults that to off).
+  private static func parseSkipUnchanged(_ flags: [String: String]) throws -> Bool? {
+    guard let raw = flags["skip-unchanged"] else { return nil }
+    switch raw {
+    case "", "true": return true
+    case "false": return false
+    default: throw ParseError.invalidValue(argument: "--skip-unchanged", value: raw)
+    }
   }
 
   /// The one decision each target type needs — the same vocabulary `node create`

--- a/GraphcodeKit/Sources/Domain/GoalSpec.swift
+++ b/GraphcodeKit/Sources/Domain/GoalSpec.swift
@@ -41,6 +41,23 @@ public struct GoalSpec: Codable, Equatable, Sendable {
   public var metricCommand: String?
   /// Which way `metricCommand`'s number should move. Defaults to `.maximize`.
   public var metricDirection: MetricDirection
+  /// How many tokens (input + output, as the backend reports them) this loop may spend
+  /// before the orchestrator ends it — docs/08-quality-and-token-budgets.md's budget,
+  /// finally enforced rather than reviewed after the fact. `nil` means unbounded, which
+  /// stays the default: a budget is a bound the author chose, never one invented.
+  ///
+  /// Enforcement shares `UsageSample`'s honesty rule: usage is *reported* by the
+  /// backend's hooks, never estimated, so a loop whose backend reports nothing can
+  /// never blow this bound. The budget is only as real as the reporting — the poller
+  /// acts on what was reported, and stays silent about what wasn't.
+  public var tokenBudget: Int?
+  /// When true, the poller skips re-running the predicate while the working tree is
+  /// unchanged (same `HEAD`, same dirty files) since the last failing run. Off by
+  /// default with reason: plenty of predicates watch things *outside* the tree — a CI
+  /// run, a deployed endpoint — and skipping those would wait on a change that never
+  /// comes. Opt in exactly when the predicate is a function of the tree (a test suite,
+  /// a lint) and expensive enough that docs/08's conservative-polling stance applies.
+  public var skipsUnchangedWorkspace: Bool
 
   public init(
     summary: String,
@@ -48,7 +65,9 @@ public struct GoalSpec: Codable, Equatable, Sendable {
     pollIntervalSeconds: Double = 60,
     stallAfterSeconds: Double? = nil,
     metricCommand: String? = nil,
-    metricDirection: MetricDirection = .maximize
+    metricDirection: MetricDirection = .maximize,
+    tokenBudget: Int? = nil,
+    skipsUnchangedWorkspace: Bool = false
   ) {
     self.summary = summary
     self.predicate = predicate
@@ -56,6 +75,8 @@ public struct GoalSpec: Codable, Equatable, Sendable {
     self.stallAfterSeconds = stallAfterSeconds
     self.metricCommand = metricCommand
     self.metricDirection = metricDirection
+    self.tokenBudget = tokenBudget
+    self.skipsUnchangedWorkspace = skipsUnchangedWorkspace
   }
 
   /// Non-empty predicate or nil — an all-whitespace field is a human leaving it blank,
@@ -95,12 +116,17 @@ public struct GoalSpec: Codable, Equatable, Sendable {
         "Measure your performance with this command (\(metricDirection.displayName)): "
           + "\(metric) — run it as you work; the orchestrator samples it each pass.")
     }
+    if let budget = tokenBudget, budget > 0 {
+      // Told to the session for the same reason the metric is: a loop that doesn't know
+      // its budget can't pace itself toward it — it can only be surprised by it.
+      parts.append("Token budget: \(budget) — the orchestrator ends this loop if it spends more.")
+    }
     return parts.joined(separator: " ")
   }
 
   private enum CodingKeys: String, CodingKey {
     case summary, predicate, pollIntervalSeconds, stallAfterSeconds
-    case metricCommand, metricDirection
+    case metricCommand, metricDirection, tokenBudget, skipsUnchangedWorkspace
   }
 
   /// Hand-written for the same reason `LoopEdge`'s is: a field added after a graph was
@@ -115,5 +141,8 @@ public struct GoalSpec: Codable, Equatable, Sendable {
     metricCommand = try container.decodeIfPresent(String.self, forKey: .metricCommand)
     metricDirection =
       try container.decodeIfPresent(MetricDirection.self, forKey: .metricDirection) ?? .maximize
+    tokenBudget = try container.decodeIfPresent(Int.self, forKey: .tokenBudget)
+    skipsUnchangedWorkspace =
+      try container.decodeIfPresent(Bool.self, forKey: .skipsUnchangedWorkspace) ?? false
   }
 }

--- a/GraphcodeKit/Sources/Domain/NodeUpdate.swift
+++ b/GraphcodeKit/Sources/Domain/NodeUpdate.swift
@@ -25,6 +25,11 @@ public struct NodeUpdate: Codable, Equatable, Sendable {
   /// `.goalBased`: new metric command (`GoalSpec.metricCommand`). Empty string clears.
   public var metricCommand: String?
   public var metricDirection: MetricDirection?
+  /// `.goalBased`: new token budget (`GoalSpec.tokenBudget`). Non-positive clears it.
+  public var tokenBudget: Int?
+  /// `.goalBased`: whether the predicate skips re-running against an unchanged tree
+  /// (`GoalSpec.skipsUnchangedWorkspace`).
+  public var skipsUnchangedWorkspace: Bool?
   /// `.timeBased`: new opening prompt. Reaches a live session only as a nudge; the
   /// session that already ran its old prompt keeps its cadence until relaunched.
   public var triggerPrompt: String?
@@ -45,6 +50,8 @@ public struct NodeUpdate: Codable, Equatable, Sendable {
     stallAfterSeconds: Double? = nil,
     metricCommand: String? = nil,
     metricDirection: MetricDirection? = nil,
+    tokenBudget: Int? = nil,
+    skipsUnchangedWorkspace: Bool? = nil,
     triggerPrompt: String? = nil,
     checkDescription: String? = nil,
     modelTier: ModelTier? = nil,
@@ -56,6 +63,8 @@ public struct NodeUpdate: Codable, Equatable, Sendable {
     self.stallAfterSeconds = stallAfterSeconds
     self.metricCommand = metricCommand
     self.metricDirection = metricDirection
+    self.tokenBudget = tokenBudget
+    self.skipsUnchangedWorkspace = skipsUnchangedWorkspace
     self.triggerPrompt = triggerPrompt
     self.checkDescription = checkDescription
     self.modelTier = modelTier
@@ -66,13 +75,17 @@ public struct NodeUpdate: Codable, Equatable, Sendable {
   public var isEmpty: Bool {
     goalSummary == nil && goalPredicate == nil && pollIntervalSeconds == nil
       && stallAfterSeconds == nil && metricCommand == nil && metricDirection == nil
+      && tokenBudget == nil && skipsUnchangedWorkspace == nil
       && triggerPrompt == nil && checkDescription == nil && modelTier == nil
   }
 
   /// Whether this update touches what decides the loop is finished. The one edit a loop
   /// may not make to *itself*: the verifier stays outside the verified, for the same
-  /// reason maker and critic are separate sessions.
+  /// reason maker and critic are separate sessions. The budget counts: raising or
+  /// clearing it is loosening the bound the loop runs under, and there is no honest way
+  /// to allow tightening while refusing the reverse without the refusal reading as
+  /// arbitrary.
   public var touchesStopCondition: Bool {
-    goalPredicate != nil
+    goalPredicate != nil || tokenBudget != nil
   }
 }

--- a/GraphcodeKit/Sources/Domain/SessionBriefing.swift
+++ b/GraphcodeKit/Sources/Domain/SessionBriefing.swift
@@ -116,7 +116,9 @@ public enum SessionBriefing {
       you", "stop, I already fixed that file". `graphcode status \(projectPath)` shows
       every loop's id. A target that isn't live gets the message staged into its
       memory instead — it reads it at its next wake, and the command tells you which
-      happened. If you were created by another loop, your memory log's first entry is
+      happened. Add `--follow-up` (first word after the id) when the message can wait:
+      the target is not interrupted mid-turn — it hears it when it next goes idle,
+      from its memory otherwise. If you were created by another loop, your memory log's first entry is
       the exact command for reporting results back to it. For recurring communication,
       an edge is still the right tool: a `message` edge fires automatically when you
       finish, a `handoff` sequences the other loop after you. This command is the
@@ -145,8 +147,9 @@ public enum SessionBriefing {
         `node delete` also erases its edges, session, and memory — irreversible, so
         reach for stop unless deletion is exactly what was asked for.
       - `graphcode node update \(projectPath) <node-id> --goal|--prompt|--check|--model …`
-        edits a loop in place; a loop may not change its own `--predicate`. For a
-        composite loop, `node pilot` dry-runs it and `node arm` arms it afterwards.
+        edits a loop in place; a loop may not change its own `--predicate` or
+        `--budget`. For a composite loop, `node pilot` dry-runs it and `node arm` arms
+        it afterwards.
       - `graphcode edge create \(projectPath) <from-id> <to-id> --kind handoff|message|spawn`
         wires loops: `handoff` sequences the target after you finish, `message` sends it
         your result, `spawn` has your finish create it.

--- a/GraphcodeKit/Sources/Domain/ShellPredicate.swift
+++ b/GraphcodeKit/Sources/Domain/ShellPredicate.swift
@@ -18,3 +18,20 @@ public struct ShellPredicate: Equatable, Sendable {
     self.workingDirectory = workingDirectory
   }
 }
+
+/// A predicate run that kept its evidence: did it hold, and what the command printed on
+/// the way to that answer. The exit status alone was enough for resolving a goal, but a
+/// *failing* stop condition has one more job — telling the session *why* it isn't done
+/// yet — and by the time anyone wants the output, the run that produced it is gone.
+public struct PredicateOutcome: Equatable, Sendable {
+  public let passed: Bool
+  /// The last stretch of combined stdout+stderr, bounded at the evaluator so a chatty
+  /// test suite can't turn a nudge into a transcript. Empty when the command printed
+  /// nothing worth relaying.
+  public let outputTail: String
+
+  public init(passed: Bool, outputTail: String = "") {
+    self.passed = passed
+    self.outputTail = outputTail
+  }
+}

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -35,6 +35,11 @@ public actor GraphStore {
   private let onEnsureSession: (@Sendable (LoopNode, String?) -> Void)?
   private let onTerminateSession: (@Sendable (LoopNode, String?) -> Void)?
   private let onEvaluatePredicate: (@Sendable (ShellPredicate) async -> Bool)?
+  /// `onEvaluatePredicate` with the evidence kept: pass/fail plus the run's output tail
+  /// (`ShellPredicateEvaluator.check`). Goal polling prefers this when wired, so a
+  /// failing stop condition can tell the session *why* it isn't done; the plain hook
+  /// stays for the `until`-guard and for every test that stubs a bare yes/no.
+  private let onCheckPredicate: (@Sendable (ShellPredicate) async -> PredicateOutcome?)?
   private let onDeliverMessage: (@Sendable (LoopNode, String, String?) async -> Bool)?
   private let onCaptureScript: (@Sendable (ShellPredicate) async -> String?)?
   private let onReadUsage: (@Sendable (LoopNode, String?) async -> UsageSample?)?
@@ -66,6 +71,20 @@ public actor GraphStore {
   static let maxSubGraphDepth = 6
   static let maxNodesPerGraph = 50
   private var goalPollers: [UUID: Task<Void, Never>] = [:]
+  /// Workspace fingerprint at the last *failing* predicate run, per node — what
+  /// `GoalSpec.skipsUnchangedWorkspace` compares against. In-memory on purpose: a
+  /// daemon restart forgetting these costs one extra predicate run, and persisting a
+  /// cache whose whole point is skipping work would be work.
+  private var failedPredicateFingerprints: [UUID: String] = [:]
+  /// The failure tail last relayed to each node's session, so an unchanged failure is
+  /// never repeated at it poll after poll.
+  private var lastPredicateFeedback: [UUID: String] = [:]
+  /// `node send --follow-up` messages waiting for their target to finish its current
+  /// turn — drained whenever the store settles (`drainAndBroadcast`) and on each
+  /// presence poll. The content is in the target's memory log from the moment it was
+  /// queued, so losing this queue to a restart delays the message to the next wake
+  /// rather than dropping it.
+  private var pendingFollowUps: [(nodeID: UUID, text: String)] = []
 
   /// A poller holds `self` weakly, so a store going away already stops it *doing*
   /// anything — but the task itself keeps sleeping in its loop forever. That was
@@ -105,6 +124,7 @@ public actor GraphStore {
     onEnsureSession: (@Sendable (LoopNode, String?) -> Void)? = nil,
     onTerminateSession: (@Sendable (LoopNode, String?) -> Void)? = nil,
     onEvaluatePredicate: (@Sendable (ShellPredicate) async -> Bool)? = nil,
+    onCheckPredicate: (@Sendable (ShellPredicate) async -> PredicateOutcome?)? = nil,
     onDeliverMessage: (@Sendable (LoopNode, String, String?) async -> Bool)? = nil,
     onCaptureScript: (@Sendable (ShellPredicate) async -> String?)? = nil,
     onReadUsage: (@Sendable (LoopNode, String?) async -> UsageSample?)? = nil,
@@ -122,6 +142,7 @@ public actor GraphStore {
     self.onEnsureSession = onEnsureSession
     self.onTerminateSession = onTerminateSession
     self.onEvaluatePredicate = onEvaluatePredicate
+    self.onCheckPredicate = onCheckPredicate
     self.onDeliverMessage = onDeliverMessage
     self.onCaptureScript = onCaptureScript
     self.onReadUsage = onReadUsage
@@ -260,8 +281,8 @@ public actor GraphStore {
         resolveNode(nodeID, succeeded: false)
       }
 
-    case .messageNode(let nodeID, let text, let from):
-      await deliverAdHocMessage(to: nodeID, text: text, from: from)
+    case .messageNode(let nodeID, let text, let from, let followUp):
+      await deliverAdHocMessage(to: nodeID, text: text, from: from, followUp: followUp ?? false)
 
     case .renameNode(let nodeID, let title):
       renameNode(nodeID, to: title)
@@ -362,6 +383,7 @@ public actor GraphStore {
       onEnsureSession: nil,
       onTerminateSession: onTerminateSession,
       onEvaluatePredicate: onEvaluatePredicate,
+      onCheckPredicate: onCheckPredicate,
       onDeliverMessage: onDeliverMessage,
       onCaptureScript: onCaptureScript,
       onAppendMemory: onAppendMemory,
@@ -606,6 +628,9 @@ public actor GraphStore {
     var changed = await refreshPresence()
     if await refreshActivity() { changed = true }
     if await refreshSummary() { changed = true }
+    // The poll that just learned a target went idle is the natural moment to hand it
+    // what was waiting on exactly that.
+    await drainPendingFollowUps()
     guard changed else { return }
     notifyClients()
   }
@@ -699,6 +724,21 @@ public actor GraphStore {
       if let direction = update.metricDirection {
         goal.metricDirection = direction
         sessionFacing.append("for your metric, \(direction.displayName)")
+      }
+      // Session-facing like the metric is: the budget was written into the opening
+      // prompt, and a loop pacing itself against the old number would be pacing
+      // against a lie.
+      if let budget = update.tokenBudget {
+        goal.tokenBudget = budget > 0 ? budget : nil
+        sessionFacing.append(
+          goal.tokenBudget.map { "token budget: \($0)" } ?? "the token budget was removed")
+      }
+      if let skips = update.skipsUnchangedWorkspace {
+        goal.skipsUnchangedWorkspace = skips
+        observerSide.append(
+          skips
+            ? "predicate skips re-runs while the tree is unchanged"
+            : "predicate runs every poll")
       }
       node.goal = goal
 
@@ -1463,7 +1503,9 @@ public actor GraphStore {
   /// every connection, which the app shows as its error banner and the CLI prints —
   /// the whole point of the message was that a peer be told something, and pretending
   /// it landed is the one wrong answer.
-  private func deliverAdHocMessage(to nodeID: UUID, text: String, from senderID: UUID?) async {
+  private func deliverAdHocMessage(
+    to nodeID: UUID, text: String, from senderID: UUID?, followUp: Bool = false
+  ) async {
     guard let target = graph.nodes[id: nodeID] else {
       announceError("message not delivered: no loop \(nodeID) in this graph")
       return
@@ -1477,6 +1519,17 @@ public actor GraphStore {
     // its source — the target should know who's talking without guessing.
     let sender = senderID.flatMap { graph.nodes[id: $0]?.title }
     let message = "[graphcode] \(sender.map { "\($0): " } ?? "")\(trimmed)"
+
+    // `--follow-up`: the sender chose deference over immediacy. A live target keeps its
+    // current turn uninterrupted and hears this when it next goes idle; the memory log
+    // gets it first, the way every deferred word does (`pendingNudges`), so a queue
+    // lost to a daemon restart delays the message to the next wake instead of
+    // dropping it.
+    if followUp, deliversLater(to: target) {
+      recordMemory(nodeID, "follow-up staged: \(message)")
+      pendingFollowUps.append((nodeID: nodeID, text: message))
+      return
+    }
 
     // Not live, or the transport failed — stage rather than drop. The refusal used to
     // be final, which was designed before loops had memory, and its sharpest edge was
@@ -1498,6 +1551,51 @@ public actor GraphStore {
           + "it will read it when it next wakes")
       return
     }
+  }
+
+  /// Whether a follow-up to this node should wait rather than type now. Mid-turn and
+  /// mid-check both qualify — deferring to a busy agent is the flag's entire meaning —
+  /// while an idle session gets ordinary immediate delivery and a dead one gets the
+  /// ordinary staged-to-memory path.
+  private func deliversLater(to target: LoopNode) -> Bool {
+    switch MessageBus.deliverability(to: target) {
+    case .targetBusyWithACheck: return true
+    case nil: return target.presence?.presence != .idle
+    default: return false
+    }
+  }
+
+  /// Delivers queued follow-ups whose targets have finished their turn. Called wherever
+  /// the store settles, and from the presence poll — the reading that says "idle" is
+  /// the reading this waits for. A target that resolved or died is simply dropped from
+  /// the queue: its memory log has carried the message since it was staged.
+  private func drainPendingFollowUps() async {
+    guard !pendingFollowUps.isEmpty else { return }
+    var remaining: [(nodeID: UUID, text: String)] = []
+    for pending in pendingFollowUps {
+      guard let node = graph.nodes[id: pending.nodeID], !node.isResolved else { continue }
+      switch MessageBus.deliverability(to: node) {
+      case .targetBusyWithACheck:
+        remaining.append(pending)
+        continue
+      case .some:
+        continue
+      case nil:
+        break
+      }
+      let presence: Presence?
+      if let onReadPresence {
+        presence = await onReadPresence(node, graph.project.path).presence
+      } else {
+        presence = node.presence?.presence
+      }
+      guard presence == .idle else {
+        remaining.append(pending)
+        continue
+      }
+      _ = await deliverToSession(node, pending.text)
+    }
+    pendingFollowUps = remaining
   }
 
   private func announceError(_ message: String) {
@@ -1528,11 +1626,13 @@ public actor GraphStore {
   /// about work that is running in a perfectly ordinary session the whole time.
   private func armGoalPoller(for node: LoopNode) {
     guard let goal = node.goal else { return }
-    // Two independent reasons to poll: a predicate to evaluate, or a stall bound to
-    // enforce. A goal stated only in prose still deserves "this should have finished by
-    // now" if its author gave it a bound.
-    let hasPredicate = goal.effectivePredicate != nil && onEvaluatePredicate != nil
-    guard hasPredicate || goal.stallAfterSeconds != nil else { return }
+    // Three independent reasons to poll: a predicate to evaluate, a stall bound to
+    // enforce, or a token budget to hold the line on. A goal stated only in prose still
+    // deserves "this should have finished by now" if its author gave it a bound.
+    let hasPredicate =
+      goal.effectivePredicate != nil && (onEvaluatePredicate != nil || onCheckPredicate != nil)
+    let hasBudget = goal.tokenBudget != nil && onReadUsage != nil
+    guard hasPredicate || goal.stallAfterSeconds != nil || hasBudget else { return }
     goalPollers[node.id]?.cancel()
     let nodeID = node.id
     let interval = max(1, goal.pollIntervalSeconds)
@@ -1547,6 +1647,11 @@ public actor GraphStore {
 
   private func cancelGoalPoller(_ nodeID: UUID) {
     goalPollers.removeValue(forKey: nodeID)?.cancel()
+    // The caches ride the poller's lifecycle: a resolved node needs neither, and an
+    // update that changed the predicate must not skip the new command on the old
+    // tree's fingerprint or suppress its first failure as "already relayed".
+    failedPredicateFingerprints.removeValue(forKey: nodeID)
+    lastPredicateFeedback.removeValue(forKey: nodeID)
   }
 
   /// One poll. Called on the timer in production and directly from tests, so the
@@ -1571,20 +1676,118 @@ public actor GraphStore {
       return
     }
 
+    // The budget is checked before the predicate for the same reason the stall bound
+    // is: a loop that has blown its bound gets no further evaluations spent on it.
+    if await enforceTokenBudget(nodeID, goal: goal) {
+      await drainAndBroadcast()
+      return
+    }
+
     // No machine predicate means polling has nothing to ask. Such a node resolves only
     // when its session exits — checked here, not just where the poller is armed, so an
     // evaluator can never resolve a goal whose author never gave it a testable one.
     guard let predicate = goal.effectivePredicate else { return }
-    guard let onEvaluatePredicate,
-      await onEvaluatePredicate(
+    let shellPredicate = ShellPredicate(
+      command: predicate, workingDirectory: node.worktreeBinding?.worktreePath)
+
+    var fingerprint: String?
+    if goal.skipsUnchangedWorkspace, let onCaptureScript {
+      fingerprint = await onCaptureScript(
         ShellPredicate(
-          command: predicate, workingDirectory: node.worktreeBinding?.worktreePath))
-    else { return }
+          command: Self.workspaceFingerprintCommand,
+          workingDirectory: node.worktreeBinding?.worktreePath ?? graph.project.path))
+      // Same tree the predicate already failed against — running it again buys the
+      // same answer at full price. A missing fingerprint (not a git repo, capture not
+      // wired) falls through to a real run: skipping is the optimisation, never the rule.
+      if let fingerprint, failedPredicateFingerprints[nodeID] == fingerprint { return }
+    }
+
+    let outcome: PredicateOutcome
+    if let onCheckPredicate {
+      guard let checked = await onCheckPredicate(shellPredicate) else { return }
+      outcome = checked
+    } else if let onEvaluatePredicate {
+      outcome = PredicateOutcome(passed: await onEvaluatePredicate(shellPredicate))
+    } else {
+      return
+    }
     // Re-check: an await means the graph could have moved under us (the node deleted,
     // or its session exited and resolved it) while the predicate was running.
     guard let current = graph.nodes[id: nodeID], !current.isResolved else { return }
-    resolveNode(nodeID, succeeded: true)
-    await drainAndBroadcast()
+    if outcome.passed {
+      resolveNode(nodeID, succeeded: true)
+      await drainAndBroadcast()
+      return
+    }
+    if let fingerprint { failedPredicateFingerprints[nodeID] = fingerprint }
+    await relayPredicateFailure(to: current, predicate: predicate, outcome: outcome)
+  }
+
+  /// `HEAD` plus the dirty file list, hashed — what `GoalSpec.skipsUnchangedWorkspace`
+  /// means by "unchanged". Exits non-zero outside a git repository so the capture
+  /// returns nil and the skip never applies where "the tree changed" has no meaning.
+  static let workspaceFingerprintCommand =
+    "git rev-parse --verify HEAD >/dev/null 2>&1 || exit 1; "
+    + "{ git rev-parse HEAD; git status --porcelain; } 2>/dev/null | cksum"
+
+  /// Ends the loop when its reported usage has crossed its budget; returns whether it
+  /// did. Reads usage fresh rather than trusting the last panel-open refresh — the
+  /// nodes that pay this subprocess are exactly the ones whose author asked for the
+  /// bound. A backend that reports nothing can never exhaust a budget: the sample
+  /// stays nil and nil is "not reported", not zero — and not infinity either.
+  private func enforceTokenBudget(_ nodeID: UUID, goal: GoalSpec) async -> Bool {
+    guard let budget = goal.tokenBudget, budget > 0 else { return false }
+    guard let node = graph.nodes[id: nodeID] else { return false }
+    if let onReadUsage, let sample = await onReadUsage(node, graph.project.path) {
+      graph.nodes[id: nodeID]?.usage = sample
+    }
+    guard let current = graph.nodes[id: nodeID], !current.isResolved,
+      let used = current.usage?.totalTokens, used >= budget
+    else { return false }
+
+    // The same stop-by-request contract `requestStop` holds: only the loop can cancel
+    // the cadence it set up, so it is told to stop — with the arithmetic, so the
+    // instruction reads as enforcement rather than a change of heart. No kill fallback
+    // here: an unreachable session is spending nothing *right now*, and its next wake
+    // reads the exhaustion from memory.
+    var asked = false
+    if MessageBus.deliverability(to: current) == nil {
+      asked = await deliverToSession(
+        current, MessageBus.budgetExhaustedRequest(used: used, budget: budget))
+    }
+    graph.nodes[id: nodeID]?.state = .stalled
+    cancelGoalPoller(nodeID)
+    recordMemory(
+      nodeID,
+      "budget exhausted: \(used) of \(budget) tokens spent"
+        + (asked ? " — its session was asked to stop" : ""))
+    fireOutgoingEdges(from: nodeID, sourceSucceeded: false)
+    return true
+  }
+
+  /// Tells a session that believes it is finished why the daemon disagrees — the
+  /// half of a machine stop condition that a bare exit status threw away. Deliberately
+  /// narrow: only an *idle* session is told (a busy one is still working and will be
+  /// judged again next poll), and only when the failure changed since it was last told,
+  /// so a predicate failing the same way every minute costs one message, not sixty.
+  private func relayPredicateFailure(
+    to node: LoopNode, predicate: String, outcome: PredicateOutcome
+  ) async {
+    let tail = outcome.outputTail.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !tail.isEmpty, lastPredicateFeedback[node.id] != tail else { return }
+    let presence: Presence?
+    if let onReadPresence {
+      presence = await onReadPresence(node, graph.project.path).presence
+    } else {
+      presence = node.presence?.presence
+    }
+    guard presence == .idle, MessageBus.deliverability(to: node) == nil else { return }
+    let message =
+      "[graphcode] Goal not met yet: `\(predicate)` still exits non-zero. "
+      + "Its output ends with: \(tail)"
+    guard await deliverToSession(node, message) else { return }
+    lastPredicateFeedback[node.id] = tail
+    recordMemory(node.id, "predicate feedback: \(tail)")
   }
 
   /// The same settle-then-tell sequence `handle` ends with, for the paths that mutate
@@ -1595,6 +1798,7 @@ public actor GraphStore {
     await drainPendingCycleReentries()
     await drainPendingHandoffDeliveries()
     await drainPendingNudges()
+    await drainPendingFollowUps()
     broadcast()
   }
 

--- a/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
+++ b/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
@@ -100,7 +100,12 @@ public indirect enum GraphCommand: Codable, Sendable, Equatable {
   /// something. `from` is the sending loop when the CLI could attribute it
   /// (`ZMX_SESSION`, the same mechanism as `NodeDraft.createdBy`), so the target sees
   /// who's talking; nil from a human's shell.
-  case messageNode(UUID, text: String, from: UUID?)
+  ///
+  /// `followUp` is `node send --follow-up`: don't interrupt — stage the message to the
+  /// target's memory and type it in when the target next goes idle, rather than
+  /// mid-turn. Optional so frames from clients that predate the flag decode as the
+  /// immediate send they always were.
+  case messageNode(UUID, text: String, from: UUID?, followUp: Bool?)
   /// Removes the node, every edge touching it, and its detached session. Irreversible
   /// — the app confirms before sending this.
   case deleteNode(UUID)

--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -26,6 +26,7 @@ public actor ProjectRegistry {
   private let ensureSession: (@Sendable (LoopNode, String?) -> Void)?
   private let terminateSession: (@Sendable (LoopNode, String?) -> Void)?
   private let evaluatePredicate: (@Sendable (ShellPredicate) async -> Bool)?
+  private let checkPredicate: (@Sendable (ShellPredicate) async -> PredicateOutcome?)?
   private let deliverMessage: (@Sendable (LoopNode, String, String?) async -> Bool)?
   private let captureScript: (@Sendable (ShellPredicate) async -> String?)?
   private let readUsage: (@Sendable (LoopNode, String?) async -> UsageSample?)?
@@ -47,6 +48,8 @@ public actor ProjectRegistry {
       CLISessionBackend.terminateSession,
     evaluatePredicate: (@Sendable (ShellPredicate) async -> Bool)? = ShellPredicateEvaluator
       .evaluate,
+    checkPredicate: (@Sendable (ShellPredicate) async -> PredicateOutcome?)? =
+      ShellPredicateEvaluator.check,
     deliverMessage: (@Sendable (LoopNode, String, String?) async -> Bool)? =
       CLISessionBackend.deliverMessage,
     captureScript: (@Sendable (ShellPredicate) async -> String?)? = ShellPredicateEvaluator.capture,
@@ -63,6 +66,7 @@ public actor ProjectRegistry {
     self.ensureSession = ensureSession
     self.terminateSession = terminateSession
     self.evaluatePredicate = evaluatePredicate
+    self.checkPredicate = checkPredicate
     self.deliverMessage = deliverMessage
     self.captureScript = captureScript
     self.readUsage = readUsage
@@ -324,6 +328,7 @@ public actor ProjectRegistry {
       onEnsureSession: ensureSession,
       onTerminateSession: terminateSession,
       onEvaluatePredicate: evaluatePredicate,
+      onCheckPredicate: checkPredicate,
       onDeliverMessage: deliverMessage,
       onCaptureScript: captureScript,
       onReadUsage: readUsage,

--- a/GraphcodeKit/Sources/Sessions/MessageBus.swift
+++ b/GraphcodeKit/Sources/Sessions/MessageBus.swift
@@ -57,6 +57,18 @@ public enum MessageBus {
     + "— and do not start another pass. Stop where you are, say where you got to, and "
     + "stay in the session: the loop is what stops, not you. Do not exit or quit."
 
+  /// The stop request a blown token budget sends (`GraphStore.evaluateGoal`). Same
+  /// instruction as `stopRequest` — only the loop can cancel its own cadence — prefixed
+  /// with the *why*, because "stop" with no reason reads as a human's change of mind
+  /// and this one is arithmetic the loop can verify against its own usage.
+  public static func budgetExhaustedRequest(used: Int, budget: Int) -> String {
+    "[graphcode] Token budget exhausted: this loop has spent \(used) of its "
+      + "\(budget)-token budget. Stop this loop now: turn off any recurring schedule "
+      + "you set up for it — a /loop, a scheduled wakeup, a cron entry — and do not "
+      + "start another pass. Stop where you are, say where you got to, and stay in the "
+      + "session: the loop is what stops, not you. Do not exit or quit."
+  }
+
   /// What actually gets typed into the target. The edge's transform decides the content;
   /// a `.script` transform runs to produce it, which is docs/08's "a script is cheaper
   /// than reasoning through the steps every time" applied to a hand-off.

--- a/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
@@ -487,6 +487,10 @@ public enum RemoteGraphAccess {
         elif subverb == "delete":
             run_and_print(project, [graph_command(project, {"deleteNode": {"_0": node_id}})])
         else:
+            follow_up = False
+            if subverb == "send" and arguments and arguments[0] == "--follow-up":
+                follow_up = True
+                arguments.pop(0)
             text = " ".join(arguments).strip()
             if not text:
                 fail("missing %s" % ("message" if subverb == "send" else "note"))
@@ -495,8 +499,11 @@ public enum RemoteGraphAccess {
             if sender:
                 payload["from"] = sender
             if subverb == "send":
+                if follow_up:
+                    payload["followUp"] = True
                 run_with_verdict(project, graph_command(project, {"messageNode": payload}),
-                                 "delivered")
+                                 "accepted — typed in when the loop next goes idle"
+                                 if follow_up else "delivered")
             else:
                 run_with_verdict(project, graph_command(project, {"memoNode": payload}),
                                  "noted")

--- a/GraphcodeKit/Sources/Sessions/ShellPredicateEvaluator.swift
+++ b/GraphcodeKit/Sources/Sessions/ShellPredicateEvaluator.swift
@@ -23,6 +23,17 @@ public enum ShellPredicateEvaluator {
     await run(predicate)?.succeeded ?? false
   }
 
+  /// The `evaluate` answer with its evidence still attached: pass/fail plus the tail of
+  /// what the command printed, stderr included — a failing test suite says *why* on
+  /// stderr, and a nudge built from a silenced stream would relay nothing. `nil` when
+  /// the command couldn't be run at all, which callers must treat as "not yet", the
+  /// same rule `evaluate` holds.
+  public static let check: @Sendable (ShellPredicate) async -> PredicateOutcome? = { predicate in
+    guard let result = await run(predicate, mergeStderr: true) else { return nil }
+    let trimmed = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+    return PredicateOutcome(passed: result.succeeded, outputTail: String(trimmed.suffix(600)))
+  }
+
   /// Same mechanism, but the *output* is the answer rather than the exit status — a
   /// `.script` payload transform on an edge, where docs/08's "use scripts for
   /// deterministic work" means the script produces the hand-off content itself.
@@ -58,7 +69,9 @@ public enum ShellPredicateEvaluator {
   /// pipe output readable after exit, and nothing here needs a terminal — the command
   /// is a predicate or metric script, not an interactive session. The pipe also ends
   /// the PTY's `^D\b\b` prelude garbling single-line output.
-  private static func run(_ predicate: ShellPredicate) async -> (succeeded: Bool, output: String)? {
+  private static func run(
+    _ predicate: ShellPredicate, mergeStderr: Bool = false
+  ) async -> (succeeded: Bool, output: String)? {
     let trimmed = predicate.command.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
 
@@ -77,7 +90,7 @@ public enum ShellPredicateEvaluator {
 
     let stdout = Pipe()
     process.standardOutput = stdout
-    process.standardError = FileHandle.nullDevice
+    process.standardError = mergeStderr ? stdout as Any : FileHandle.nullDevice as Any
     process.standardInput = FileHandle.nullDevice
 
     // Reader and exit are joined by a group, not sequenced: reading after exit

--- a/graphcode-cli/Sources/main.swift
+++ b/graphcode-cli/Sources/main.swift
@@ -168,7 +168,7 @@ do {
       projectPath: projectPath,
       [.graphCommand(projectPath: projectPath, command: .deleteNode(nodeID))])
 
-  case .sendMessage(let projectPath, let nodeID, let text):
+  case .sendMessage(let projectPath, let nodeID, let text, let followUp):
     // Attributed the same way `node create` attributes `createdBy`: run from inside a
     // loop, ZMX_SESSION names the sender, and the target sees who's talking.
     let sender = SurfaceRef.nodeID(
@@ -178,7 +178,7 @@ do {
     try client.send(
       .graphCommand(
         projectPath: projectPath,
-        command: .messageNode(nodeID, text: text, from: sender)))
+        command: .messageNode(nodeID, text: text, from: sender, followUp: followUp)))
     // Delivery is judged and attempted before the daemon broadcasts, so the first event
     // back is the verdict: an error means it did not land, the graph means it did.
     let verdict = try client.waitForEvent { event in
@@ -188,7 +188,9 @@ do {
       }
     }
     if case .errorOccurred(let message) = verdict { fail(message) }
-    print("delivered")
+    // A follow-up to a busy loop is accepted, not typed: it's in the loop's memory now
+    // and its session hears it when it next goes idle — "delivered" would overclaim.
+    print(followUp ? "accepted — typed in when the loop next goes idle" : "delivered")
 
   case .updateNode(let projectPath, let nodeID, let update):
     // Attributed like `node create`/`node send`: run from inside a loop, ZMX_SESSION

--- a/graphcode/Tests/CreatedByLoopTests.swift
+++ b/graphcode/Tests/CreatedByLoopTests.swift
@@ -67,7 +67,8 @@ struct CreatedByLoopTests {
     let parentID = try #require(await store.graph.nodes.first?.id)
     await store.handle(.nodeCheckApproved(parentID))
 
-    await store.handle(.messageNode(parentID, text: "task done: report attached", from: nil))
+    await store.handle(
+      .messageNode(parentID, text: "task done: report attached", from: nil, followUp: nil))
 
     let staged = memory.value.filter {
       $0.nodeID == parentID && $0.entry.contains("while you were away")

--- a/graphcode/Tests/FollowUpMessageTests.swift
+++ b/graphcode/Tests/FollowUpMessageTests.swift
@@ -1,0 +1,156 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+/// `node send --follow-up`: the sender chooses deference over immediacy. A busy target
+/// keeps its turn uninterrupted and hears the message when it next goes idle; the
+/// memory log carries it from the moment it was queued, so nothing depends on the
+/// queue surviving.
+@Suite
+struct FollowUpMessageTests {
+  private func graph(targetPresence: Presence?, state: LoopState = .running) -> LoopGraph {
+    LoopGraph(
+      project: ProjectRef(path: "/tmp/followup", name: "followup"),
+      nodes: [
+        LoopNode(
+          title: "Worker", loopType: .goalBased,
+          goal: GoalSpec(summary: "work"),
+          presence: targetPresence.map { PresenceReading(presence: $0, confidence: .reported) },
+          state: state)
+      ])
+  }
+
+  @Test
+  func aFollowUpToABusyLoopWaitsForIdleThenDelivers() async {
+    let delivered = LockIsolated<[String]>([])
+    let remembered = LockIsolated<[String]>([])
+    let presence = LockIsolated(Presence.busy)
+    let graph = graph(targetPresence: .busy)
+    let store = GraphStore(
+      graph: graph,
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      },
+      onReadPresence: { _, _ in PresenceReading(presence: presence.value, confidence: .reported) },
+      onAppendMemory: { _, entry in remembered.withValue { $0.append(entry) } })
+    let nodeID = graph.nodes[0].id
+
+    await store.handle(.messageNode(nodeID, text: "the API changed", from: nil, followUp: true))
+
+    // Not typed in mid-turn — staged to memory, waiting on idle.
+    #expect(delivered.value.isEmpty)
+    #expect(remembered.value.contains { $0.contains("follow-up staged") })
+
+    // Still busy at the next settle: still waiting.
+    await store.handle(.refreshUsage)
+    #expect(delivered.value.isEmpty)
+
+    presence.setValue(.idle)
+    await store.handle(.refreshUsage)
+    #expect(delivered.value == ["[graphcode] the API changed"])
+
+    // Delivered once — the queue entry is spent.
+    await store.handle(.refreshUsage)
+    #expect(delivered.value.count == 1)
+  }
+
+  @Test
+  func aFollowUpToAnIdleLoopDeliversImmediately() async {
+    let delivered = LockIsolated<[String]>([])
+    let graph = graph(targetPresence: .idle)
+    let store = GraphStore(
+      graph: graph,
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      })
+
+    await store.handle(
+      .messageNode(graph.nodes[0].id, text: "ready when you are", from: nil, followUp: true))
+
+    #expect(delivered.value == ["[graphcode] ready when you are"])
+  }
+
+  @Test
+  func aFollowUpToAResolvedLoopIsStagedLikeAnyOtherMessage() async {
+    let delivered = LockIsolated<[String]>([])
+    let remembered = LockIsolated<[String]>([])
+    let graph = graph(targetPresence: nil, state: .succeeded)
+    let store = GraphStore(
+      graph: graph,
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      },
+      onAppendMemory: { _, entry in remembered.withValue { $0.append(entry) } })
+
+    await store.handle(
+      .messageNode(graph.nodes[0].id, text: "for your next wake", from: nil, followUp: true))
+
+    #expect(delivered.value.isEmpty)
+    #expect(remembered.value.contains { $0.contains("while you were away") })
+  }
+
+  @Test
+  func aTargetThatDiesWhileQueuedIsDroppedNotRedelivered() async {
+    // The memory log has carried the message since it was staged; a dead session's
+    // next wake reads it there, so the queue owes it nothing further.
+    let delivered = LockIsolated<[String]>([])
+    let graph = graph(targetPresence: .busy)
+    let store = GraphStore(
+      graph: graph,
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      },
+      onReadPresence: { _, _ in PresenceReading(presence: .busy, confidence: .reported) })
+    let nodeID = graph.nodes[0].id
+
+    await store.handle(.messageNode(nodeID, text: "late news", from: nil, followUp: true))
+    await store.handle(.nodeCheckRejected(nodeID))
+    await store.handle(.refreshUsage)
+
+    #expect(delivered.value.isEmpty)
+  }
+
+  @Test
+  func anOldMessageNodeFrameStillDecodesAsAnImmediateSend() throws {
+    // Clients that predate the flag omit the key entirely; the frame must decode as
+    // the immediate send it always was, not fail the connection.
+    let json = #"{"messageNode":{"_0":"00000000-0000-0000-0000-000000000001","text":"hi"}}"#
+    let command = try JSONDecoder().decode(GraphCommand.self, from: Data(json.utf8))
+    guard case .messageNode(_, let text, let from, let followUp) = command else {
+      Issue.record("expected messageNode, got \(command)")
+      return
+    }
+    #expect(text == "hi")
+    #expect(from == nil)
+    #expect(followUp == nil)
+  }
+
+  @Test
+  func theCLIParsesFollowUpOnlyAsTheFirstWord() throws {
+    let flagged = try GraphcodeCommand.parse([
+      "node", "send", "/tmp/p", UUID().uuidString, "--follow-up", "tests", "are", "green",
+    ])
+    guard case .sendMessage(_, _, let text, let followUp) = flagged else {
+      Issue.record("expected sendMessage, got \(flagged)")
+      return
+    }
+    #expect(followUp == true)
+    #expect(text == "tests are green")
+
+    // Anywhere later it is message text, so the words stay sendable.
+    let literal = try GraphcodeCommand.parse([
+      "node", "send", "/tmp/p", UUID().uuidString, "pass", "--follow-up", "to", "the", "critic",
+    ])
+    guard case .sendMessage(_, _, let literalText, let literalFlag) = literal else {
+      Issue.record("expected sendMessage, got \(literal)")
+      return
+    }
+    #expect(literalFlag == false)
+    #expect(literalText == "pass --follow-up to the critic")
+  }
+}

--- a/graphcode/Tests/MessageAndSpawnTests.swift
+++ b/graphcode/Tests/MessageAndSpawnTests.swift
@@ -246,7 +246,8 @@ struct MessageAndSpawnTests {
     let sender = await store.graph.nodes[0]
     let target = await store.graph.nodes[1]
 
-    await store.handle(.messageNode(target.id, text: "the API changed", from: sender.id))
+    await store.handle(
+      .messageNode(target.id, text: "the API changed", from: sender.id, followUp: nil))
 
     #expect(delivered.value.count == 1)
     #expect(delivered.value[0].nodeTitle == "Review")
@@ -259,7 +260,7 @@ struct MessageAndSpawnTests {
     let store = await messagePair(targetState: .running, delivered: delivered)
     let target = await store.graph.nodes[1]
 
-    await store.handle(.messageNode(target.id, text: "wrap it up", from: nil))
+    await store.handle(.messageNode(target.id, text: "wrap it up", from: nil, followUp: nil))
 
     #expect(delivered.value == [Delivery(nodeTitle: "Review", text: "[graphcode] wrap it up")])
   }
@@ -272,7 +273,7 @@ struct MessageAndSpawnTests {
     let store = await messagePair(targetState: .awaitingInput, delivered: delivered)
     let target = await store.graph.nodes[1]
 
-    await store.handle(.messageNode(target.id, text: "hello?", from: nil))
+    await store.handle(.messageNode(target.id, text: "hello?", from: nil, followUp: nil))
 
     #expect(delivered.value.isEmpty)
   }
@@ -283,7 +284,7 @@ struct MessageAndSpawnTests {
     let store = await messagePair(targetState: .running, delivered: delivered)
     let target = await store.graph.nodes[1]
 
-    await store.handle(.messageNode(target.id, text: "   ", from: nil))
+    await store.handle(.messageNode(target.id, text: "   ", from: nil, followUp: nil))
 
     #expect(delivered.value.isEmpty)
   }

--- a/graphcode/Tests/PredicateFeedbackTests.swift
+++ b/graphcode/Tests/PredicateFeedbackTests.swift
@@ -1,0 +1,182 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+/// The two halves a bare exit status threw away: a failing stop condition telling the
+/// session *why* it isn't done (`relayPredicateFailure`), and an expensive predicate
+/// declining to re-run against a tree that hasn't changed since it last failed
+/// (`GoalSpec.skipsUnchangedWorkspace`).
+@Suite
+struct PredicateFeedbackTests {
+  private func goalGraph(
+    presence: Presence? = .idle, skipsUnchanged: Bool = false
+  ) -> LoopGraph {
+    LoopGraph(
+      project: ProjectRef(path: "/tmp/feedback", name: "feedback"),
+      nodes: [
+        LoopNode(
+          title: "Green build", loopType: .goalBased,
+          goal: GoalSpec(
+            summary: "CI passes", predicate: "make test",
+            skipsUnchangedWorkspace: skipsUnchanged),
+          presence: presence.map { PresenceReading(presence: $0, confidence: .reported) },
+          state: .running)
+      ])
+  }
+
+  @Test
+  func aFailingPredicateTellsAnIdleSessionWhatItPrinted() async {
+    let delivered = LockIsolated<[String]>([])
+    let remembered = LockIsolated<[String]>([])
+    let graph = goalGraph()
+    let store = GraphStore(
+      graph: graph,
+      onCheckPredicate: { _ in PredicateOutcome(passed: false, outputTail: "2 tests failed") },
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      },
+      onAppendMemory: { _, entry in remembered.withValue { $0.append(entry) } })
+
+    await store.evaluateGoal(graph.nodes[0].id)
+
+    #expect(await store.graph.nodes[0].state == .running)
+    #expect(delivered.value.count == 1)
+    #expect(delivered.value[0].contains("make test"))
+    #expect(delivered.value[0].contains("2 tests failed"))
+    #expect(remembered.value.contains { $0.contains("predicate feedback: 2 tests failed") })
+  }
+
+  @Test
+  func theSameFailureIsRelayedOnceNotEveryPoll() async {
+    let delivered = LockIsolated(0)
+    let graph = goalGraph()
+    let store = GraphStore(
+      graph: graph,
+      onCheckPredicate: { _ in PredicateOutcome(passed: false, outputTail: "2 tests failed") },
+      onDeliverMessage: { _, _, _ in
+        delivered.withValue { $0 += 1 }
+        return true
+      })
+
+    await store.evaluateGoal(graph.nodes[0].id)
+    await store.evaluateGoal(graph.nodes[0].id)
+
+    #expect(delivered.value == 1)
+  }
+
+  @Test
+  func aBusySessionIsNotInterruptedWithFeedback() async {
+    // A busy agent is still working; it will be judged again next poll. The relay
+    // exists for the session that believes it is finished.
+    let delivered = LockIsolated(0)
+    let graph = goalGraph(presence: .busy)
+    let store = GraphStore(
+      graph: graph,
+      onCheckPredicate: { _ in PredicateOutcome(passed: false, outputTail: "still failing") },
+      onDeliverMessage: { _, _, _ in
+        delivered.withValue { $0 += 1 }
+        return true
+      })
+
+    await store.evaluateGoal(graph.nodes[0].id)
+
+    #expect(delivered.value == 0)
+  }
+
+  @Test
+  func aPassingCheckedPredicateStillResolvesTheNode() async {
+    let graph = goalGraph()
+    let store = GraphStore(
+      graph: graph, onCheckPredicate: { _ in PredicateOutcome(passed: true) })
+
+    await store.evaluateGoal(graph.nodes[0].id)
+
+    #expect(await store.graph.nodes[0].state == .succeeded)
+  }
+
+  @Test
+  func anUnchangedTreeSkipsTheRerunUntilItChanges() async {
+    let fingerprint = LockIsolated("tree-1")
+    let evaluated = LockIsolated(0)
+    let graph = goalGraph(presence: .busy, skipsUnchanged: true)
+    let store = GraphStore(
+      graph: graph,
+      onCheckPredicate: { _ in
+        evaluated.withValue { $0 += 1 }
+        return PredicateOutcome(passed: false, outputTail: "no")
+      },
+      onCaptureScript: { _ in fingerprint.value })
+
+    await store.evaluateGoal(graph.nodes[0].id)
+    await store.evaluateGoal(graph.nodes[0].id)
+    #expect(evaluated.value == 1)
+
+    fingerprint.setValue("tree-2")
+    await store.evaluateGoal(graph.nodes[0].id)
+    #expect(evaluated.value == 2)
+  }
+
+  @Test
+  func aMissingFingerprintMeansThePredicateAlwaysRuns() async {
+    // Outside a git repository "the tree changed" has no meaning, so the skip — an
+    // optimisation, never the rule — simply doesn't apply.
+    let evaluated = LockIsolated(0)
+    let graph = goalGraph(presence: .busy, skipsUnchanged: true)
+    let store = GraphStore(
+      graph: graph,
+      onCheckPredicate: { _ in
+        evaluated.withValue { $0 += 1 }
+        return PredicateOutcome(passed: false, outputTail: "no")
+      },
+      onCaptureScript: { _ in nil })
+
+    await store.evaluateGoal(graph.nodes[0].id)
+    await store.evaluateGoal(graph.nodes[0].id)
+
+    #expect(evaluated.value == 2)
+  }
+
+  @Test
+  func withoutOptingInThePredicateRunsEveryPoll() async {
+    // The default stays off with reason: predicates that watch things outside the
+    // tree — CI, a deploy — would otherwise wait on a change that never comes.
+    let evaluated = LockIsolated(0)
+    let graph = goalGraph(presence: .busy)
+    let store = GraphStore(
+      graph: graph,
+      onCheckPredicate: { _ in
+        evaluated.withValue { $0 += 1 }
+        return PredicateOutcome(passed: false, outputTail: "no")
+      },
+      onCaptureScript: { _ in "tree-1" })
+
+    await store.evaluateGoal(graph.nodes[0].id)
+    await store.evaluateGoal(graph.nodes[0].id)
+
+    #expect(evaluated.value == 2)
+  }
+
+  @Test
+  func theCLIParsesSkipUnchanged() throws {
+    let create = try GraphcodeCommand.parse([
+      "node", "create", "/tmp/p", "--title", "S", "--type", "goal",
+      "--goal", "done", "--predicate", "make test", "--skip-unchanged",
+    ])
+    guard case .createNode(_, let draft, _) = create else {
+      Issue.record("expected createNode, got \(create)")
+      return
+    }
+    #expect(draft.goal?.skipsUnchangedWorkspace == true)
+
+    let update = try GraphcodeCommand.parse([
+      "node", "update", "/tmp/p", UUID().uuidString, "--skip-unchanged", "false",
+    ])
+    guard case .updateNode(_, _, let nodeUpdate) = update else {
+      Issue.record("expected updateNode, got \(update)")
+      return
+    }
+    #expect(nodeUpdate.skipsUnchangedWorkspace == false)
+  }
+}

--- a/graphcode/Tests/RemoteCLIShimTests.swift
+++ b/graphcode/Tests/RemoteCLIShimTests.swift
@@ -73,7 +73,7 @@ struct RemoteCLIShimTests {
       run.commands.dropFirst().first
         == .graphCommand(
           projectPath: Self.project,
-          command: .messageNode(nodeID, text: "the API changed", from: nil)))
+          command: .messageNode(nodeID, text: "the API changed", from: nil, followUp: nil)))
   }
 
   // MARK: - Harness

--- a/graphcode/Tests/TokenBudgetTests.swift
+++ b/graphcode/Tests/TokenBudgetTests.swift
@@ -1,0 +1,168 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+/// Token budgets on goals — docs/08-quality-and-token-budgets.md's budget as an
+/// enforced bound rather than a reviewed number. Driven through `evaluateGoal` directly
+/// for the same reason `GoalBasedLoopTests` is: the poller is a sleep loop around
+/// exactly this call.
+@Suite
+struct TokenBudgetTests {
+  private func budgetGraph(budget: Int? = 100, state: LoopState = .running) -> LoopGraph {
+    LoopGraph(
+      project: ProjectRef(path: "/tmp/budget", name: "budget"),
+      nodes: [
+        LoopNode(
+          title: "Sweep", loopType: .goalBased,
+          goal: GoalSpec(summary: "the sweep finishes", tokenBudget: budget),
+          state: state)
+      ])
+  }
+
+  @Test
+  func blowingTheBudgetStallsTheLoopAndAsksItsSessionToStop() async {
+    let delivered = LockIsolated<[String]>([])
+    let remembered = LockIsolated<[String]>([])
+    let graph = budgetGraph()
+    let store = GraphStore(
+      graph: graph,
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      },
+      onReadUsage: { _, _ in UsageSample(inputTokens: 80, outputTokens: 30) },
+      onAppendMemory: { _, entry in remembered.withValue { $0.append(entry) } })
+
+    await store.evaluateGoal(graph.nodes[0].id)
+
+    #expect(await store.graph.nodes[0].state == .stalled)
+    #expect(delivered.value.count == 1)
+    #expect(delivered.value[0].contains("110 of its 100-token budget"))
+    #expect(remembered.value.contains { $0.contains("budget exhausted: 110 of 100") })
+  }
+
+  @Test
+  func aBlownBudgetFiresDownstreamEdgesAsAFailure() async {
+    // Same reasoning as a stall: everything waiting on this loop must not sit blocked
+    // forever because the money ran out.
+    let graph = budgetGraph()
+    let store = GraphStore(
+      graph: graph, onReadUsage: { _, _ in UsageSample(inputTokens: 200) })
+    let goalID = graph.nodes[0].id
+    await store.handle(
+      .createNode(
+        NodeDraft(
+          title: "Escalate", loopType: .turnBased, checkDescription: "?",
+          firstInstruction: "Escalate")))
+    let escalateID = await store.graph.nodes[1].id
+    await store.handle(
+      .createEdge(from: goalID, to: escalateID, spec: EdgeSpec(condition: .onFailure)))
+
+    await store.evaluateGoal(goalID)
+
+    let updated = await store.graph
+    #expect(updated.edges[0].fired == true)
+    #expect(updated.nodes[id: escalateID]?.state == .idle)
+  }
+
+  @Test
+  func usageUnderTheBudgetKeepsTheLoopRunningAndIsRecordedOnTheNode() async {
+    let graph = budgetGraph()
+    let store = GraphStore(
+      graph: graph, onReadUsage: { _, _ in UsageSample(inputTokens: 40, outputTokens: 10) })
+
+    await store.evaluateGoal(graph.nodes[0].id)
+
+    let node = await store.graph.nodes[0]
+    #expect(node.state == .running)
+    #expect(node.usage?.totalTokens == 50)
+  }
+
+  @Test
+  func unreportedUsageNeverExhaustsABudget() async {
+    // The budget shares `UsageSample`'s honesty rule: a backend that reports nothing
+    // spends nothing the daemon can act on — nil is "not reported", never zero and
+    // never infinity.
+    let graph = budgetGraph()
+    let store = GraphStore(graph: graph, onReadUsage: { _, _ in nil })
+
+    await store.evaluateGoal(graph.nodes[0].id)
+
+    #expect(await store.graph.nodes[0].state == .running)
+  }
+
+  @Test
+  func aLoopMayNotChangeItsOwnBudget() async {
+    let remembered = LockIsolated<[String]>([])
+    let graph = budgetGraph()
+    let store = GraphStore(
+      graph: graph,
+      onAppendMemory: { _, entry in remembered.withValue { $0.append(entry) } })
+    let nodeID = graph.nodes[0].id
+
+    await store.handle(
+      .updateNode(nodeID, update: NodeUpdate(tokenBudget: 999_999, updatedBy: nodeID)))
+
+    #expect(await store.graph.nodes[0].goal?.tokenBudget == 100)
+    #expect(remembered.value.contains { $0.contains("update refused") })
+  }
+
+  @Test
+  func aHumanCanRaiseOrClearTheBudget() async {
+    let graph = budgetGraph()
+    let store = GraphStore(graph: graph)
+    let nodeID = graph.nodes[0].id
+
+    await store.handle(.updateNode(nodeID, update: NodeUpdate(tokenBudget: 500)))
+    #expect(await store.graph.nodes[0].goal?.tokenBudget == 500)
+
+    await store.handle(.updateNode(nodeID, update: NodeUpdate(tokenBudget: 0)))
+    #expect(await store.graph.nodes[0].goal?.tokenBudget == nil)
+  }
+
+  @Test
+  func theSessionPromptCarriesTheBudget() throws {
+    // Told for the same reason the metric is: a loop that doesn't know its budget can
+    // only be surprised by it.
+    let node = LoopNode(
+      title: "Sweep", loopType: .goalBased,
+      goal: GoalSpec(summary: "done", tokenBudget: 5000))
+    let prompt = try #require(node.sessionPrompt)
+    #expect(prompt.contains("Token budget: 5000"))
+
+    let unbounded = LoopNode(
+      title: "Sweep", loopType: .goalBased, goal: GoalSpec(summary: "done"))
+    #expect(try #require(unbounded.sessionPrompt).contains("Token budget") == false)
+  }
+
+  @Test
+  func theCLIParsesBudgetOnCreateAndUpdate() throws {
+    let create = try GraphcodeCommand.parse([
+      "node", "create", "/tmp/p", "--title", "Sweep", "--type", "goal",
+      "--goal", "done", "--budget", "5000",
+    ])
+    guard case .createNode(_, let draft, _) = create else {
+      Issue.record("expected createNode, got \(create)")
+      return
+    }
+    #expect(draft.goal?.tokenBudget == 5000)
+
+    let update = try GraphcodeCommand.parse([
+      "node", "update", "/tmp/p", UUID().uuidString, "--budget", "0",
+    ])
+    guard case .updateNode(_, _, let nodeUpdate) = update else {
+      Issue.record("expected updateNode, got \(update)")
+      return
+    }
+    #expect(nodeUpdate.tokenBudget == 0)
+
+    // A creation budget of zero is a contradiction, not a clear — refused.
+    #expect(throws: GraphcodeCommand.ParseError.self) {
+      try GraphcodeCommand.parse([
+        "node", "create", "/tmp/p", "--title", "S", "--type", "goal",
+        "--goal", "done", "--budget", "0",
+      ])
+    }
+  }
+}


### PR DESCRIPTION
Adopts three mechanisms from [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent)'s long-running-agent design, each fitted onto existing GraphCode machinery rather than imported wholesale.

## 1. Token budgets on goals
- `GoalSpec.tokenBudget` (`node create/update --budget <tokens>`); the goal poller reads the node's usage fresh via the backend hooks and, once reported spend crosses the budget, marks the loop stalled, fires downstream edges as a failure, records the arithmetic in loop memory, and asks the session to stop looping (`MessageBus.budgetExhaustedRequest`).
- Shares `UsageSample`'s honesty rule: usage is reported, never estimated — a backend that reports nothing can never blow a budget.
- The budget is part of the stop condition: a loop may not raise or clear its own (`NodeUpdate.touchesStopCondition`), and the session is told its budget in its opening prompt so it can pace itself.

## 2. Predicate failure feedback + skip-unchanged
- New `ShellPredicateEvaluator.check` keeps the run's output tail (stderr merged, bounded at 600 chars); `GraphStore` prefers it via the new `onCheckPredicate` hook.
- When the predicate fails and the session is idle — it believes it is finished — the daemon types the failure tail into it, once per distinct failure, so the loop can retry against evidence instead of silence.
- Opt-in `--skip-unchanged`: skips re-running the predicate while `HEAD` + `git status --porcelain` are unchanged since its last failure. Off by default because predicates that watch CI or a deploy must keep polling; outside a git repo the skip never applies.

## 3. `node send --follow-up`
- Deference over immediacy: a busy target is not interrupted mid-turn. The message lands in its memory log immediately (so nothing depends on the in-memory queue surviving) and is typed into the session when it next goes idle, drained on every store settle and presence poll.
- `--follow-up` counts only as the first word after the node id, so the literal words stay sendable. Supported in the remote shim too.
- Wire-compatible: `messageNode` gained an optional `followUp`; frames from older clients decode as the immediate send they always were.

## Verification
- Full suite green: `xcodebuild -scheme graphcode test` — **TEST SUCCEEDED**, including 22 new tests across `TokenBudgetTests`, `PredicateFeedbackTests`, `FollowUpMessageTests`.
- `swiftlint lint` and `swift format lint --strict` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)