### PR TITLE
Token budget field in the goal-loop creation form

### DIFF
--- a/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
+++ b/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
@@ -53,23 +53,19 @@ struct GoalDraftFields: View {
 
       if store.isMetricExpanded {
         metricFields
-      } else {
-        Button {
-          store.isMetricExpanded = true
-        } label: {
-          Text("+ Track a progress metric")
-            .font(.system(size: 11.5))
-            .foregroundStyle(.white.opacity(0.6))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, 8)
-            .padding(.horizontal, 9)
-            .overlay {
-              RoundedRectangle(cornerRadius: 8)
-                .stroke(
-                  .white.opacity(0.14), style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
-            }
+      }
+      if store.isBudgetExpanded {
+        budgetFields
+      }
+      if !store.isMetricExpanded || !store.isBudgetExpanded {
+        HStack(spacing: 8) {
+          if !store.isMetricExpanded {
+            expander("+ Track a progress metric") { store.isMetricExpanded = true }
+          }
+          if !store.isBudgetExpanded {
+            expander("+ Cap its token spend") { store.isBudgetExpanded = true }
+          }
         }
-        .buttonStyle(.plain)
       }
 
       DraftField(label: "Name", qualifier: "optional") {
@@ -77,6 +73,23 @@ struct GoalDraftFields: View {
           placeholder: "the loop names itself once it starts", text: $store.draftTitle)
       }
     }
+  }
+
+  private func expander(_ title: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+      Text(title)
+        .font(.system(size: 11.5))
+        .foregroundStyle(.white.opacity(0.6))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 9)
+        .overlay {
+          RoundedRectangle(cornerRadius: 8)
+            .stroke(
+              .white.opacity(0.14), style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+        }
+    }
+    .buttonStyle(.plain)
   }
 
   private var metricFields: some View {
@@ -94,6 +107,16 @@ struct GoalDraftFields: View {
       }
       .pickerStyle(.segmented)
       .labelsHidden()
+    }
+  }
+
+  private var budgetFields: some View {
+    DraftField(
+      label: "Token budget", qualifier: "optional",
+      help: "Stopped once its backend reports this many tokens spent (input + output). "
+        + "Reported, never estimated — a backend that reports nothing is never stopped."
+    ) {
+      DraftTextField(placeholder: "200000", text: $store.draftBudget, isMono: true)
     }
   }
 
