### PR TITLE
usage.sh: count each message once, not once per content block

### DIFF
--- a/GraphcodeKit/Sources/Domain/UsageSample.swift
+++ b/GraphcodeKit/Sources/Domain/UsageSample.swift
@@ -48,9 +48,9 @@ public struct UsageSample: Codable, Equatable, Sendable {
   ///
   /// - `key=value` pairs separated by spaces or commas — the original documented form.
   ///   It turns out a `zmx` label *value* can never actually hold one (`zmx set` takes
-  ///   only `[A-Za-z0-9._-]` in a value, and `=` and `,` are both outside it), but the
-  ///   remote path hands whole label lines through here and the shape costs nothing to
-  ///   keep.
+  ///   only `[A-Za-z0-9._-]` in a value, and `=` and `,` are both outside it), so
+  ///   nothing writes it today; kept because parsing is cheap and a future writer with
+  ///   a laxer transport shouldn't find half a parser.
   /// - `key.value` pairs joined by `_` — `input.559576_output.5397_cost.0.0042` — built
   ///   from exactly the bytes a label value may contain. This is what
   ///   `PresenceHooks.usageScript` writes, and the only form that survives `zmx set`;

--- a/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
+++ b/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
@@ -123,6 +123,15 @@ public enum PresenceHooks {
   /// keys (their preceding byte is `_`, not `"`), which are summed separately below —
   /// a budget is spent by what the API metered, cache reads included.
   ///
+  /// **One count per message, not per line.** Claude Code writes one JSONL record per
+  /// content block — a turn with text plus three tool calls is four records — and
+  /// every record repeats the same message-level `usage`. A naive line-sum therefore
+  /// overcounted roughly 2× (measured on a real transcript: 1,524,855 vs 768,566 after
+  /// dedup), tripping budgets at half their stated bound. Records dedup on the
+  /// message `id` (`"id":"msg_…"`), and a record with a usage block but no such id —
+  /// not a shape Claude Code writes today — still counts rather than silently
+  /// vanishing.
+  ///
   /// Runs on `Stop` — once per turn, when the spend just changed — never per tool call:
   /// it reads the whole transcript, and `PreToolUse` frequency would price it wrong.
   /// Cannot fail and cannot block, same contract as every hook here: every path exits 0.
@@ -148,6 +157,10 @@ public enum PresenceHooks {
         return n
       }
       {
+        if (match($0, /"id":"msg_[A-Za-z0-9]+"/)) {
+          id = substr($0, RSTART, RLENGTH)
+          if (seen[id]++) next
+        }
         input += grab("\\"input_tokens\\":")
         input += grab("\\"cache_creation_input_tokens\\":")
         input += grab("\\"cache_read_input_tokens\\":")

--- a/graphcode/Tests/UsageReportingTests.swift
+++ b/graphcode/Tests/UsageReportingTests.swift
@@ -86,6 +86,25 @@ struct UsageReportingTests {
   }
 
   @Test
+  func aMultiBlockTurnCountsItsMessageOnceNotPerRecord() throws {
+    // Claude Code writes one JSONL record per content block, each repeating the same
+    // message-level usage — the double-count a budget-capped review loop caught in the
+    // first version of this script (naive line-sum ran ~2× the metered spend).
+    let transcript = """
+      {"type":"assistant","message":{"id":"msg_01AAA","usage":{"input_tokens":100,\
+      "output_tokens":40}}}
+      {"type":"assistant","message":{"id":"msg_01AAA","usage":{"input_tokens":100,\
+      "output_tokens":40}}}
+      {"type":"assistant","message":{"id":"msg_01AAA","usage":{"input_tokens":100,\
+      "output_tokens":40}}}
+      {"type":"assistant","message":{"id":"msg_01BBB","usage":{"input_tokens":7,\
+      "output_tokens":3}}}
+      """
+    let label = try reportedLabel(payload: stopPayload, transcript: transcript)
+    #expect(label == "usage=input.107_output.43")
+  }
+
+  @Test
   func aMissingTranscriptReportsNothingAndStillExitsZero() throws {
     let payload = """
       {"session_id":"a","hook_event_name":"Stop","transcript_path":"/nonexistent/t.jsonl"}


### PR DESCRIPTION
Found by the budget-capped review loop from the #131 demo, auditing the very mechanism that stopped it: **the usage reporter (#133) double-counts**. Claude Code writes one JSONL record per content block — a turn with text plus three tool calls is four records — and every record repeats the same message-level `usage`. The naive line-sum therefore overcounts with tool-call density (measured 3.55M naive vs 2.05M deduped on the reviewer's own transcript), so budgets tripped well before their stated bound and the usage/cost rollup overreported.

## Changes
- `usageScript`'s awk pass dedups records on the message id (`"id":"msg_…"`) before summing; a usage block with no such id — not a shape Claude Code writes today — still counts rather than silently vanishing.
- Retires `UsageSample.parse`'s stale doc claim about the remote path (it passes value-only labels, same as local — flagged in the same review).

## Verification
- Full suite: **931 tests in 95 suites passed**, including a new regression test shaped exactly like the failure (three records, one message id, counted once).
- Deduped sum verified against the real reviewer transcript through the actual awk script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)