### PR TITLE
Daemon heartbeat (experimental, default off)

### DIFF
--- a/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
+++ b/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
@@ -88,6 +88,10 @@ public enum GraphcodeCommand: Equatable, Sendable {
       --predicate <cmd>    optional stop condition for --type goal (exit 0 = met)
       --prompt <text>      required for --type time; put the cadence in it (/loop 1h …).
                            For --type sketch it is the optional starting note
+      --heartbeat <secs>   for --type time, experimental: the daemon delivers the prompt
+                           every interval instead of the prompt carrying /loop. Needs
+                           "Daemon heartbeat" enabled in the app's Settings; the prompt
+                           is then the bare task, no cadence in it
       --backend <name>     claudeCode | copilotCLI | codex — default: run from inside a
                            loop, the creating loop's backend; otherwise claudeCode
       --model <tier>       fast | standard | capable           (default: by loop type)
@@ -109,6 +113,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
       --poll <seconds>     how often the predicate is polled
       --stall <seconds>    stall bound; 0 clears it
       --budget <tokens>    token budget; 0 clears it
+      --heartbeat <secs>   daemon heartbeat interval; 0 returns cadence to the prompt
       --skip-unchanged <true|false>
       A loop may not change its own --predicate or --budget: the verifier stays outside
       the verified. Session-facing changes reach a live session as a [graphcode] notice.
@@ -350,11 +355,20 @@ public enum GraphcodeCommand: Equatable, Sendable {
     }
     let skipsUnchanged = try parseSkipUnchanged(flags) ?? false
 
+    var heartbeat: Double?
+    if let raw = flags["heartbeat"] {
+      guard let value = Double(raw), value > 0 else {
+        throw ParseError.invalidValue(argument: "--heartbeat", value: raw)
+      }
+      heartbeat = value
+    }
+
     let draft = NodeDraft(
       title: title,
       loopType: loopType,
       checkDescription: flags["check"],
       triggerPrompt: flags["prompt"],
+      heartbeatIntervalSeconds: loopType == .timeBased ? heartbeat : nil,
       // A turn-based loop needs something to do. `--prompt` is what a caller already
       // types for a timed loop's opening instruction, so it means the same thing here
       // rather than making them learn a second flag for the same idea.
@@ -417,6 +431,13 @@ public enum GraphcodeCommand: Equatable, Sendable {
       }
       tokenBudget = value
     }
+    var heartbeat: Double?
+    if let raw = flags["heartbeat"] {
+      guard let value = Double(raw) else {
+        throw ParseError.invalidValue(argument: "--heartbeat", value: raw)
+      }
+      heartbeat = value
+    }
 
     let update = NodeUpdate(
       goalSummary: flags["goal"],
@@ -428,6 +449,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
       tokenBudget: tokenBudget,
       skipsUnchangedWorkspace: try parseSkipUnchanged(flags),
       triggerPrompt: flags["prompt"],
+      heartbeatIntervalSeconds: heartbeat,
       checkDescription: flags["check"],
       modelTier: modelTier)
     guard !update.isEmpty else { throw ParseError.missingArgument("an option to change") }

--- a/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
+++ b/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
@@ -292,6 +292,24 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
   /// the derived beat exactly as it was — see `SummaryModelWriter`.
   public var summaryUsesModel: Bool
 
+  /// Whether the daemon may drive time-based loops on its own timer — the experiment
+  /// that tests the *opposite* of this project's founding cadence decision.
+  ///
+  /// **Off by default, and experimental.** Off, recurrence lives where it always has:
+  /// inside the loop's own prompt as a `/loop` directive the agent runs on itself, and
+  /// the daemon holds no timers (`GraphStore`'s header explains the headless-timer
+  /// failure that decision came from). On, a time-based loop created with a heartbeat
+  /// interval is *ticked by the daemon*: a `[graphcode] heartbeat` typed into its
+  /// session each interval, missed ticks coalescing (a busy session is skipped, not
+  /// queued), and stopping the loop cancels the timer instead of asking the session to
+  /// dismantle its own cadence.
+  ///
+  /// Both models coexist deliberately — a heartbeat loop's prompt carries no `/loop`,
+  /// an ordinary time loop's timer never exists — so the experiment can be judged
+  /// side by side. Read fresh at every tick, so flipping this off silences existing
+  /// heartbeat loops immediately without restarting anything.
+  public var daemonHeartbeatEnabled: Bool
+
   // There is deliberately no window-opacity setting here any more. graphcode used to own
   // one and apply it as `NSWindow.alphaValue`, which fades the whole window — terminal
   // text included — rather than only the background behind it. Ghostty already has
@@ -310,6 +328,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     sharesLoops: Bool = true,
     summarisesLoops: Bool = false,
     summaryUsesModel: Bool = false,
+    daemonHeartbeatEnabled: Bool = false,
     worktreePolicies: [String: WorktreeHygienePolicy] = [:]
   ) {
     self.defaultBackend = defaultBackend.isSpiked ? defaultBackend : .claudeCode
@@ -322,6 +341,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     self.sharesLoops = sharesLoops
     self.summarisesLoops = summarisesLoops
     self.summaryUsesModel = summaryUsesModel
+    self.daemonHeartbeatEnabled = daemonHeartbeatEnabled
     self.worktreePolicies = worktreePolicies
   }
 