@@ -380,7 +403,8 @@ struct NodeDraftRecap: View {
         draft.goal?.effectivePredicate == nil
         ? "resolves when its session finishes"
         : "resolves itself when the done check passes"
-      return "Starts now\(location), works toward the goal, and \(check)."
+      let cap = draft.goal?.tokenBudget.map { " Stops if it spends more than \($0) tokens." } ?? ""
+      return "Starts now\(location), works toward the goal, and \(check).\(cap)"
     case .timeBased:
       return "Starts now\(location) and runs again on its own until you stop it."
     case .turnBased:

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -56,6 +56,12 @@ struct ProjectFeature {
     /// Collapsed by default — a metric is off the path for the common goal loop, and a
     /// command field sitting open invites people to fill it in because it is there.
     var isMetricExpanded = false
+    /// The goal's optional token budget (`GoalSpec.tokenBudget`), kept as typed so a
+    /// half-edited number never round-trips into a different one. Parsed at draft
+    /// assembly (`parsedBudget`); anything that isn't a positive integer travels as
+    /// "no budget". Its row collapses for the same reason the metric's does.
+    var draftBudget = ""
+    var isBudgetExpanded = false
     /// What pressing **Test** on the done check found, and whether one is in flight.
     var doneCheckOutcome: DoneCheckOutcome?
     var isTestingDoneCheck = false
@@ -426,18 +432,7 @@ struct ProjectFeature {
         return .none
 
       case .doneCheckTestTapped:
-        let command = state.draftPredicate.trimmingCharacters(in: .whitespaces)
-        guard !command.isEmpty, !state.isTestingDoneCheck else { return .none }
-        state.isTestingDoneCheck = true
-        state.doneCheckOutcome = nil
-        let directory = state.graph.project.path
-        return .run { send in
-          let result = await ShellPredicateEvaluator.probe(
-            ShellPredicate(command: command, workingDirectory: directory))
-          await send(
-            .doneCheckTested(
-              passed: result?.passed ?? false, duration: result?.duration ?? 0))
-        }
+        return runDoneCheckTest(&state)
 
       case .doneCheckTested(let passed, let duration):
         state.isTestingDoneCheck = false
@@ -653,6 +648,23 @@ extension ProjectFeature {
   /// finished is what most work wants, where the old turn-based default made a loop
   /// that sits idle until a human opens it — surprising as the *default* outcome of
   /// Create.
+  /// Runs the form's done check exactly the way `graphcoded` will — same evaluator,
+  /// same shell, same directory (`GoalDraftFields.testButton`).
+  private func runDoneCheckTest(_ state: inout State) -> Effect<Action> {
+    let command = state.draftPredicate.trimmingCharacters(in: .whitespaces)
+    guard !command.isEmpty, !state.isTestingDoneCheck else { return .none }
+    state.isTestingDoneCheck = true
+    state.doneCheckOutcome = nil
+    let directory = state.graph.project.path
+    return .run { send in
+      let result = await ShellPredicateEvaluator.probe(
+        ShellPredicate(command: command, workingDirectory: directory))
+      await send(
+        .doneCheckTested(
+          passed: result?.passed ?? false, duration: result?.duration ?? 0))
+    }
+  }
+
   private func openNodeForm(
     _ state: inout State, backend: CLISessionBackendKind?, parentNodeID: UUID?
   ) -> Effect<Action> {
@@ -666,6 +678,8 @@ extension ProjectFeature {
     state.draftMetric = ""
     state.draftMetricDirection = .maximize
     state.isMetricExpanded = false
+    state.draftBudget = ""
+    state.isBudgetExpanded = false
     state.doneCheckOutcome = nil
     state.isTestingDoneCheck = false
     state.draftFirstInstruction = ""

--- a/graphcode/Sources/Features/Project/ProjectFeatureState.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeatureState.swift
@@ -61,7 +61,8 @@ extension ProjectFeature.State {
           summary: draftGoal,
           predicate: draftPredicate.isEmpty ? nil : draftPredicate,
           metricCommand: draftMetric.isEmpty ? nil : draftMetric,
-          metricDirection: draftMetricDirection)
+          metricDirection: draftMetricDirection,
+          tokenBudget: parsedBudget)
         : nil,
       backend: draftBackend,
       // Only an *existing* worktree can be bound here; a new one has to be created on
@@ -70,6 +71,15 @@ extension ProjectFeature.State {
         if case .existing(let ref) = draftWorktree { return ref }
         return nil
       }())
+  }
+
+  /// The budget field as a number, or nil — a blank field, a typo, or a zero all mean
+  /// "no budget", never a budget of garbage. Mirrors `GoalSpec.effectivePredicate`'s
+  /// reading of an all-whitespace field.
+  var parsedBudget: Int? {
+    guard let value = Int(draftBudget.trimmingCharacters(in: .whitespaces)), value > 0
+    else { return nil }
+    return value
   }
 
   /// What a timed loop's session actually opens with, composed rather than typed.

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -209,6 +209,23 @@ struct ProjectFeatureTests {
     state.draftMetric = ""
     #expect(state.draft.goal?.metricCommand == nil)
   }
+
+  /// The budget field becomes `GoalSpec.tokenBudget` — same silent-no-op concern as the
+  /// metric — and anything that isn't a positive integer travels as "no budget".
+  @Test
+  @MainActor
+  func theBudgetFieldTravelsIntoTheGoalSpec() {
+    var state = ProjectFeature.State(graph: LoopGraph(project: Self.testProject))
+    state.draftLoopType = .goalBased
+    state.draftGoal = "the sweep finishes"
+    state.draftBudget = " 200000 "
+    #expect(state.draft.goal?.tokenBudget == 200_000)
+
+    for junk in ["", "0", "-5", "lots"] {
+      state.draftBudget = junk
+      #expect(state.draft.goal?.tokenBudget == nil, "\(junk) should mean no budget")
+    }
+  }
 }
 
 private actor SentGraphCommandsBox {


### PR DESCRIPTION
The token budget from #131 was CLI-only; this adds it to the app's goal-loop creation dialog.

- Collapsed behind a dashed **+ Cap its token spend** row, mirroring the metric's pattern (an open field invites filling it in because it is there; a cap nobody meant is a loop stopped for no reason).
- The field keeps what was typed and parses at draft assembly: blank, `0`, negative, or non-numeric all travel as *no budget* — never a budget of garbage.
- The recap sentence appends "Stops if it spends more than N tokens." so Create states what it arms.
- Mechanical rider: the two new `@ObservableState` fields tipped `ProjectFeature` over swiftlint's 350-line type-body budget, so `doneCheckTestTapped`'s handler moved verbatim into the existing trailing extension (stored macro-tracked vars can't be consolidated into multi-bindings — the macro refuses them).

## Verification
- Full suite: **TEST SUCCEEDED**, including new `theBudgetFieldTravelsIntoTheGoalSpec`.
- `swiftlint` + `swift format lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)