### PR TITLE
Usage reporting that can actually be stored

### DIFF
--- a/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
+++ b/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
@@ -561,8 +561,11 @@ extension GraphcodeCommand {
     guard let usage = graph.usage else {
       return """
         \(graph.project.name): no usage reported (0/\(coverage.total) loops)
-          Usage is reported by the backend, never estimated — install a hook that runs
-          `zmx set "$ZMX_SESSION" usage=inputTokens=…,outputTokens=…,costUSD=…`
+          Usage is reported by the backend, never estimated. Claude Code loops report it
+          automatically at each turn end (graphcode's own Stop hook); a loop that has
+          not finished a turn since that hook was installed has nothing to report yet.
+          Other backends need a hook running
+          `zmx set "$ZMX_SESSION" usage=input.<tokens>_output.<tokens>`
         """
     }
     var lines = ["\(graph.project.name): \(coverage.reporting)/\(coverage.total) loops reporting"]

--- a/GraphcodeKit/Sources/Domain/UsageSample.swift
+++ b/GraphcodeKit/Sources/Domain/UsageSample.swift
@@ -44,7 +44,20 @@ public struct UsageSample: Codable, Equatable, Sendable {
     return (inputTokens ?? 0) + (outputTokens ?? 0)
   }
 
-  /// Parses a `zmx` usage label: space-separated `key=value` pairs, any subset present.
+  /// Parses a `zmx` usage label, in either of two shapes:
+  ///
+  /// - `key=value` pairs separated by spaces or commas — the original documented form.
+  ///   It turns out a `zmx` label *value* can never actually hold one (`zmx set` takes
+  ///   only `[A-Za-z0-9._-]` in a value, and `=` and `,` are both outside it), but the
+  ///   remote path hands whole label lines through here and the shape costs nothing to
+  ///   keep.
+  /// - `key.value` pairs joined by `_` — `input.559576_output.5397_cost.0.0042` — built
+  ///   from exactly the bytes a label value may contain. This is what
+  ///   `PresenceHooks.usageScript` writes, and the only form that survives `zmx set`;
+  ///   the same charset wall `activityScript` hit is why the activity label is
+  ///   percent-encoded. The value is everything after the *first* `.`, which is what
+  ///   lets a cost keep its decimal point.
+  ///
   /// Unknown keys are ignored rather than rejected, so a backend reporting more than
   /// graphcode understands doesn't lose the fields it does.
   ///
@@ -55,15 +68,25 @@ public struct UsageSample: Codable, Equatable, Sendable {
     for pair in label.split(whereSeparator: { $0 == " " || $0 == "," }) {
       let parts = pair.split(separator: "=", maxSplits: 1)
       guard parts.count == 2 else { continue }
-      let value = String(parts[1]).trimmingCharacters(in: .whitespaces)
-      switch parts[0] {
-      case "inputTokens", "input": sample.inputTokens = Int(value)
-      case "outputTokens", "output": sample.outputTokens = Int(value)
-      case "costUSD", "cost": sample.costUSD = Double(value)
-      default: continue
+      sample.assign(String(parts[0]), String(parts[1]).trimmingCharacters(in: .whitespaces))
+    }
+    if sample.isEmpty, !label.contains("=") {
+      for pair in label.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: "_") {
+        let parts = pair.split(separator: ".", maxSplits: 1)
+        guard parts.count == 2 else { continue }
+        sample.assign(String(parts[0]), String(parts[1]))
       }
     }
     return sample.isEmpty ? nil : sample
+  }
+
+  private mutating func assign(_ key: String, _ value: String) {
+    switch key {
+    case "inputTokens", "input": inputTokens = Int(value)
+    case "outputTokens", "output": outputTokens = Int(value)
+    case "costUSD", "cost": costUSD = Double(value)
+    default: break
+    }
   }
 
   public static func + (lhs: UsageSample, rhs: UsageSample) -> UsageSample {

--- a/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
+++ b/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
@@ -35,6 +35,11 @@ public enum PresenceHooks {
     directory.appendingPathComponent("activity.sh")
   }
 
+  /// The `Stop`/`SessionEnd` usage reporter, a file for the same `MAX_CANON` reason.
+  public static var usageScriptFile: URL {
+    directory.appendingPathComponent("usage.sh")
+  }
+
   /// Which of a backend's lifecycle events mean what, in the backend's own event names.
   ///
   /// `nil` for a backend with no hook mechanism at all, which is the honest answer for
@@ -94,6 +99,66 @@ public enum PresenceHooks {
   /// nicety went wrong.
   static func reportActivity(scriptPath: String) -> String {
     "if [ -r \(scriptPath) ]; then /bin/sh \(scriptPath); fi; exit 0"
+  }
+
+  /// The `Stop`/`SessionEnd` body that runs `usageScript`, guarded the same way and for
+  /// the same reasons as `reportActivity` — and kept beside the presence report rather
+  /// than folded in, so token accounting going wrong can never stop presence being
+  /// reported.
+  static func reportUsage(scriptPath: String) -> String {
+    "if [ -r \(scriptPath) ]; then /bin/sh \(scriptPath); fi; exit 0"
+  }
+
+  /// This session's cumulative token spend, summed from its own transcript — the write
+  /// half of `LoopNode.usage`, which shipped with a reader (`ZmxSessionLauncher.usage`),
+  /// a rollup, a cost panel, and — once budgets landed — an *enforcer*, and nothing at
+  /// all that wrote it. `UsageSample`'s docs said "install a hook that runs `zmx set
+  /// usage=inputTokens=…`", and no such hook could even work: a `zmx` label value takes
+  /// only `[A-Za-z0-9._-]`, so the documented format was unstorable. This writes the
+  /// `key.value_key.value` form `UsageSample.parse` reads for exactly that reason.
+  ///
+  /// The transcript is the source because it is the only thing on disk the backend
+  /// itself wrote per turn: every assistant record carries its `usage` block, and the
+  /// literal `"input_tokens":` match cannot collide with the `cache_…_input_tokens`
+  /// keys (their preceding byte is `_`, not `"`), which are summed separately below —
+  /// a budget is spent by what the API metered, cache reads included.
+  ///
+  /// Runs on `Stop` — once per turn, when the spend just changed — never per tool call:
+  /// it reads the whole transcript, and `PreToolUse` frequency would price it wrong.
+  /// Cannot fail and cannot block, same contract as every hook here: every path exits 0.
+  static func usageScript(zmxPath: String) -> String {
+    """
+    # Written by graphcode. Reports this session's token spend, for the usage rollup
+    # and goal budgets.
+    [ -n "$ZMX_SESSION" ] || exit 0
+    payload=$(head -c 4096 | tr '\\n' ' ')
+    transcript=$(printf '%s' "$payload" |
+      sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p')
+    [ -r "$transcript" ] || exit 0
+    label=$(awk '
+      function grab(key,    s, t, n) {
+        n = 0
+        s = $0
+        while (match(s, key "[0-9]+")) {
+          t = substr(s, RSTART, RLENGTH)
+          gsub(/[^0-9]/, "", t)
+          n += t
+          s = substr(s, RSTART + RLENGTH)
+        }
+        return n
+      }
+      {
+        input += grab("\\"input_tokens\\":")
+        input += grab("\\"cache_creation_input_tokens\\":")
+        input += grab("\\"cache_read_input_tokens\\":")
+        output += grab("\\"output_tokens\\":")
+      }
+      END { if (input + output > 0) printf "input.%d_output.%d", input, output }
+    ' "$transcript" 2>/dev/null)
+    [ -n "$label" ] || exit 0
+    \(singleQuoted(zmxPath)) set "$ZMX_SESSION" "usage=$label" >/dev/null 2>&1
+    exit 0
+    """
   }
 
   /// What the session is doing, in its own words, derived from the `PreToolUse` payload
@@ -193,6 +258,13 @@ public enum PresenceHooks {
 
   public static let remoteActivityScriptExpression = "\"$HOME/.graphcode/hooks/activity.sh\""
 
+  /// Where `usageScript` lands, in the same two shapes again.
+  static var localUsageScriptExpression: String {
+    singleQuoted(usageScriptFile.path)
+  }
+
+  public static let remoteUsageScriptExpression = "\"$HOME/.graphcode/hooks/usage.sh\""
+
   /// The remote twin of `SessionIDStore.file(forNodeID:)` — the file the remote
   /// `SessionStart` hook wrote, as a shell expression the ensure dial can `cat`.
   ///
@@ -210,11 +282,13 @@ public enum PresenceHooks {
   /// path, not a syntax error.
   public static func json(
     forBackend backend: CLISessionBackendKind, zmxPath: String,
-    sessionsDirectory: String? = nil, activityScriptPath: String? = nil
+    sessionsDirectory: String? = nil, activityScriptPath: String? = nil,
+    usageScriptPath: String? = nil
   ) -> String? {
     guard let events = events(forBackend: backend) else { return nil }
     let sessions = sessionsDirectory ?? localSessionsExpression
     let script = activityScriptPath ?? localActivityScriptExpression
+    let usage = usageScriptPath ?? localUsageScriptExpression
     let hooks = events.reduce(into: [String: [Matcher]]()) { result, event in
       let isToolUse = event.0 == "PreToolUse"
       var commands = [
@@ -225,6 +299,11 @@ public enum PresenceHooks {
       }
       if event.0 == "SessionStart" && backend == .claudeCode {
         commands.append(Command(command: captureSessionID(sessionsDirectory: sessions)))
+      }
+      // Turn end and session end are when the spend just changed and the session can
+      // afford a transcript read — never per tool call.
+      if (event.0 == "Stop" || event.0 == "SessionEnd") && backend == .claudeCode {
+        commands.append(Command(command: reportUsage(scriptPath: usage)))
       }
       result[event.0] = [Matcher(hooks: commands)]
     }
@@ -252,6 +331,8 @@ public enum PresenceHooks {
       // that runs this file checks it is readable first.
       try? activityScript(zmxPath: ZmxLocator.binaryURL.path)
         .write(to: activityScriptFile, atomically: true, encoding: .utf8)
+      try? usageScript(zmxPath: ZmxLocator.binaryURL.path)
+        .write(to: usageScriptFile, atomically: true, encoding: .utf8)
       try json.write(to: url, atomically: true, encoding: .utf8)
       return url
     } catch {
@@ -286,15 +367,18 @@ public enum PresenceHooks {
       let json = json(
         forBackend: .claudeCode, zmxPath: "zmx",
         sessionsDirectory: remoteSessionsExpression,
-        activityScriptPath: remoteActivityScriptExpression)
+        activityScriptPath: remoteActivityScriptExpression,
+        usageScriptPath: remoteUsageScriptExpression)
     else { return nil }
     // `|| true` so both call sites can chain it with `&&` — a failed write must never
-    // block the launch it precedes. The reporter goes first: the settings that name it
-    // are what makes it run, and a host that takes one write and not the other should
+    // block the launch it precedes. The reporters go first: the settings that name them
+    // are what makes them run, and a host that takes one write and not the other should
     // fail towards a hook file pointing at a script that is already there.
     return "{ mkdir -p \"$HOME/.graphcode/hooks\""
       + " && printf '%s' \(singleQuoted(activityScript(zmxPath: "zmx")))"
       + " > \(remoteActivityScriptExpression)"
+      + " && printf '%s' \(singleQuoted(usageScript(zmxPath: "zmx")))"
+      + " > \(remoteUsageScriptExpression)"
       + " && printf '%s' \(singleQuoted(json))"
       + " > \"\(remotePathExpression)\"; } 2>/dev/null || true"
   }

--- a/graphcode/Tests/UsageReportingTests.swift
+++ b/graphcode/Tests/UsageReportingTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// The write half of the usage channel — `PresenceHooks.usageScript` summing the
+/// session's own transcript into a label `zmx` will actually keep, and
+/// `UsageSample.parse` reading that label back. Exercised through a real shell for the
+/// same reason `PresenceReportingTests` is: the risk is an expression surviving being
+/// Swift, JSON and shell and still not matching what a hook receives.
+@Suite
+struct UsageReportingTests {
+  /// Runs the generated reporter the way Claude Code runs it — `/bin/sh`, the hook
+  /// payload on stdin — against a `zmx` that records what it was asked to set.
+  private func reportedLabel(payload: String, transcript: String?) throws -> String? {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("graphcode-usage-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    var payload = payload
+    if let transcript {
+      let transcriptFile = directory.appendingPathComponent("transcript.jsonl")
+      try transcript.write(to: transcriptFile, atomically: true, encoding: .utf8)
+      payload = payload.replacingOccurrences(of: "TRANSCRIPT", with: transcriptFile.path)
+    }
+
+    let recording = directory.appendingPathComponent("set.txt")
+    let fakeZmx = directory.appendingPathComponent("zmx")
+    try "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '\(recording.path)'\n"
+      .write(to: fakeZmx, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o755], ofItemAtPath: fakeZmx.path)
+
+    let script = directory.appendingPathComponent("usage.sh")
+    try PresenceHooks.usageScript(zmxPath: fakeZmx.path)
+      .write(to: script, atomically: true, encoding: .utf8)
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sh")
+    process.arguments = [script.path]
+    process.environment = ["ZMX_SESSION": "graphcode-test", "PATH": "/usr/bin:/bin"]
+    let input = Pipe()
+    process.standardInput = input
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    try process.run()
+    input.fileHandleForWriting.write(Data(payload.utf8))
+    try input.fileHandleForWriting.close()
+    process.waitUntilExit()
+
+    // A `Stop` hook exiting non-zero blocks the very stop it was reporting.
+    #expect(process.terminationStatus == 0)
+    guard let recorded = try? String(contentsOf: recording, encoding: .utf8),
+      let line = recorded.split(separator: "\n").last,
+      let label = line.split(separator: " ").last.map(String.init)
+    else { return nil }
+    return label
+  }
+
+  private let stopPayload = """
+    {"session_id":"a","hook_event_name":"Stop","transcript_path":"TRANSCRIPT"}
+    """
+
+  @Test
+  func theTranscriptsSpendBecomesALabelTheReaderUnderstands() throws {
+    // Two assistant turns; cache creation and cache reads count as input — a budget is
+    // spent by what the API metered, not just the fresh bytes.
+    let transcript = """
+      {"type":"user","message":{"role":"user","content":"hi"}}
+      {"type":"assistant","message":{"usage":{"input_tokens":100,\
+      "cache_creation_input_tokens":2000,"cache_read_input_tokens":30000,\
+      "output_tokens":40}}}
+      {"type":"assistant","message":{"usage":{"input_tokens":10,\
+      "cache_read_input_tokens":32000,"output_tokens":60}}}
+      """
+    let label = try reportedLabel(payload: stopPayload, transcript: transcript)
+    #expect(label == "usage=input.64110_output.100")
+
+    // Both halves of the channel: a label the reader can't undo is the same bug as no
+    // label at all.
+    let sample = UsageSample.parse("input.64110_output.100")
+    #expect(sample?.inputTokens == 64110)
+    #expect(sample?.outputTokens == 100)
+    #expect(sample?.totalTokens == 64210)
+  }
+
+  @Test
+  func aMissingTranscriptReportsNothingAndStillExitsZero() throws {
+    let payload = """
+      {"session_id":"a","hook_event_name":"Stop","transcript_path":"/nonexistent/t.jsonl"}
+      """
+    #expect(try reportedLabel(payload: payload, transcript: nil) == nil)
+  }
+
+  @Test
+  func aTranscriptWithNoUsageReportsNothing() throws {
+    // Zero would be a claim; silence is the honest reading of a transcript that has
+    // no metered turns yet.
+    let transcript = """
+      {"type":"user","message":{"role":"user","content":"hi"}}
+      """
+    #expect(try reportedLabel(payload: stopPayload, transcript: transcript) == nil)
+  }
+
+  @Test
+  func theDottedFormParsesAndTheDocumentedEqualsFormStillDoes() {
+    // The dotted form is built from exactly the bytes a zmx label value may hold.
+    #expect(UsageSample.parse("input.10_output.20")?.totalTokens == 30)
+    #expect(UsageSample.parse("input.10_output.20_cost.0.0042")?.costUSD == 0.0042)
+    #expect(UsageSample.parse("inputTokens.10")?.inputTokens == 10)
+    // Unknown keys are ignored; garbage stays nil, never a confident zero.
+    #expect(UsageSample.parse("something.9_output.4")?.outputTokens == 4)
+    #expect(UsageSample.parse("input.notanumber") == nil)
+    // The original space/comma k=v shape keeps working for the remote path.
+    #expect(UsageSample.parse("inputTokens=10,outputTokens=20")?.totalTokens == 30)
+  }
+
+  @Test
+  func turnEndAndSessionEndRunTheReporterOtherEventsDoNot() throws {
+    let json = try #require(
+      PresenceHooks.json(forBackend: .claudeCode, zmxPath: "/usr/local/bin/zmx"))
+    let settings = try #require(
+      try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+    let hooks = try #require(settings["hooks"] as? [String: Any])
+    func bodies(_ event: String) throws -> [String] {
+      let matchers = try #require(hooks[event] as? [[String: Any]])
+      let entries = try #require(matchers.first?["hooks"] as? [[String: Any]])
+      return entries.compactMap { $0["command"] as? String }
+    }
+    #expect(try bodies("Stop").contains { $0.contains("usage.sh") })
+    #expect(try bodies("SessionEnd").contains { $0.contains("usage.sh") })
+    // Per tool call would price a whole-transcript read wrong.
+    #expect(try !bodies("PreToolUse").contains { $0.contains("usage.sh") })
+  }
+
+  @Test
+  func aRemoteSessionIsHandedTheReporterToo() throws {
+    let fragment = try #require(PresenceHooks.remoteWriteFragment())
+    #expect(fragment.contains("$HOME/.graphcode/hooks/usage.sh"))
+  }
+}


### PR DESCRIPTION
Found while demonstrating goal token budgets (#131): **no loop on any install has ever reported usage** (`graphcode usage`: 0/N reporting), because the usage channel shipped as a reader whose documented write format is unstorable — `usage=inputTokens=…,outputTokens=…` needs `=` and `,`, and a zmx label value accepts only `[A-Za-z0-9._-]`. This is the same charset wall the activity label hit (it percent-encodes for exactly this reason). Budgets read this channel, so they could never trip.

## Changes
- **`UsageSample.parse`** accepts a charset-safe form built from exactly the bytes a label may hold: `input.559576_output.5397_cost.0.0042` (value = everything after the *first* `.`, so a cost keeps its decimal point). The original `k=v` shape stays for the remote path, and garbage still parses to nil, never a confident zero.
- **`PresenceHooks.usageScript`** — the write half that never existed. Runs on `Stop` and `SessionEnd` (once per turn, when the spend just changed — never per tool call, which would price a whole-transcript read wrong), sums the session transcript's `usage` blocks with awk (cache creation + reads count as input; the literal `"input_tokens":` match can't collide with `cache_*_input_tokens` keys), and writes the label. Written alongside `activity.sh`, shipped to remote hosts in `remoteWriteFragment`, and it cannot fail or block: every path exits 0.
- The CLI's "no usage reported" hint no longer documents the impossible format.

## Verification
- Full suite **TEST SUCCEEDED**, including new `UsageReportingTests` which run the generated script through a real `/bin/sh` against a recording fake zmx (same harness as `PresenceReportingTests`) and assert the round trip through `UsageSample.parse`.
- Script smoke-tested against a real live session transcript: produces `usage=input.1557032_output.12364`.
- Label round-trip verified through real zmx: `input.559576_output.5397` stores and reads back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)