### PR TITLE
Continual harness: node playbooks, refine verb, and skill distillation

### DIFF
--- a/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
+++ b/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
@@ -27,6 +27,11 @@ public enum GraphcodeCommand: Equatable, Sendable {
   /// matching how `updateNode` fills `updatedBy`.
   case promoteNode(projectPath: String, nodeID: UUID, promotion: SketchPromotion)
   case memoNode(projectPath: String, nodeID: UUID, text: String)
+  /// Replace the loop's playbook (`NodeMemory.refinePlaybook`) — trailing words, or a
+  /// whole file via `--file` since a playbook is a multi-line document and argv words
+  /// arrive flattened. `--rollback` restores the previous version instead.
+  case refineNode(projectPath: String, nodeID: UUID, text: String)
+  case rollbackRefinement(projectPath: String, nodeID: UUID)
   case pilotComposite(projectPath: String, nodeID: UUID)
   case armComposite(projectPath: String, nodeID: UUID)
   case usage(projectPath: String)
@@ -56,6 +61,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
       graphcode node promote <project-path> <node-id> --type <goal|turn|time> [options]
                            give a sketch a shape, keeping its session, edges and memory
       graphcode node memo <project-path> <node-id> <note…>
+      graphcode node refine <project-path> <node-id> <playbook…|--file f|--rollback>
       graphcode node pilot <project-path> <node-id>     dry-run a composite
       graphcode node arm <project-path> <node-id>       arm it (needs a pilot first)
       graphcode edge create <project-path> <from-id> <to-id> [--kind <k>] [--condition <c>]
@@ -123,6 +129,11 @@ public enum GraphcodeCommand: Equatable, Sendable {
 
     node memo appends a note to the loop's own memory log — what the next pass reads
     before starting. Record dead ends and decisions, not a transcript.
+
+    node refine replaces the loop's playbook — its own distilled method, carried into
+    every wake ahead of the history. Whole document each time (--file for multi-line);
+    the old version is snapshotted, --rollback restores it. A loop may refine itself;
+    it still may not touch its goal, predicate, or budget.
 
     EDGE OPTIONS
       --kind <k>           handoff | message | spawn           (default: handoff)
@@ -206,7 +217,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
           into = id
         }
         return .createNode(projectPath: path, draft: try parseDraft(arguments), into: into)
-      case "stop", "delete", "pilot", "arm", "send", "update", "memo", "promote":
+      case "stop", "delete", "pilot", "arm", "send", "update", "memo", "promote", "refine":
         let raw = try take(&arguments, name: "node-id")
         guard let nodeID = UUID(uuidString: raw) else {
           throw ParseError.invalidValue(argument: "node-id", value: raw)
@@ -239,6 +250,8 @@ public enum GraphcodeCommand: Equatable, Sendable {
           let text = arguments.joined(separator: " ").trimmingCharacters(in: .whitespaces)
           guard !text.isEmpty else { throw ParseError.missingArgument("note") }
           return .memoNode(projectPath: path, nodeID: nodeID, text: text)
+        case "refine":
+          return try parseRefine(arguments, projectPath: path, nodeID: nodeID)
         default: return .stopNode(projectPath: path, nodeID: nodeID)
         }
       default:
@@ -419,6 +432,31 @@ public enum GraphcodeCommand: Equatable, Sendable {
       modelTier: modelTier)
     guard !update.isEmpty else { throw ParseError.missingArgument("an option to change") }
     return update
+  }
+
+  /// `node refine`'s three spellings: `--rollback` restores the previous playbook,
+  /// `--file <path>` sends a file's contents (a playbook is a multi-line document, and
+  /// joined argv words arrive as one line), and trailing words send exactly what was
+  /// typed. The file is read *here*, on the caller's machine, because the daemon may be
+  /// serving a remote project whose filesystem has no such path.
+  private static func parseRefine(
+    _ arguments: [String], projectPath: String, nodeID: UUID
+  ) throws -> GraphcodeCommand {
+    if arguments.first == "--rollback" {
+      return .rollbackRefinement(projectPath: projectPath, nodeID: nodeID)
+    }
+    if arguments.first == "--file" {
+      guard arguments.count >= 2 else { throw ParseError.missingArgument("file path") }
+      guard let text = try? String(contentsOfFile: arguments[1], encoding: .utf8),
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      else {
+        throw ParseError.invalidValue(argument: "--file", value: arguments[1])
+      }
+      return .refineNode(projectPath: projectPath, nodeID: nodeID, text: text)
+    }
+    let text = arguments.joined(separator: " ").trimmingCharacters(in: .whitespaces)
+    guard !text.isEmpty else { throw ParseError.missingArgument("playbook text") }
+    return .refineNode(projectPath: projectPath, nodeID: nodeID, text: text)
   }
 
   /// `--skip-unchanged` — bare or `true` opts in, `false` opts back out, absent means

--- a/GraphcodeKit/Sources/Domain/SessionBriefing.swift
+++ b/GraphcodeKit/Sources/Domain/SessionBriefing.swift
@@ -139,6 +139,30 @@ public enum SessionBriefing {
       a transcript, and nothing the code or git history already says. Your node id is
       the suffix of `$ZMX_SESSION` after `graphcode-`.
 
+      Memos record what happened; your **playbook** records how to do this job. It rides
+      into every wake ahead of the history, so when a pass teaches you a better method —
+      an order of operations, a check worth running first, a tool that works here —
+      rewrite it (whole document, small evidence-backed changes):
+
+      ```sh
+      graphcode node refine \(projectPath) <your-node-id> <playbook text>
+      ```
+
+      `--file <path>` sends a multi-line document; `--rollback` restores the previous
+      version (the old one is always snapshotted). Refine your method freely — your
+      goal, predicate, and budget stay out of reach regardless.
+
+      ## Project skills
+
+      Your playbook is yours; a **skill** is for every loop in this project. Check the
+      project's skill library before working something out from scratch (Claude Code
+      loads `.claude/skills/` automatically). When your work produces a method another
+      loop could reuse — a build recipe, a verification sequence, a workaround with a
+      why — distill it into a skill in your backend's native format: for Claude Code,
+      `.claude/skills/<name>/SKILL.md`, a short markdown recipe with a one-line
+      description. When a goal loop resolves with its session still live, graphcode
+      asks it this once; one-off work should not become a skill.
+
       ## The rest of the CLI
 
       Rarer verbs, one line each — like everything above, they take the project path:

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -60,6 +60,12 @@ public actor GraphStore {
   private let onAppendMemory: (@Sendable (UUID, String) -> Void)?
   /// Tears a deleted node's memory down alongside its session.
   private let onRemoveMemory: (@Sendable (UUID) -> Void)?
+  /// Replaces a node's playbook, snapshotting the old one (`NodeMemory.refinePlaybook`).
+  /// Returns whether the write happened — refinement is the one memory write whose
+  /// failure the author must hear about, since they will work *from* it next wake.
+  private let onRefinePlaybook: (@Sendable (UUID, String) -> Bool)?
+  /// Restores the previous playbook, consuming a snapshot (`NodeMemory.rollbackPlaybook`).
+  private let onRollbackPlaybook: (@Sendable (UUID) -> Bool)?
   /// How many composites deep this store sits: 0 at the project root, 1 inside the
   /// first composite, and so on — see `runInSubGraph`, which increments it.
   ///
@@ -107,6 +113,11 @@ public actor GraphStore {
   /// Best-effort: the same fact is always in the memory log first, so a session that
   /// couldn't be reached reads it at its next wake instead.
   private var pendingNudges: [(nodeID: UUID, text: String)] = []
+  /// Words for a session whose node just *resolved* — the distill-a-skill ask. Its own
+  /// queue because `MessageBus.deliverability` reads the very state resolution wrote,
+  /// so the ordinary nudge drain would drop every one of these; this drain types into
+  /// the PTY directly and lets an exited session fail the send harmlessly.
+  private var pendingResolutionNudges: [(nodeID: UUID, text: String)] = []
   /// Messages the orchestrator declined to deliver, newest last. Surfaced so an
   /// undelivered message is visible rather than silently dropped.
   public private(set) var undeliveredMessages:
@@ -134,6 +145,8 @@ public actor GraphStore {
     onSpawnIntoProject: (@Sendable (String, NodeDraft) -> Void)? = nil,
     onAppendMemory: (@Sendable (UUID, String) -> Void)? = nil,
     onRemoveMemory: (@Sendable (UUID) -> Void)? = nil,
+    onRefinePlaybook: (@Sendable (UUID, String) -> Bool)? = nil,
+    onRollbackPlaybook: (@Sendable (UUID) -> Bool)? = nil,
     subGraphDepth: Int = 0
   ) {
     self.graph = graph
@@ -152,6 +165,8 @@ public actor GraphStore {
     self.onSpawnIntoProject = onSpawnIntoProject
     self.onAppendMemory = onAppendMemory
     self.onRemoveMemory = onRemoveMemory
+    self.onRefinePlaybook = onRefinePlaybook
+    self.onRollbackPlaybook = onRollbackPlaybook
   }
 
   private func recordMemory(_ nodeID: UUID, _ entry: String) {
@@ -296,6 +311,12 @@ public actor GraphStore {
     case .memoNode(let nodeID, let text, let from):
       memoNode(nodeID, text: text, from: from)
 
+    case .refineNode(let nodeID, let text, let from):
+      refineNode(nodeID, text: text, from: from)
+
+    case .rollbackRefinement(let nodeID, let from):
+      rollbackRefinement(nodeID, from: from)
+
     case .deleteNode(let nodeID):
       deleteNode(nodeID)
 
@@ -388,6 +409,8 @@ public actor GraphStore {
       onCaptureScript: onCaptureScript,
       onAppendMemory: onAppendMemory,
       onRemoveMemory: onRemoveMemory,
+      onRefinePlaybook: onRefinePlaybook,
+      onRollbackPlaybook: onRollbackPlaybook,
       subGraphDepth: subGraphDepth + 1)
     await child.handle(command)
     graph.nodes[id: nodeID]?.subGraph = await child.graph
@@ -908,6 +931,55 @@ public actor GraphStore {
     recordMemory(nodeID, "note\(sender.map { " (from \($0))" } ?? ""): \(trimmed)")
   }
 
+  /// Replaces a node's playbook — `graphcode node refine`. Refusals are said out loud
+  /// because the author will *work from* this document next wake: a refinement that
+  /// silently didn't land is a loop following a playbook it believes it replaced.
+  ///
+  /// Note what is deliberately *not* guarded: a loop refining itself. Self-refinement
+  /// is the feature — the verifier-stays-outside rule protects the stop condition
+  /// (goal, predicate, budget), and the playbook is method, not verdict.
+  private func refineNode(_ nodeID: UUID, text: String, from senderID: UUID?) {
+    guard graph.nodes[id: nodeID] != nil else {
+      announceError("playbook not refined: no loop \(nodeID) in this graph")
+      return
+    }
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      announceError("playbook not refined: empty text — to undo, use node refine --rollback")
+      return
+    }
+    guard trimmed.utf8.count <= NodeMemory.maxPlaybookBytes else {
+      announceError(
+        "playbook not refined: \(trimmed.utf8.count) bytes is over the "
+          + "\(NodeMemory.maxPlaybookBytes)-byte bound — a playbook is distilled method, "
+          + "not a transcript; move history to node memo instead")
+      return
+    }
+    guard let onRefinePlaybook, onRefinePlaybook(nodeID, trimmed) else {
+      announceError("playbook not refined: the write failed")
+      return
+    }
+    let sender = senderID.flatMap { $0 == nodeID ? nil : graph.nodes[id: $0]?.title }
+    recordMemory(
+      nodeID,
+      "playbook refined\(sender.map { " by \($0)" } ?? "") (\(trimmed.utf8.count) bytes) "
+        + "— next wake works from the new version")
+  }
+
+  /// Restores the playbook's previous version — the undo half of `refineNode`.
+  private func rollbackRefinement(_ nodeID: UUID, from senderID: UUID?) {
+    guard graph.nodes[id: nodeID] != nil else {
+      announceError("playbook not rolled back: no loop \(nodeID) in this graph")
+      return
+    }
+    guard let onRollbackPlaybook, onRollbackPlaybook(nodeID) else {
+      announceError("playbook not rolled back: no earlier version to restore")
+      return
+    }
+    let sender = senderID.flatMap { $0 == nodeID ? nil : graph.nodes[id: $0]?.title }
+    recordMemory(nodeID, "playbook rolled back\(sender.map { " by \($0)" } ?? "")")
+  }
+
   // MARK: - Import
 
   /// Splices an export bundle's loops into this graph — the daemon half of
@@ -1106,11 +1178,27 @@ public actor GraphStore {
     return false
   }
 
-  private func resolveNode(_ nodeID: UUID, succeeded: Bool) {
-    guard graph.nodes[id: nodeID] != nil else { return }
+  /// `sessionMayStillBeLive` is true only for predicate-driven resolutions: the goal
+  /// poller proved the goal met while the session runs on, which is the one moment an
+  /// agent is both finished and present. The other resolution paths
+  /// (`nodeCheckApproved`, composite roll-up) fire *because* the session ended, so
+  /// there is nobody left to speak to.
+  private func resolveNode(
+    _ nodeID: UUID, succeeded: Bool, sessionMayStillBeLive: Bool = false
+  ) {
+    guard let node = graph.nodes[id: nodeID] else { return }
     graph.nodes[id: nodeID]?.state = succeeded ? .succeeded : .failed
     cancelGoalPoller(nodeID)
     recordMemory(nodeID, "resolved: \(succeeded ? "succeeded" : "failed")")
+    // Skill distillation rides resolution: a goal loop that just succeeded is the one
+    // agent holding a proven method in context. Its own queue rather than
+    // `pendingNudges`, because the state written above is exactly what
+    // `MessageBus.deliverability` reads — a resolved node is "not live" to the graph
+    // while its PTY is still very much there (the `requestStop` ordering lesson).
+    // Success only: a failed loop's method is not a recipe.
+    if succeeded, sessionMayStillBeLive, node.loopType == .goalBased {
+      pendingResolutionNudges.append((nodeID, MessageBus.distillSkillRequest))
+    }
     fireOutgoingEdges(from: nodeID, sourceSucceeded: succeeded)
   }
 
@@ -1492,6 +1580,13 @@ public actor GraphStore {
       else { continue }
       _ = await deliverToSession(target, text)
     }
+    while !pendingResolutionNudges.isEmpty {
+      let (nodeID, text) = pendingResolutionNudges.removeFirst()
+      guard let target = graph.nodes[id: nodeID],
+        target.backend.capabilities.supportsMidSessionInput
+      else { continue }
+      _ = await deliverToSession(target, text)
+    }
   }
 
   /// One loop telling another something, now — `graphcode node send`'s half of the
@@ -1715,7 +1810,7 @@ public actor GraphStore {
     // or its session exited and resolved it) while the predicate was running.
     guard let current = graph.nodes[id: nodeID], !current.isResolved else { return }
     if outcome.passed {
-      resolveNode(nodeID, succeeded: true)
+      resolveNode(nodeID, succeeded: true, sessionMayStillBeLive: true)
       await drainAndBroadcast()
       return
     }

--- a/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
+++ b/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
@@ -92,6 +92,17 @@ public indirect enum GraphCommand: Codable, Sendable, Equatable {
   /// Append a learned note to a node's memory log (`NodeMemory`) — what `graphcode
   /// node memo` rides on. `from` is attributed the same way `messageNode`'s is.
   case memoNode(UUID, text: String, from: UUID?)
+  /// Replace a node's playbook — its refinable supplemental prompt
+  /// (`NodeMemory.refinePlaybook`), what `graphcode node refine` rides on. The
+  /// continual-harness counterpart to `memoNode`: a memo appends one fact to the log,
+  /// a refinement rewrites the *method* the next wake reads. A loop may refine itself
+  /// — that is the point — because the things refinement must never touch (the goal,
+  /// the predicate, the budget, the briefing) live elsewhere and keep their own
+  /// guards. `from` is attributed the same way `memoNode`'s is.
+  case refineNode(UUID, text: String, from: UUID?)
+  /// Restore the playbook's previous version, consuming one snapshot — the undo that
+  /// makes whole-document refinement safe.
+  case rollbackRefinement(UUID, from: UUID?)
   /// Type a message into a node's live session, right now — the ad-hoc counterpart to
   /// a `.message` edge, sharing its transport and its deliverability rules
   /// (`MessageBus`). This is what `graphcode node send` rides on, and its reason to

--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -344,6 +344,12 @@ public actor ProjectRegistry {
       },
       onRemoveMemory: { nodeID in
         NodeMemory.remove(projectPath: path, nodeID: nodeID)
+      },
+      onRefinePlaybook: { nodeID, text in
+        NodeMemory.refinePlaybook(text, projectPath: path, nodeID: nodeID)
+      },
+      onRollbackPlaybook: { nodeID in
+        NodeMemory.rollbackPlaybook(projectPath: path, nodeID: nodeID)
       })
     stores[path] = newStore
     // Only on first load of this project — a time-based node's session outlives the app

--- a/GraphcodeKit/Sources/Sessions/MessageBus.swift
+++ b/GraphcodeKit/Sources/Sessions/MessageBus.swift
@@ -69,6 +69,22 @@ public enum MessageBus {
       + "session: the loop is what stops, not you. Do not exit or quit."
   }
 
+  /// Typed into a goal loop's still-live session the moment it resolves successfully —
+  /// the one moment the method that worked is fully in context and the loop has nothing
+  /// left to do with it. The ask is to write into the *backend's* native skill format
+  /// inside the project (agents write to the project all the time; graphcode itself
+  /// never does), so the next loop's backend picks it up with no graphcode runtime in
+  /// between: the graph curates, the backend executes.
+  ///
+  /// "If" is load-bearing: a one-off fix distilled into a skill is library pollution,
+  /// and the judgement of reusability belongs to the agent that did the work.
+  public static let distillSkillRequest =
+    "[graphcode] Goal met. Before you finish: if the method that got you here would be "
+    + "reusable by another loop in this project, distill it into a project skill in "
+    + "your backend's native format (for Claude Code: .claude/skills/<name>/SKILL.md, "
+    + "a short markdown recipe with a one-line description). If it was one-off work, "
+    + "skip this."
+
   /// What actually gets typed into the target. The edge's transform decides the content;
   /// a `.script` transform runs to produce it, which is docs/08's "a script is cheaper
   /// than reasoning through the steps every time" applied to a hand-off.

--- a/GraphcodeKit/Sources/Sessions/NodeMemory.swift
+++ b/GraphcodeKit/Sources/Sessions/NodeMemory.swift
@@ -28,6 +28,13 @@ public enum NodeMemory {
   public static let logFileName = "LOG.txt"
   public static let wakeFileName = "WAKE.md"
   public static let promptFileName = "PROMPT.md"
+  /// The node's refinable supplemental prompt — the continual-harness half of memory.
+  /// The log records what *happened*; the playbook is what the loop has distilled about
+  /// *how to do this job*, rewritten whole by `graphcode node refine` and carried into
+  /// every wake digest. Distinct from `PROMPT.md`, which is the launch path's delivery
+  /// vehicle for an oversized opening prompt, and from the briefing, which is the
+  /// immutable base no refinement may touch.
+  public static let playbookFileName = "PLAYBOOK.md"
 
   /// How many recent log lines a wake digest carries verbatim (~a few KB). Older
   /// entries are elided with a pointer at the full log — available on demand, out of
@@ -37,6 +44,16 @@ public enum NodeMemory {
   /// Notes are capped the way OptMem caps them: forcing salience at write time is what
   /// keeps the log a memory rather than a transcript.
   public static let maxEntryBytes = 512
+
+  /// The playbook's write-time bound, an order of magnitude looser than a log entry's
+  /// because it is a *document* the loop maintains — but still a bound, because the
+  /// whole file rides into every wake digest and an unbounded playbook would grow into
+  /// exactly the transcript the digest budget exists to keep out.
+  public static let maxPlaybookBytes = 8192
+
+  /// How many superseded playbooks are kept for rollback. Refinement is supposed to be
+  /// small, evidence-backed steps; five steps of undo covers a bad session's worth.
+  public static let playbookSnapshotLimit = 5
 
   /// One directory per (project, node). The project component reuses
   /// `SessionBriefing.slug` so a human browsing `~/.graphcode/memory` can tell which
@@ -118,7 +135,10 @@ public enum NodeMemory {
     projectPath: String, nodeID: UUID, baseURL: URL = SupportDirectory.url
   ) -> URL? {
     let all = entries(forProjectPath: projectPath, nodeID: nodeID, baseURL: baseURL)
-    guard !all.isEmpty else { return nil }
+    let playbook = playbook(forProjectPath: projectPath, nodeID: nodeID, baseURL: baseURL)
+    // A playbook alone still earns a digest: refinement is exactly the knowledge a
+    // fresh session must start from, log or no log.
+    guard !all.isEmpty || playbook != nil else { return nil }
 
     let recent = all.suffix(wakeLineBudget)
     let elided = all.count - recent.count
@@ -133,6 +153,20 @@ public enum NodeMemory {
       "with: graphcode node memo <project-path> <your-node-id> <note>",
       "",
     ]
+    if let playbook {
+      // The playbook rides ahead of the history: it is the distilled *how*, where the
+      // log is the raw *what happened*, and a session should read method before events.
+      lines.append("## Your playbook")
+      lines.append("")
+      lines.append("Written by your own earlier passes. Follow it, and when this pass")
+      lines.append("teaches you a better way of working, rewrite it (whole document) with:")
+      lines.append("graphcode node refine <project-path> <your-node-id> <new playbook text>")
+      lines.append("")
+      lines.append(playbook)
+      lines.append("")
+      lines.append("## Recent history")
+      lines.append("")
+    }
     if elided > 0 {
       lines.append("(\(elided) earlier entries elided — full log: \(logPath))")
       lines.append("")
@@ -150,6 +184,104 @@ public enum NodeMemory {
     } catch {
       return nil
     }
+  }
+
+  public static func playbookURL(
+    forProjectPath projectPath: String, nodeID: UUID, baseURL: URL = SupportDirectory.url
+  ) -> URL {
+    directory(forProjectPath: projectPath, nodeID: nodeID, baseURL: baseURL)
+      .appendingPathComponent(playbookFileName)
+  }
+
+  /// The playbook's current text, or `nil` when the node has never refined one — the
+  /// wake digest uses the distinction to omit the section entirely rather than show an
+  /// empty heading.
+  public static func playbook(
+    forProjectPath projectPath: String, nodeID: UUID, baseURL: URL = SupportDirectory.url
+  ) -> String? {
+    let url = playbookURL(forProjectPath: projectPath, nodeID: nodeID, baseURL: baseURL)
+    guard let text = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  /// Replaces the playbook, snapshotting what it replaced — `graphcode node refine`'s
+  /// write half. Whole-document replacement rather than patching, because the loop
+  /// authoring it holds the old text in context anyway and a patch language would be a
+  /// second thing to get wrong; the snapshots are what make replacement safe.
+  ///
+  /// Returns false — and writes nothing — for empty text (that is what rollback is
+  /// for) or text over `maxPlaybookBytes`: unlike a memo, a playbook truncated
+  /// mid-sentence would be *followed* in its corrupted form on every future wake, so
+  /// oversize is refused loudly at the daemon rather than trimmed quietly here.
+  public static func refinePlaybook(
+    _ text: String, projectPath: String, nodeID: UUID, baseURL: URL = SupportDirectory.url
+  ) -> Bool {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, trimmed.utf8.count <= maxPlaybookBytes else { return false }
+    let url = playbookURL(forProjectPath: projectPath, nodeID: nodeID, baseURL: baseURL)
+    do {
+      try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+      if FileManager.default.fileExists(atPath: url.path) {
+        try snapshotPlaybook(at: url)
+      }
+      try (trimmed + "\n").write(to: url, atomically: true, encoding: .utf8)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /// Restores the newest snapshot as the current playbook and consumes it — undo, one
+  /// step at a time, up to `playbookSnapshotLimit` steps. Returns false when there is
+  /// nothing to roll back to.
+  public static func rollbackPlaybook(
+    projectPath: String, nodeID: UUID, baseURL: URL = SupportDirectory.url
+  ) -> Bool {
+    let url = playbookURL(forProjectPath: projectPath, nodeID: nodeID, baseURL: baseURL)
+    guard let newest = playbookSnapshots(besidePlaybookAt: url).last else { return false }
+    do {
+      if FileManager.default.fileExists(atPath: url.path) {
+        try FileManager.default.removeItem(at: url)
+      }
+      try FileManager.default.moveItem(at: newest, to: url)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /// Copies the current playbook aside as `PLAYBOOK.<sequence>.md` and prunes the
+  /// oldest beyond the limit. The sequence is one past the newest existing snapshot's,
+  /// so names stay ordered however many rollbacks have consumed the middle.
+  private static func snapshotPlaybook(at url: URL) throws {
+    let existing = playbookSnapshots(besidePlaybookAt: url)
+    let next = (existing.last.flatMap(snapshotSequence) ?? 0) + 1
+    let snapshot = url.deletingLastPathComponent()
+      .appendingPathComponent("PLAYBOOK.\(next).md")
+    try FileManager.default.copyItem(at: url, to: snapshot)
+    for stale in existing.dropLast(playbookSnapshotLimit - 1) {
+      try? FileManager.default.removeItem(at: stale)
+    }
+  }
+
+  /// Existing snapshots, oldest first.
+  private static func playbookSnapshots(besidePlaybookAt url: URL) -> [URL] {
+    let directory = url.deletingLastPathComponent()
+    let contents =
+      (try? FileManager.default.contentsOfDirectory(
+        at: directory, includingPropertiesForKeys: nil)) ?? []
+    return
+      contents
+      .filter { snapshotSequence($0) != nil }
+      .sorted { (snapshotSequence($0) ?? 0) < (snapshotSequence($1) ?? 0) }
+  }
+
+  private static func snapshotSequence(_ url: URL) -> Int? {
+    let name = url.lastPathComponent
+    guard name.hasPrefix("PLAYBOOK."), name.hasSuffix(".md") else { return nil }
+    return Int(name.dropFirst("PLAYBOOK.".count).dropLast(".md".count))
   }
 
   /// Writes a node's full prompt to its `PROMPT.md` and returns where it landed, or

--- a/graphcode-cli/Sources/main.swift
+++ b/graphcode-cli/Sources/main.swift
@@ -258,6 +258,40 @@ do {
     if case .errorOccurred(let message) = memoVerdict { fail(message) }
     print("noted")
 
+  case .refineNode(let projectPath, let nodeID, let text):
+    let refiner = SurfaceRef.nodeID(
+      fromZmxSessionName: ProcessInfo.processInfo.environment["ZMX_SESSION"] ?? "")
+    try client.send(.openProject(path: projectPath))
+    _ = try client.waitForEvent { if case .graphChanged = $0 { return true } else { return false } }
+    try client.send(
+      .graphCommand(
+        projectPath: projectPath, command: .refineNode(nodeID, text: text, from: refiner)))
+    let refineVerdict = try client.waitForEvent { event in
+      switch event {
+      case .graphChanged, .errorOccurred: return true
+      default: return false
+      }
+    }
+    if case .errorOccurred(let message) = refineVerdict { fail(message) }
+    print("refined — the next wake works from the new playbook")
+
+  case .rollbackRefinement(let projectPath, let nodeID):
+    let requester = SurfaceRef.nodeID(
+      fromZmxSessionName: ProcessInfo.processInfo.environment["ZMX_SESSION"] ?? "")
+    try client.send(.openProject(path: projectPath))
+    _ = try client.waitForEvent { if case .graphChanged = $0 { return true } else { return false } }
+    try client.send(
+      .graphCommand(
+        projectPath: projectPath, command: .rollbackRefinement(nodeID, from: requester)))
+    let rollbackVerdict = try client.waitForEvent { event in
+      switch event {
+      case .graphChanged, .errorOccurred: return true
+      default: return false
+      }
+    }
+    if case .errorOccurred(let message) = rollbackVerdict { fail(message) }
+    print("rolled back to the previous playbook")
+
   case .pilotComposite(let projectPath, let nodeID):
     try runAndPrintGraph(
       projectPath: projectPath,

--- a/graphcode/Tests/PlaybookRefinementTests.swift
+++ b/graphcode/Tests/PlaybookRefinementTests.swift
@@ -1,0 +1,205 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// The continual harness: a node's playbook — its refinable supplemental prompt —
+/// rewritten whole by `node refine`, snapshotted for rollback, and carried into every
+/// wake digest ahead of the history. The base briefing and the stop condition stay out
+/// of its reach by construction: they are different files with different owners.
+@Suite
+struct PlaybookRefinementTests {
+  private let projectPath = "/tmp/refine-tests"
+  private let nodeID = UUID()
+
+  private func temporaryBase() throws -> URL {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("graphcode-playbook-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+    return base
+  }
+
+  @Test
+  func refineWritesAndTheWakeDigestCarriesItAheadOfHistory() throws {
+    let base = try temporaryBase()
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    NodeMemory.append("resolved: pass one", projectPath: projectPath, nodeID: nodeID, baseURL: base)
+    #expect(
+      NodeMemory.refinePlaybook(
+        "Always run make check before claiming done.",
+        projectPath: projectPath, nodeID: nodeID, baseURL: base))
+
+    let digestURL = try #require(
+      NodeMemory.writeWakeDigest(projectPath: projectPath, nodeID: nodeID, baseURL: base))
+    let digest = try String(contentsOf: digestURL, encoding: .utf8)
+    let playbookIndex = try #require(digest.range(of: "Always run make check"))
+    let historyIndex = try #require(digest.range(of: "resolved: pass one"))
+    #expect(playbookIndex.lowerBound < historyIndex.lowerBound)
+    #expect(digest.contains("graphcode node refine"))
+  }
+
+  @Test
+  func aPlaybookAloneStillEarnsAWakeDigest() throws {
+    // Refinement is exactly the knowledge a fresh session must start from, log or no.
+    let base = try temporaryBase()
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    #expect(
+      NodeMemory.refinePlaybook(
+        "Prefer small diffs.", projectPath: projectPath, nodeID: nodeID, baseURL: base))
+    #expect(
+      NodeMemory.writeWakeDigest(projectPath: projectPath, nodeID: nodeID, baseURL: base) != nil)
+    // And a node with neither still gets none — a first launch must not be told to go
+    // read an empty file.
+    #expect(
+      NodeMemory.writeWakeDigest(projectPath: projectPath, nodeID: UUID(), baseURL: base) == nil)
+  }
+
+  @Test
+  func rollbackRestoresTheVersionRefineReplaced() throws {
+    let base = try temporaryBase()
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    #expect(
+      NodeMemory.refinePlaybook("v1", projectPath: projectPath, nodeID: nodeID, baseURL: base))
+    #expect(
+      NodeMemory.refinePlaybook("v2", projectPath: projectPath, nodeID: nodeID, baseURL: base))
+    #expect(
+      NodeMemory.playbook(forProjectPath: projectPath, nodeID: nodeID, baseURL: base) == "v2")
+
+    #expect(NodeMemory.rollbackPlaybook(projectPath: projectPath, nodeID: nodeID, baseURL: base))
+    #expect(
+      NodeMemory.playbook(forProjectPath: projectPath, nodeID: nodeID, baseURL: base) == "v1")
+    // One snapshot, one undo: a second rollback has nothing left to restore.
+    #expect(!NodeMemory.rollbackPlaybook(projectPath: projectPath, nodeID: nodeID, baseURL: base))
+  }
+
+  @Test
+  func snapshotsAreBoundedAndOrderedAcrossManyRefinements() throws {
+    let base = try temporaryBase()
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    for version in 1...8 {
+      #expect(
+        NodeMemory.refinePlaybook(
+          "v\(version)", projectPath: projectPath, nodeID: nodeID, baseURL: base))
+    }
+    let directory = NodeMemory.directory(
+      forProjectPath: projectPath, nodeID: nodeID, baseURL: base)
+    let snapshots = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+      .filter { $0.hasPrefix("PLAYBOOK.") && $0 != "PLAYBOOK.md" }
+    #expect(snapshots.count == NodeMemory.playbookSnapshotLimit)
+
+    // Undo steps back through the retained tail, newest first.
+    #expect(NodeMemory.rollbackPlaybook(projectPath: projectPath, nodeID: nodeID, baseURL: base))
+    #expect(
+      NodeMemory.playbook(forProjectPath: projectPath, nodeID: nodeID, baseURL: base) == "v7")
+  }
+
+  @Test
+  func emptyAndOversizedPlaybooksAreRefusedWholesale() throws {
+    let base = try temporaryBase()
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    #expect(
+      !NodeMemory.refinePlaybook("   ", projectPath: projectPath, nodeID: nodeID, baseURL: base))
+    let oversized = String(repeating: "x", count: NodeMemory.maxPlaybookBytes + 1)
+    #expect(
+      !NodeMemory.refinePlaybook(
+        oversized, projectPath: projectPath, nodeID: nodeID, baseURL: base))
+    // Refused means untouched — not truncated, not created.
+    #expect(NodeMemory.playbook(forProjectPath: projectPath, nodeID: nodeID, baseURL: base) == nil)
+  }
+
+  @Test
+  func theStoreRecordsARefinementAndSaysWhoMadeIt() async {
+    let refined = LockIsolated<[(UUID, String)]>([])
+    let remembered = LockIsolated<[String]>([])
+    let graph = LoopGraph(
+      project: ProjectRef(path: "/tmp/p", name: "p"),
+      nodes: [
+        LoopNode(title: "Worker", loopType: .goalBased, goal: GoalSpec(summary: "work")),
+        LoopNode(title: "Coach", loopType: .goalBased, goal: GoalSpec(summary: "advise")),
+      ])
+    let store = GraphStore(
+      graph: graph,
+      onAppendMemory: { _, entry in remembered.withValue { $0.append(entry) } },
+      onRefinePlaybook: { nodeID, text in
+        refined.withValue { $0.append((nodeID, text)) }
+        return true
+      })
+    let (workerID, coachID) = (graph.nodes[0].id, graph.nodes[1].id)
+
+    // Self-refinement is the feature, and needs no attribution.
+    await store.handle(.refineNode(workerID, text: "Test first.", from: workerID))
+    #expect(refined.value.count == 1)
+    #expect(remembered.value.contains { $0.contains("playbook refined (") })
+
+    // A peer's refinement names its author, the way a memo from a peer does.
+    await store.handle(.refineNode(workerID, text: "Test first, then lint.", from: coachID))
+    #expect(remembered.value.contains { $0.contains("playbook refined by Coach") })
+  }
+
+  @Test
+  func theStoreRefusesEmptyAndOversizedBeforeTheFileLayerSeesThem() async {
+    // Refused at the store means the hook is never called and nothing lands in the
+    // memory log — the loop hears the refusal (announceError) instead of silently
+    // working from a playbook it believes it replaced.
+    let refineCalls = LockIsolated(0)
+    let remembered = LockIsolated<[String]>([])
+    let graph = LoopGraph(
+      project: ProjectRef(path: "/tmp/p", name: "p"),
+      nodes: [LoopNode(title: "Worker", loopType: .goalBased, goal: GoalSpec(summary: "work"))])
+    let store = GraphStore(
+      graph: graph,
+      onAppendMemory: { _, entry in remembered.withValue { $0.append(entry) } },
+      onRefinePlaybook: { _, _ in
+        refineCalls.withValue { $0 += 1 }
+        return true
+      })
+
+    await store.handle(.refineNode(graph.nodes[0].id, text: "   ", from: nil))
+    let oversized = String(repeating: "x", count: NodeMemory.maxPlaybookBytes + 1)
+    await store.handle(.refineNode(graph.nodes[0].id, text: oversized, from: nil))
+    await store.handle(.rollbackRefinement(UUID(), from: nil))
+
+    #expect(refineCalls.value == 0)
+    #expect(!remembered.value.contains { $0.contains("playbook") })
+  }
+
+  @Test
+  func theCLIParsesAllThreeSpellings() throws {
+    let id = UUID()
+    let words = try GraphcodeCommand.parse([
+      "node", "refine", "/tmp/p", id.uuidString, "Test", "first.",
+    ])
+    guard case .refineNode(_, _, let text) = words else {
+      Issue.record("expected refineNode, got \(words)")
+      return
+    }
+    #expect(text == "Test first.")
+
+    let rollback = try GraphcodeCommand.parse([
+      "node", "refine", "/tmp/p", id.uuidString, "--rollback",
+    ])
+    guard case .rollbackRefinement = rollback else {
+      Issue.record("expected rollbackRefinement, got \(rollback)")
+      return
+    }
+
+    let file = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("playbook-\(UUID().uuidString).md")
+    try "Line one\nLine two\n".write(to: file, atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(at: file) }
+    let fromFile = try GraphcodeCommand.parse([
+      "node", "refine", "/tmp/p", id.uuidString, "--file", file.path,
+    ])
+    guard case .refineNode(_, _, let fileText) = fromFile else {
+      Issue.record("expected refineNode, got \(fromFile)")
+      return
+    }
+    #expect(fileText.contains("Line one\nLine two"))
+  }
+}

--- a/graphcode/Tests/SkillDistillationTests.swift
+++ b/graphcode/Tests/SkillDistillationTests.swift
@@ -1,0 +1,126 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// The distillation ask: the moment a goal loop resolves successfully, its still-live
+/// session is asked — once — to fold a reusable method into the project's own skill
+/// library. The graph curates, the backend executes; graphcode itself never writes
+/// into the project.
+@Suite
+struct SkillDistillationTests {
+  private func goalGraph() -> LoopGraph {
+    LoopGraph(
+      project: ProjectRef(path: "/tmp/distill", name: "distill"),
+      nodes: [
+        LoopNode(
+          title: "Green build", loopType: .goalBased,
+          goal: GoalSpec(summary: "CI passes", predicate: "true"),
+          state: .running)
+      ])
+  }
+
+  @Test
+  func aSucceedingGoalLoopIsAskedToDistillItsMethod() async {
+    let delivered = LockIsolated<[String]>([])
+    let store = GraphStore(
+      graph: goalGraph(),
+      onEvaluatePredicate: { _ in true },
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      })
+    let nodeID = await store.graph.nodes[0].id
+
+    await store.evaluateGoal(nodeID)
+
+    #expect(await store.graph.nodes[0].state == .succeeded)
+    #expect(delivered.value.contains { $0.contains("distill it into a project skill") })
+  }
+
+  @Test
+  func anExitResolvedGoalIsNotAskedThereIsNobodyLeft() async {
+    // `nodeCheckApproved` is the session-exit resolution path: the loop finished by
+    // leaving. Only the predicate path proves the session is still there to ask.
+    let delivered = LockIsolated<[String]>([])
+    let store = GraphStore(
+      graph: goalGraph(),
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      })
+    let nodeID = await store.graph.nodes[0].id
+
+    await store.handle(.nodeCheckApproved(nodeID))
+
+    #expect(await store.graph.nodes[0].state == .succeeded)
+    #expect(delivered.value.isEmpty)
+  }
+
+  @Test
+  func aFailingResolutionAsksForNothing() async {
+    // A failed loop's method is not a recipe.
+    let delivered = LockIsolated<[String]>([])
+    let store = GraphStore(
+      graph: goalGraph(),
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      })
+    let nodeID = await store.graph.nodes[0].id
+
+    await store.handle(.nodeCheckRejected(nodeID))
+
+    #expect(await store.graph.nodes[0].state == .failed)
+    #expect(delivered.value.isEmpty)
+  }
+
+  @Test
+  func aTurnBasedResolutionAsksForNothing() async {
+    // The ask is scoped to goal loops: a turn-based loop resolves under a human's eye,
+    // and that human decides what is worth keeping.
+    let delivered = LockIsolated<[String]>([])
+    let graph = LoopGraph(
+      project: ProjectRef(path: "/tmp/distill", name: "distill"),
+      nodes: [
+        LoopNode(title: "Review", checkDescription: "sound?", state: .running)
+      ])
+    let store = GraphStore(
+      graph: graph,
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      })
+
+    await store.handle(.nodeCheckApproved(graph.nodes[0].id))
+
+    #expect(await store.graph.nodes[0].state == .succeeded)
+    #expect(delivered.value.isEmpty)
+  }
+
+  @Test
+  func theAskSurvivesTheResolvedStateTheOrdinaryNudgeDrainWouldTripOn() async {
+    // The regression this design dodged: resolution writes the very state
+    // `MessageBus.deliverability` reads, so a resolved-but-live session is "not live"
+    // to the graph. The ask must still reach the PTY.
+    let node = LoopNode(
+      title: "Green build", loopType: .goalBased,
+      goal: GoalSpec(summary: "done", predicate: "true"),
+      state: .running)
+    #expect(MessageBus.deliverability(to: node) == nil)
+    var resolved = node
+    resolved.state = .succeeded
+    #expect(MessageBus.deliverability(to: resolved) == .targetNotLive)
+    // …which is exactly why the delivered-message assertion in the first test proves
+    // the separate drain, not the ordinary one.
+  }
+
+  @Test
+  func theBriefingTeachesTheSkillLibraryAndTheRefineVerb() throws {
+    let briefing = try #require(SessionBriefing.text(projectPath: "/tmp/distill"))
+    #expect(briefing.contains(".claude/skills"))
+    #expect(briefing.contains("Project skills"))
+    #expect(briefing.contains("node refine"))
+  }
+}