@@ -365,6 +385,8 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     // money on a machine whose owner only asked to see what their loops were doing.
     summaryUsesModel =
       try container.decodeIfPresent(Bool.self, forKey: .summaryUsesModel) ?? false
+    daemonHeartbeatEnabled =
+      try container.decodeIfPresent(Bool.self, forKey: .daemonHeartbeatEnabled) ?? false
     worktreePolicies =
       try container.decodeIfPresent(
         [String: WorktreeHygienePolicy].self, forKey: .worktreePolicies) ?? [:]

--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -30,6 +30,14 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
   /// fires headlessly. It also means cron and self-pacing work without graphcode
   /// modelling either, and nothing here inspects or validates the prompt.
   public var triggerPrompt: String?
+  /// `.timeBased`, experimental: the daemon drives this loop instead — a `[graphcode]`
+  /// heartbeat typed into its session every interval (`GraphStore.deliverHeartbeat`),
+  /// active only while `GraphcodeSettings.daemonHeartbeatEnabled` is on. When set,
+  /// `triggerPrompt` is the bare task with no `/loop` directive: exactly one of the two
+  /// cadence models drives a given loop, never both. `nil` — every loop that predates
+  /// the experiment, and every loop whose author didn't opt in — means the prompt owns
+  /// the cadence as it always has.
+  public var heartbeatIntervalSeconds: Double?
   /// `.turnBased`: what the session is actually asked to do.
   ///
   /// Without this the type had no task field at all — a turn-based session opened
@@ -124,6 +132,7 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     loopType: LoopType = .turnBased,
     checkDescription: String? = nil,
     triggerPrompt: String? = nil,
+    heartbeatIntervalSeconds: Double? = nil,
     firstInstruction: String? = nil,
     pausesBeforeWritesOnly: Bool = false,
     goal: GoalSpec? = nil,
@@ -146,6 +155,7 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     self.loopType = loopType
     self.checkDescription = checkDescription
     self.triggerPrompt = triggerPrompt
+    self.heartbeatIntervalSeconds = heartbeatIntervalSeconds
     self.firstInstruction = firstInstruction
     self.pausesBeforeWritesOnly = pausesBeforeWritesOnly
     self.goal = goal
@@ -188,7 +198,16 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
       // quiet and waits — asking nothing up front is what the type is for.
       let note = firstInstruction?.trimmingCharacters(in: .whitespaces) ?? ""
       return note.isEmpty ? nil : note
-    case .timeBased: return triggerPrompt
+    case .timeBased:
+      guard let interval = heartbeatIntervalSeconds, interval > 0, let task = triggerPrompt
+      else { return triggerPrompt }
+      // The heartbeat counterpart of the /loop directive: the session is told who
+      // holds the timer, so it neither schedules its own cadence (double-driving)
+      // nor exits believing one pass was the whole job.
+      return "Every \(Int(interval))s you will receive a [graphcode] heartbeat message. "
+        + "Each one is your cue to run one pass of this task, then wait for the next: "
+        + "\(task) Do not schedule your own /loop, wakeup, or cron for it — the "
+        + "orchestrator holds the timer. Stay in the session between heartbeats."
     case .goalBased: return goal?.sessionPrompt
     case .turnBased:
       return Self.turnBasedPrompt(
@@ -291,7 +310,7 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     case id, title, loopType, checkDescription, triggerPrompt, goal, backend, modelTier
     case worktreeBinding, subGraph, pilotState, usage, metricHistory, createdBy
     case state, createdAt, activity, presence, firstInstruction, pausesBeforeWritesOnly
-    case summary
+    case summary, heartbeatIntervalSeconds
   }
 
   /// Hand-written for the same reason `LoopEdge`'s is: `ProjectPersistence.loadGraph`
