### PR TITLE
Timed-loop form: choose the daemon heartbeat

### DIFF
--- a/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
+++ b/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
@@ -193,6 +193,22 @@ struct TimedDraftFields: View {
           text: $store.draftTimedTask)
       }
 
+      if SettingsModel.shared.settings.daemonHeartbeatEnabled {
+        DraftField(
+          label: "Driven by", qualifier: "experimental",
+          help: "Heartbeat: the daemon wakes the loop each interval and holds the "
+            + "timer; the loop schedules nothing itself, and stopping it stops the "
+            + "timer. Off, the loop runs itself with /loop as always."
+        ) {
+          Picker("", selection: $store.draftUsesHeartbeat) {
+            Text("Itself, with /loop").tag(false)
+            Text("Daemon heartbeat").tag(true)
+          }
+          .pickerStyle(.segmented)
+          .labelsHidden()
+        }
+      }
+
       if !store.triggerPreview.isEmpty {
         HStack(spacing: 8) {
           Text("will run")
@@ -208,11 +224,13 @@ struct TimedDraftFields: View {
         .background(Theme.draftField, in: RoundedRectangle(cornerRadius: 8))
       }
 
-      DraftField(
-        label: "Stop after", qualifier: "optional",
-        help: "Left empty, it keeps running until you stop it."
-      ) {
-        DraftTextField(placeholder: "20 runs, or 3 days", text: $store.draftStopAfter)
+      if !store.draftUsesHeartbeat {
+        DraftField(
+          label: "Stop after", qualifier: "optional",
+          help: "Left empty, it keeps running until you stop it."
+        ) {
+          DraftTextField(placeholder: "20 runs, or 3 days", text: $store.draftStopAfter)
+        }
       }
 
       DraftField(label: "Name", qualifier: "optional") {
@@ -406,6 +424,10 @@ struct NodeDraftRecap: View {
       let cap = draft.goal?.tokenBudget.map { " Stops if it spends more than \($0) tokens." } ?? ""
       return "Starts now\(location), works toward the goal, and \(check).\(cap)"
     case .timeBased:
+      if draft.heartbeatIntervalSeconds != nil {
+        return "Starts now\(location); the daemon wakes it each interval until you "
+          + "stop it — stopping also stops the timer."
+      }
       return "Starts now\(location) and runs again on its own until you stop it."
     case .turnBased:
       return

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -74,6 +74,10 @@ struct ProjectFeature {
     /// `.timeBased`: how often, and what to do each time. GraphCode composes the `/loop`
     /// directive from the two — see `ProjectFeature.State.composedTriggerPrompt`.
     var draftInterval: IntervalChoice = .hourly
+    /// `.timeBased`, experimental: the daemon holds the timer instead of the prompt
+    /// carrying /loop. Offered by the form only while the Settings toggle is on;
+    /// always defaults off, per loop — enabling the experiment converts nothing.
+    var draftUsesHeartbeat = false
     var draftCustomInterval = ""
     var draftTimedTask = ""
     var draftStopAfter = ""
@@ -686,6 +690,7 @@ extension ProjectFeature {
     state.draftPausesBeforeWritesOnly = false
     state.draftSketchNote = ""
     state.draftInterval = .hourly
+    state.draftUsesHeartbeat = false
     state.draftCustomInterval = ""
     state.draftTimedTask = ""
     state.draftStopAfter = ""

--- a/graphcode/Sources/Features/Project/ProjectFeatureState.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeatureState.swift
@@ -48,6 +48,8 @@ extension ProjectFeature.State {
       loopType: draftLoopType,
       checkDescription: draftLoopType == .turnBased ? draftCheck : nil,
       triggerPrompt: composedTriggerPrompt,
+      heartbeatIntervalSeconds: draftLoopType == .timeBased && draftUsesHeartbeat
+        ? draftHeartbeatSeconds : nil,
       firstInstruction: {
         switch draftLoopType {
         case .turnBased: return draftFirstInstruction
@@ -96,6 +98,10 @@ extension ProjectFeature.State {
     case .timeBased:
       let task = draftTimedTask.trimmingCharacters(in: .whitespaces)
       guard !task.isEmpty else { return nil }
+      // Heartbeat mode: the daemon holds the timer, so the prompt is the bare task —
+      // `LoopNode.sessionPrompt` wraps it in the who-holds-the-timer framing at
+      // launch. No /loop, and no "Stop after": a heartbeat loop runs until stopped.
+      if draftUsesHeartbeat { return task }
       var directive = "/loop \(draftInterval.directiveValue(custom: draftCustomInterval)) \(task)"
       let stop = draftStopAfter.trimmingCharacters(in: .whitespaces)
       if !stop.isEmpty { directive += " Stop after \(stop)." }
@@ -109,7 +115,46 @@ extension ProjectFeature.State {
 
   /// The mono line the dialog shows under the interval control, so what will be written
   /// is visible before it is written.
-  var triggerPreview: String { composedTriggerPrompt ?? "" }
+  var triggerPreview: String {
+    if draftLoopType == .timeBased, draftUsesHeartbeat,
+      !draftTimedTask.trimmingCharacters(in: .whitespaces).isEmpty
+    {
+      let interval = draftInterval.directiveValue(custom: draftCustomInterval)
+      return "[graphcode] heartbeat every \(interval) — the daemon holds the timer"
+    }
+    return composedTriggerPrompt ?? ""
+  }
+
+  /// The form's interval as the seconds `LoopNode.heartbeatIntervalSeconds` stores.
+  /// A custom value nobody can parse falls back to an hour, the same forgiveness
+  /// `IntervalChoice.directiveValue` shows a blank one — the /loop path hands garbage
+  /// to an agent that can interpret it, but a timer needs a number.
+  var draftHeartbeatSeconds: Double {
+    switch draftInterval {
+    case .quarterHour: return 900
+    case .hourly: return 3600
+    case .sixHourly: return 21600
+    case .daily: return 86400
+    case .custom:
+      return Self.seconds(fromInterval: draftCustomInterval) ?? 3600
+    }
+  }
+
+  /// "90s", "30m", "2h", "3d" — bare digits count as minutes, matching what people
+  /// type into the /loop field today.
+  static func seconds(fromInterval text: String) -> Double? {
+    let trimmed = text.trimmingCharacters(in: .whitespaces).lowercased()
+    guard !trimmed.isEmpty else { return nil }
+    let digits = trimmed.hasSuffix("s") || trimmed.hasSuffix("m") || trimmed.hasSuffix("h")
+      || trimmed.hasSuffix("d") ? String(trimmed.dropLast()) : trimmed
+    guard let value = Double(digits), value > 0 else { return nil }
+    switch trimmed.last {
+    case "s": return value
+    case "h": return value * 3600
+    case "d": return value * 86400
+    default: return value * 60
+    }
+  }
 
   /// What the promotion form currently means — nil while its one required field is
   /// empty. Computed like `draft`, so there is exactly one definition of it.

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -226,6 +226,54 @@ struct ProjectFeatureTests {
       #expect(state.draft.goal?.tokenBudget == nil, "\(junk) should mean no budget")
     }
   }
+
+  /// The form's "Driven by" choice becomes the draft's cadence model: heartbeat mode
+  /// sends the bare task plus an interval in seconds, /loop mode composes the
+  /// directive exactly as it always has.
+  @Test
+  @MainActor
+  func theCadenceChoiceTravelsIntoTheDraft() {
+    var state = ProjectFeature.State(graph: LoopGraph(project: Self.testProject))
+    state.draftLoopType = .timeBased
+    state.draftTimedTask = "check for new crash reports"
+    state.draftInterval = .quarterHour
+    state.draftStopAfter = "20 runs"
+
+    // Default: prompt-owned, /loop composed, stop-after included, no interval stored.
+    var draft = state.draft
+    #expect(draft.triggerPrompt == "/loop 15m check for new crash reports Stop after 20 runs.")
+    #expect(draft.heartbeatIntervalSeconds == nil)
+
+    // Heartbeat: bare task, interval in seconds, and the stop-after clause dropped —
+    // a heartbeat loop runs until stopped, and a clause the daemon can't honour must
+    // not ride into the prompt looking honoured.
+    state.draftUsesHeartbeat = true
+    draft = state.draft
+    #expect(draft.triggerPrompt == "check for new crash reports")
+    #expect(draft.heartbeatIntervalSeconds == 900)
+  }
+
+  @Test
+  @MainActor
+  func customIntervalsParseIntoSecondsWithAnHonestFallback() {
+    #expect(ProjectFeature.State.seconds(fromInterval: "90s") == 90)
+    #expect(ProjectFeature.State.seconds(fromInterval: "30m") == 1800)
+    #expect(ProjectFeature.State.seconds(fromInterval: "2h") == 7200)
+    #expect(ProjectFeature.State.seconds(fromInterval: "3d") == 259_200)
+    // Bare digits are minutes, matching what people type into the /loop field.
+    #expect(ProjectFeature.State.seconds(fromInterval: "45") == 2700)
+    #expect(ProjectFeature.State.seconds(fromInterval: "tomorrow") == nil)
+
+    var state = ProjectFeature.State(graph: LoopGraph(project: Self.testProject))
+    state.draftLoopType = .timeBased
+    state.draftTimedTask = "check"
+    state.draftUsesHeartbeat = true
+    state.draftInterval = .custom
+    state.draftCustomInterval = "tomorrow"
+    // A timer needs a number where an agent could have interpreted prose; the
+    // fallback is the same hour a blank custom /loop interval gets.
+    #expect(state.draft.heartbeatIntervalSeconds == 3600)
+  }
 }
 
 private actor SentGraphCommandsBox {


### PR DESCRIPTION
Closes the gap found in testing #136: the experiment was CLI-only — the app's timed-loop form composed `/loop` unconditionally, so canvas-created loops could never be heartbeat-driven regardless of the Settings toggle.

- While **Daemon heartbeat (experimental)** is on, the form shows a "Driven by" segmented choice: *Itself, with /loop* (default — enabling the experiment converts nothing) vs *Daemon heartbeat*. Toggle off, the form is byte-for-byte unchanged.
- Heartbeat mode sends the bare task plus the interval picker's value in seconds (`15m`→900 etc.; custom `90s/30m/2h/3d` parsed, bare digits as minutes, unparsable → 1h fallback since a timer needs a number where an agent could have interpreted prose).
- **"Stop after" hides in heartbeat mode** — the daemon can't honor "20 runs", and a clause riding into the prompt looking honored would be a lie.
- The preview line shows the beat (`[graphcode] heartbeat every 15m — the daemon holds the timer`) instead of the `/loop` directive; the recap notes stopping also stops the timer.

## Verification
Full suite **942 tests in 96 suites passed**, including two new form-to-draft tests (cadence choice travels; custom-interval parsing with honest fallback). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)