### PR DESCRIPTION
Items 3 and 4 from the prime-agent adoption plan (#131, #133 were 1/2/5 and the usage substrate).

## Playbooks — `graphcode node refine` (item 3)
- `PLAYBOOK.md` joins the node memory dir: the log is *what happened*, the playbook is the loop's own distilled *how to do this job*. It rides into every wake digest ahead of the history — method before events.
- Whole-document replacement, snapshotted (`PLAYBOOK.1.md`… keep 5) with `--rollback` undo, bounded at 8KB and refused loudly over it — a playbook truncated mid-sentence would be followed in its corrupted form on every future wake.
- `graphcode node refine <text…>` / `--file <path>` (multi-line documents; read on the caller's machine) / `--rollback`. Self-refinement is allowed by design: the verifier-stays-outside rule protects the stop condition (goal/predicate/budget), and the playbook is method, not verdict. The briefing teaches the verb and the memo/refine distinction.

## Skill distillation on resolve (item 4)
- When a goal loop resolves **through its predicate** — the one resolution path that proves the session is still alive — the daemon types in one ask (`MessageBus.distillSkillRequest`): distill the method into the backend's native project skill (`.claude/skills/<name>/SKILL.md` for Claude Code) if reusable, skip if one-off. The graph curates; the backend executes; graphcode never writes into the project.
- Needed its own delivery queue: resolution writes the very state `MessageBus.deliverability` reads, so the ordinary nudge drain would drop every one (the `requestStop` ordering lesson, now encoded in a test).
- Exit-driven resolutions (`nodeCheckApproved`, composite roll-up) ask nobody — the session already left. Failed resolutions ask nobody — a failed loop's method is not a recipe.
- The briefing gains a "Project skills" section so every new loop checks the library before reinventing.

## Known limitation
`node refine` is not yet in the remote-host CLI shim; remote loops get the "runs from the Mac's own shell" refusal.

## Verification
- Full suite: **930 tests in 95 suites passed**, including 9 new `PlaybookRefinementTests` and 6 new `SkillDistillationTests`.
- `swiftlint` + `swift format lint --strict` clean.
- One pre-existing behavior deliberately preserved and re-proven: messages to resolved targets still stage to memory, never type into the void (`CreatedByLoopTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)