@@ -304,6 +323,8 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     loopType = try container.decodeIfPresent(LoopType.self, forKey: .loopType) ?? .turnBased
     checkDescription = try container.decodeIfPresent(String.self, forKey: .checkDescription)
     triggerPrompt = try container.decodeIfPresent(String.self, forKey: .triggerPrompt)
+    heartbeatIntervalSeconds =
+      try container.decodeIfPresent(Double.self, forKey: .heartbeatIntervalSeconds)
     firstInstruction = try container.decodeIfPresent(String.self, forKey: .firstInstruction)
     // Absent from graphs saved before the field existed. Those loops paused after every
     // turn, which is what `false` says.

--- a/GraphcodeKit/Sources/Domain/NodeDraft.swift
+++ b/GraphcodeKit/Sources/Domain/NodeDraft.swift
@@ -34,6 +34,10 @@ public struct NodeDraft: Codable, Equatable, Sendable {
   /// composite doesn't run at creation, so this is a statement of intent until it's
   /// piloted and armed.
   public var triggerPrompt: String?
+  /// `.timeBased`, experimental: ask the daemon to drive this loop on its own timer —
+  /// see `LoopNode.heartbeatIntervalSeconds`. Refused at creation unless
+  /// `GraphcodeSettings.daemonHeartbeatEnabled` is on.
+  public var heartbeatIntervalSeconds: Double?
   /// `.turnBased`: what the session should actually do. See `LoopNode.firstInstruction`.
   /// `.sketch`: the optional starting note — blank means the session opens quiet.
   public var firstInstruction: String?
@@ -71,6 +75,7 @@ public struct NodeDraft: Codable, Equatable, Sendable {
     loopType: LoopType,
     checkDescription: String? = nil,
     triggerPrompt: String? = nil,
+    heartbeatIntervalSeconds: Double? = nil,
     firstInstruction: String? = nil,
     pausesBeforeWritesOnly: Bool = false,
     goal: GoalSpec? = nil,
@@ -85,6 +90,7 @@ public struct NodeDraft: Codable, Equatable, Sendable {
     self.loopType = loopType
     self.checkDescription = checkDescription
     self.triggerPrompt = triggerPrompt
+    self.heartbeatIntervalSeconds = heartbeatIntervalSeconds
     self.firstInstruction = firstInstruction
     self.pausesBeforeWritesOnly = pausesBeforeWritesOnly
     self.goal = goal
@@ -171,6 +177,7 @@ public struct NodeDraft: Codable, Equatable, Sendable {
       loopType: loopType,
       checkDescription: checkDescription,
       triggerPrompt: triggerPrompt,
+      heartbeatIntervalSeconds: heartbeatIntervalSeconds,
       firstInstruction: firstInstruction,
       pausesBeforeWritesOnly: pausesBeforeWritesOnly,
       goal: goal,
@@ -194,6 +201,7 @@ extension NodeDraft {
   private enum CodingKeys: String, CodingKey {
     case id, title, loopType, checkDescription, triggerPrompt, goal, backend, modelTier
     case worktree, subGraph, createdBy, firstInstruction, pausesBeforeWritesOnly
+    case heartbeatIntervalSeconds
   }
 
   /// `id` is `decodeIfPresent` because drafts also arrive over the wire from a CLI that
@@ -207,6 +215,8 @@ extension NodeDraft {
     loopType = try container.decode(LoopType.self, forKey: .loopType)
     checkDescription = try container.decodeIfPresent(String.self, forKey: .checkDescription)
     triggerPrompt = try container.decodeIfPresent(String.self, forKey: .triggerPrompt)
+    heartbeatIntervalSeconds =
+      try container.decodeIfPresent(Double.self, forKey: .heartbeatIntervalSeconds)
     firstInstruction = try container.decodeIfPresent(String.self, forKey: .firstInstruction)
     // Absent from drafts written by a CLI that predates the field. Those loops paused
     // after every turn, which is what `false` means.

--- a/GraphcodeKit/Sources/Domain/NodeUpdate.swift
+++ b/GraphcodeKit/Sources/Domain/NodeUpdate.swift
@@ -33,6 +33,9 @@ public struct NodeUpdate: Codable, Equatable, Sendable {
   /// `.timeBased`: new opening prompt. Reaches a live session only as a nudge; the
   /// session that already ran its old prompt keeps its cadence until relaunched.
   public var triggerPrompt: String?
+  /// `.timeBased`: new daemon-heartbeat interval (`LoopNode.heartbeatIntervalSeconds`).
+  /// Non-positive clears it, returning the loop to prompt-owned cadence.
+  public var heartbeatIntervalSeconds: Double?
   /// `.turnBased`: new per-turn criterion.
   public var checkDescription: String?
   /// Takes effect at the session's next launch — the daemon never restarts a live
@@ -53,6 +56,7 @@ public struct NodeUpdate: Codable, Equatable, Sendable {
     tokenBudget: Int? = nil,
     skipsUnchangedWorkspace: Bool? = nil,
     triggerPrompt: String? = nil,
+    heartbeatIntervalSeconds: Double? = nil,
     checkDescription: String? = nil,
     modelTier: ModelTier? = nil,
     updatedBy: UUID? = nil
@@ -66,6 +70,7 @@ public struct NodeUpdate: Codable, Equatable, Sendable {
     self.tokenBudget = tokenBudget
     self.skipsUnchangedWorkspace = skipsUnchangedWorkspace
     self.triggerPrompt = triggerPrompt
+    self.heartbeatIntervalSeconds = heartbeatIntervalSeconds
     self.checkDescription = checkDescription
     self.modelTier = modelTier
     self.updatedBy = updatedBy
@@ -76,7 +81,8 @@ public struct NodeUpdate: Codable, Equatable, Sendable {
     goalSummary == nil && goalPredicate == nil && pollIntervalSeconds == nil
       && stallAfterSeconds == nil && metricCommand == nil && metricDirection == nil
       && tokenBudget == nil && skipsUnchangedWorkspace == nil
-      && triggerPrompt == nil && checkDescription == nil && modelTier == nil
+      && triggerPrompt == nil && heartbeatIntervalSeconds == nil
+      && checkDescription == nil && modelTier == nil
   }
 
   /// Whether this update touches what decides the loop is finished. The one edit a loop

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -66,6 +66,11 @@ public actor GraphStore {
   private let onRefinePlaybook: (@Sendable (UUID, String) -> Bool)?
   /// Restores the previous playbook, consuming a snapshot (`NodeMemory.rollbackPlaybook`).
   private let onRollbackPlaybook: (@Sendable (UUID) -> Bool)?
+  /// Whether the daemon-heartbeat experiment is on, read fresh at every gate — creation,
+  /// and every tick — so flipping the Settings toggle applies immediately. `nil` (tests
+  /// that don't care, and any client that never wires it) means off, which is the
+  /// experiment's default.
+  private let onHeartbeatEnabled: (@Sendable () -> Bool)?
   /// How many composites deep this store sits: 0 at the project root, 1 inside the
   /// first composite, and so on — see `runInSubGraph`, which increments it.
   ///
@@ -77,6 +82,12 @@ public actor GraphStore {
   static let maxSubGraphDepth = 6
   static let maxNodesPerGraph = 50
   private var goalPollers: [UUID: Task<Void, Never>] = [:]
+  /// The experiment's timers — one per heartbeat-driven time loop, alive whether the
+  /// Settings toggle is on or off. The *tick* checks the toggle, not the arming: a
+  /// timer that skips its beat costs one closure call a minute, and it means flipping
+  /// the experiment on mid-run starts existing heartbeat loops beating without anyone
+  /// re-arming anything.
+  private var heartbeatTimers: [UUID: Task<Void, Never>] = [:]
   /// Workspace fingerprint at the last *failing* predicate run, per node — what
   /// `GoalSpec.skipsUnchangedWorkspace` compares against. In-memory on purpose: a
   /// daemon restart forgetting these costs one extra predicate run, and persisting a
@@ -97,7 +108,10 @@ public actor GraphStore {
   /// harmless while every store outlived the process; `runInSubGraph` builds one per
   /// command and throws it away, so without this a goal loop inside a composite leaks a
   /// sleeping task every time anything addresses that sub-graph.
-  deinit { for poller in goalPollers.values { poller.cancel() } }
+  deinit {
+    for poller in goalPollers.values { poller.cancel() }
+    for timer in heartbeatTimers.values { timer.cancel() }
+  }
   /// Guarded edges whose re-fire is waiting on an `until` predicate — see
   /// `fireOutgoingEdges`, drained by `handle` before it broadcasts.
   private var pendingCycleReentries: [UUID] = []
@@ -147,6 +161,7 @@ public actor GraphStore {
     onRemoveMemory: (@Sendable (UUID) -> Void)? = nil,
     onRefinePlaybook: (@Sendable (UUID, String) -> Bool)? = nil,
     onRollbackPlaybook: (@Sendable (UUID) -> Bool)? = nil,
+    onHeartbeatEnabled: (@Sendable () -> Bool)? = nil,
     subGraphDepth: Int = 0
   ) {
     self.graph = graph
@@ -167,6 +182,7 @@ public actor GraphStore {
     self.onRemoveMemory = onRemoveMemory
     self.onRefinePlaybook = onRefinePlaybook
     self.onRollbackPlaybook = onRollbackPlaybook
+    self.onHeartbeatEnabled = onHeartbeatEnabled
   }
 
   private func recordMemory(_ nodeID: UUID, _ entry: String) {
@@ -234,6 +250,16 @@ public actor GraphStore {
           "composites are nested \(subGraphDepth) deep (limit \(Self.maxSubGraphDepth))")
         return
       }
+      // The experiment's gate: a heartbeat loop created while the toggle is off would
+      // sit silent looking broken, and refusal-with-a-pointer is the export precedent.
+      if let interval = draft.heartbeatIntervalSeconds, interval > 0,
+        onHeartbeatEnabled?() != true
+      {
+        announceError(
+          "heartbeat loops need the Daemon heartbeat experiment enabled in Settings "
+            + "(daemonHeartbeatEnabled in ~/.graphcode/settings.json)")
+        return
+      }
       guard draft.isValid else { return }
       var node = draft.makeNode()
       // A goal loop is born `.running`, which is right on a project canvas and a lie in a
@@ -270,6 +296,7 @@ public actor GraphStore {
       if node.loopType == .goalBased {
         armGoalPoller(for: node)
       }
+      armHeartbeat(for: node)
 
     case .createEdge(let from, let to, let spec):
       // Duplicates are scoped per kind, not per pair: a `.handoff` and a `.message`
@@ -775,6 +802,21 @@ public actor GraphStore {
         node.triggerPrompt = trimmed
         sessionFacing.append("prompt is now: \(trimmed)")
       }
+      if let interval = update.heartbeatIntervalSeconds {
+        // Setting an interval needs the experiment on; *clearing* one never does —
+        // turning the toggle off must not strand a loop with a cadence nobody can
+        // remove.
+        if interval > 0, onHeartbeatEnabled?() != true {
+          announceError(
+            "update refused: heartbeats need the Daemon heartbeat experiment enabled "
+              + "in Settings")
+          return
+        }
+        node.heartbeatIntervalSeconds = interval > 0 ? interval : nil
+        sessionFacing.append(
+          node.heartbeatIntervalSeconds.map { "the daemon now drives you every \(Int($0))s" }
+            ?? "the daemon heartbeat was removed — own your cadence again")
+      }
 
     case .turnBased:
       if let check = update.checkDescription {
@@ -808,6 +850,10 @@ public actor GraphStore {
     if node.loopType == .goalBased, !node.isResolved {
       cancelGoalPoller(nodeID)
       armGoalPoller(for: node)
+    }
+    if node.loopType == .timeBased, !node.isResolved {
+      cancelHeartbeat(nodeID)
+      armHeartbeat(for: node)
     }
 
     let author = update.updatedBy.flatMap { graph.nodes[id: $0]?.title } ?? "a human"
@@ -1039,6 +1085,7 @@ public actor GraphStore {
     graph.edges.removeAll { $0.from == node.id || $0.to == node.id }
     graph.nodes.remove(id: node.id)
     cancelGoalPoller(node.id)
+    cancelHeartbeat(node.id)
     // The summary reader keeps one modification date per node so a quiet transcript costs
     // a `stat` and no read; a deleted loop should not keep one for the life of the daemon.
     let deletedID = node.id
@@ -1135,6 +1182,9 @@ public actor GraphStore {
     }
     graph.nodes[id: node.id]?.state = .stopped
     cancelGoalPoller(node.id)
+    // The experiment's clean-stop dividend: a heartbeat loop's cadence dies here, with
+    // the timer — no typed request needed for a schedule the agent never owned.
+    cancelHeartbeat(node.id)
     recordMemory(
       node.id,
       asked
@@ -1908,6 +1958,61 @@ public actor GraphStore {
     fireOutgoingEdges(from: nodeID, sourceSucceeded: false)
   }
 
+  // MARK: - Daemon heartbeat (experimental)
+
+  /// Arms the experiment's timer for a heartbeat-driven time loop. The counterpart of
+  /// `armGoalPoller` in shape and in restraint: the timer only ever *asks* whether a
+  /// tick should fire — `deliverHeartbeat` re-checks the Settings toggle, the node, and
+  /// the session on every beat, so the timer itself holds no authority anything else
+  /// would need revoking.
+  private func armHeartbeat(for node: LoopNode) {
+    guard node.loopType == .timeBased, let interval = node.heartbeatIntervalSeconds,
+      interval > 0, onDeliverMessage != nil
+    else { return }
+    heartbeatTimers[node.id]?.cancel()
+    let nodeID = node.id
+    let beat = max(10, interval)
+    heartbeatTimers[nodeID] = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(for: .seconds(beat))
+        guard !Task.isCancelled else { return }
+        await self?.deliverHeartbeat(nodeID)
+      }
+    }
+  }
+
+  private func cancelHeartbeat(_ nodeID: UUID) {
+    heartbeatTimers.removeValue(forKey: nodeID)?.cancel()
+  }
+
+  /// One tick. Called on the timer in production and directly from tests, the
+  /// `evaluateGoal` pattern.
+  ///
+  /// Missed ticks coalesce by construction: a busy session is *skipped*, never queued —
+  /// the next beat arrives on schedule, and an agent mid-pass hearing "start a pass"
+  /// was the double-driving this experiment must not reintroduce. Skips are silent; a
+  /// heartbeat that logged every beat would turn the memory log into a metronome.
+  public func deliverHeartbeat(_ nodeID: UUID) async {
+    guard onHeartbeatEnabled?() == true else { return }
+    guard let node = graph.nodes[id: nodeID], node.loopType == .timeBased, !node.isResolved,
+      let interval = node.heartbeatIntervalSeconds, interval > 0
+    else {
+      cancelHeartbeat(nodeID)
+      return
+    }
+    guard MessageBus.deliverability(to: node) == nil else { return }
+    let presence: Presence?
+    if let onReadPresence {
+      presence = await onReadPresence(node, graph.project.path).presence
+    } else {
+      presence = node.presence?.presence
+    }
+    guard presence != .busy else { return }
+    let task = node.triggerPrompt ?? ""
+    _ = await deliverToSession(
+      node, "[graphcode] Heartbeat — run one pass of your task now: \(task)")
+  }
+
   // MARK: - Time-based session liveness
 
   /// Makes sure every unattended node in this graph — time-based and goal-based — has
@@ -1931,6 +2036,7 @@ public actor GraphStore {
         guard !node.isResolved else { continue }
         armGoalPoller(for: node)
       }
+      if !node.isResolved { armHeartbeat(for: node) }
       ensureSession(node)
     }
   }

--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -350,7 +350,8 @@ public actor ProjectRegistry {
       },
       onRollbackPlaybook: { nodeID in
         NodeMemory.rollbackPlaybook(projectPath: path, nodeID: nodeID)
-      })
+      },
+      onHeartbeatEnabled: { GraphcodeSettingsStore.load().daemonHeartbeatEnabled })
     stores[path] = newStore
     // Only on first load of this project — a time-based node's session outlives the app
     // but not a reboot, so something has to restart it, and this is the moment the

--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -126,6 +126,18 @@ struct SettingsView: View {
           .fixedSize(horizontal: false, vertical: true)
 
         Toggle(
+          "Daemon heartbeat (experimental)",
+          isOn: $model.settings.daemonHeartbeatEnabled)
+        Text(
+          "Lets the daemon drive a time-based loop on its own timer: create one with "
+            + "--heartbeat <seconds> and it is ticked from outside instead of running "
+            + "/loop on itself. Off, existing heartbeat loops fall silent immediately."
+        )
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+        Toggle(
           "Export and import loops",
           isOn: $model.settings.sharesLoops)
         Text(

--- a/graphcode/Tests/DaemonHeartbeatTests.swift
+++ b/graphcode/Tests/DaemonHeartbeatTests.swift
@@ -1,0 +1,199 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// The daemon-heartbeat experiment: a time-based loop the *daemon* ticks, behind
+/// `GraphcodeSettings.daemonHeartbeatEnabled`, default off. Ticks are driven directly
+/// (`deliverHeartbeat`) the way goal polling is — the timer is a sleep loop around
+/// exactly this call.
+@Suite
+struct DaemonHeartbeatTests {
+  private func heartbeatGraph(presence: Presence? = .idle) -> LoopGraph {
+    LoopGraph(
+      project: ProjectRef(path: "/tmp/heartbeat", name: "heartbeat"),
+      nodes: [
+        LoopNode(
+          title: "Watcher", loopType: .timeBased,
+          triggerPrompt: "check for new crash reports",
+          heartbeatIntervalSeconds: 300,
+          presence: presence.map { PresenceReading(presence: $0, confidence: .reported) },
+          state: .running)
+      ])
+  }
+
+  @Test
+  func theToggleOffMeansNoBeatEverFires() async {
+    let delivered = LockIsolated(0)
+    let graph = heartbeatGraph()
+    let store = GraphStore(
+      graph: graph,
+      onDeliverMessage: { _, _, _ in
+        delivered.withValue { $0 += 1 }
+        return true
+      },
+      onHeartbeatEnabled: { false })
+
+    await store.deliverHeartbeat(graph.nodes[0].id)
+
+    #expect(delivered.value == 0)
+  }
+
+  @Test
+  func aBeatDeliversTheTaskToAnIdleSession() async {
+    let delivered = LockIsolated<[String]>([])
+    let graph = heartbeatGraph()
+    let store = GraphStore(
+      graph: graph,
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      },
+      onHeartbeatEnabled: { true })
+
+    await store.deliverHeartbeat(graph.nodes[0].id)
+
+    #expect(delivered.value.count == 1)
+    #expect(delivered.value[0].contains("Heartbeat"))
+    #expect(delivered.value[0].contains("check for new crash reports"))
+  }
+
+  @Test
+  func aBusySessionIsSkippedNotQueued() async {
+    // Missed ticks coalesce: an agent mid-pass told to start a pass is the
+    // double-driving this experiment must not reintroduce.
+    let delivered = LockIsolated(0)
+    let presence = LockIsolated(Presence.busy)
+    let graph = heartbeatGraph(presence: .busy)
+    let store = GraphStore(
+      graph: graph,
+      onDeliverMessage: { _, _, _ in
+        delivered.withValue { $0 += 1 }
+        return true
+      },
+      onReadPresence: { _, _ in
+        PresenceReading(presence: presence.value, confidence: .reported)
+      },
+      onHeartbeatEnabled: { true })
+    let nodeID = graph.nodes[0].id
+
+    await store.deliverHeartbeat(nodeID)
+    await store.deliverHeartbeat(nodeID)
+    #expect(delivered.value == 0)
+
+    presence.setValue(.idle)
+    await store.deliverHeartbeat(nodeID)
+    #expect(delivered.value == 1)
+  }
+
+  @Test
+  func aStoppedLoopHearsNoFurtherBeats() async {
+    let delivered = LockIsolated(0)
+    let graph = heartbeatGraph()
+    let store = GraphStore(
+      graph: graph,
+      onDeliverMessage: { _, _, _ in
+        delivered.withValue { $0 += 1 }
+        return true
+      },
+      onHeartbeatEnabled: { true })
+    let nodeID = graph.nodes[0].id
+
+    await store.handle(.stopNode(nodeID))
+    await store.deliverHeartbeat(nodeID)
+
+    // The stop request itself was one delivery; the beat after must add nothing.
+    #expect(delivered.value == 1)
+  }
+
+  @Test
+  func creatingAHeartbeatLoopNeedsTheExperimentOn() async {
+    let draft = NodeDraft(
+      title: "Watcher", loopType: .timeBased,
+      triggerPrompt: "check reports", heartbeatIntervalSeconds: 300)
+
+    let gated = GraphStore(onHeartbeatEnabled: { false })
+    await gated.handle(.createNode(draft))
+    #expect(await gated.graph.nodes.isEmpty)
+
+    let open = GraphStore(onHeartbeatEnabled: { true })
+    await open.handle(.createNode(draft))
+    #expect(await open.graph.nodes.count == 1)
+  }
+
+  @Test
+  func theHeartbeatPromptOwnsTheCadenceAndSaysSo() throws {
+    let node = LoopNode(
+      title: "Watcher", loopType: .timeBased,
+      triggerPrompt: "check for new crash reports",
+      heartbeatIntervalSeconds: 300)
+    let prompt = try #require(node.sessionPrompt)
+    #expect(prompt.contains("heartbeat"))
+    #expect(prompt.contains("check for new crash reports"))
+    #expect(prompt.contains("Do not schedule your own /loop"))
+
+    // Without a heartbeat the prompt is exactly what it always was: the trigger
+    // prompt, cadence inside it, no mention of any of this.
+    let ordinary = LoopNode(
+      title: "Watcher", loopType: .timeBased, triggerPrompt: "/loop 1h check reports")
+    #expect(ordinary.sessionPrompt == "/loop 1h check reports")
+  }
+
+  @Test
+  func settingAnIntervalNeedsTheExperimentButClearingNeverDoes() async {
+    // Turning the toggle off must not strand a loop with a cadence nobody can remove.
+    let graph = heartbeatGraph()
+    let store = GraphStore(graph: graph, onHeartbeatEnabled: { false })
+    let nodeID = graph.nodes[0].id
+
+    await store.handle(.updateNode(nodeID, update: NodeUpdate(heartbeatIntervalSeconds: 60)))
+    #expect(await store.graph.nodes[0].heartbeatIntervalSeconds == 300)
+
+    await store.handle(.updateNode(nodeID, update: NodeUpdate(heartbeatIntervalSeconds: 0)))
+    #expect(await store.graph.nodes[0].heartbeatIntervalSeconds == nil)
+  }
+
+  @Test
+  func theCLIParsesHeartbeatOnCreateAndUpdate() throws {
+    let create = try GraphcodeCommand.parse([
+      "node", "create", "/tmp/p", "--title", "W", "--type", "time",
+      "--prompt", "check reports", "--heartbeat", "300",
+    ])
+    guard case .createNode(_, let draft, _) = create else {
+      Issue.record("expected createNode, got \(create)")
+      return
+    }
+    #expect(draft.heartbeatIntervalSeconds == 300)
+
+    let update = try GraphcodeCommand.parse([
+      "node", "update", "/tmp/p", UUID().uuidString, "--heartbeat", "0",
+    ])
+    guard case .updateNode(_, _, let nodeUpdate) = update else {
+      Issue.record("expected updateNode, got \(update)")
+      return
+    }
+    #expect(nodeUpdate.heartbeatIntervalSeconds == 0)
+
+    #expect(throws: GraphcodeCommand.ParseError.self) {
+      try GraphcodeCommand.parse([
+        "node", "create", "/tmp/p", "--title", "W", "--type", "time",
+        "--prompt", "check", "--heartbeat", "-5",
+      ])
+    }
+  }
+
+  @Test
+  func oldGraphsAndSettingsFilesDecodeToTheExperimentOff() throws {
+    let settings = try JSONDecoder().decode(
+      GraphcodeSettings.self, from: Data("{}".utf8))
+    #expect(settings.daemonHeartbeatEnabled == false)
+
+    let nodeJSON = """
+      {"id":"00000000-0000-0000-0000-000000000001","title":"W",\
+      "triggerPrompt":"/loop 1h check"}
+      """
+    let node = try JSONDecoder().decode(LoopNode.self, from: Data(nodeJSON.utf8))
+    #expect(node.heartbeatIntervalSeconds == nil)
+  }
+}


### PR DESCRIPTION
Item 6 from the prime-agent adoption plan — the one that reverses a founding decision (prompt-owned cadence, "the daemon holds no timers") rather than filling a gap. Shipped as a side-by-side experiment per discussion: **default off**, full plumbing present for testing, both cadence models coexist.

## Behavior
- **Settings › "Daemon heartbeat (experimental)"** (`daemonHeartbeatEnabled` in `~/.graphcode/settings.json`, default false). Read fresh at every gate — flipping it applies immediately, no restarts.
- `node create --type time --prompt <bare task> --heartbeat <seconds>`: the daemon ticks the loop — `[graphcode] Heartbeat — run one pass…` typed into the session each interval. The opening prompt states who holds the timer and forbids self-scheduling, so exactly one model ever drives a given loop.
- **Missed ticks coalesce**: a busy session is skipped, never queued (Prime Agent's coalescing semantic; also the guard against double-driving). Skips are silent — no metronome in the memory log.
- **Clean stop**: stopping a heartbeat loop cancels the timer; no typed cancel-your-cadence request needed for a schedule the agent never owned.
- **Gating**: creating with `--heartbeat`, or setting an interval via `update`, is refused with a pointer while the toggle is off (the export-gating precedent). *Clearing* (`--heartbeat 0`) always works, so turning the experiment off can never strand a loop with a cadence nobody can remove — it just falls silent immediately.
- Ordinary time-based loops are byte-for-byte unaffected: same prompt, same `/loop` cadence, no timer ever created.
- Old graphs and settings files decode with the field absent → experiment off.

## Verification
- Full suite: **940 tests in 96 suites passed**, including 9 new `DaemonHeartbeatTests` (toggle gating both ways, busy-skip coalescing, stop cancels beats, prompt composition, CLI parsing, decode compat).
- `swiftlint` + `swift format lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)