### PR TITLE
New Child Loop in the canvas and sidebar context menus

### DIFF
--- a/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
@@ -153,6 +153,15 @@ extension AppSidebarView {
   func nodeMenu(for node: LoopNode, in projectPath: String) -> some View {
     Button("Open Terminal") { send(.nodeTapped(node.id), to: projectPath) }
 
+    // Selects the project first: the creation sheet presents from that project's
+    // canvas, and a form opened on a canvas that isn't showing opens nowhere.
+    if !node.isResolved {
+      Button("New Child Loop…") {
+        store.send(.projectHeaderTapped(projectPath))
+        send(.addChildNodeTapped(node.id), to: projectPath)
+      }
+    }
+
     if node.loopType == .composite {
       Button("Pilot Once…") { send(.pilotCompositeTapped(node.id), to: projectPath) }
       Button("Arm Schedule") { send(.armCompositeTapped(node.id), to: projectPath) }

--- a/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
@@ -54,6 +54,12 @@ extension ProjectCanvasView {
   @ViewBuilder
   private func nodeMenu(for node: LoopNode) -> some View {
     Button("Open Terminal") { store.send(.nodeTapped(node.id)) }
+    // The + handle's verb, findable where every other loop verb lives. Hidden on a
+    // resolved loop: its hand-off edges have already fired, so a child created now
+    // would wait on a parent that can never release it.
+    if !node.isResolved {
+      Button("New Child Loop…") { store.send(.addChildNodeTapped(node.id)) }
+    }
     if node.loopType == .composite {
       // First, because it is the step everything else depends on: a composite with
       // nothing inside can be piloted and armed and still do nothing at all.

--- a/graphcode/Sources/Features/Project/ProjectFeatureState.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeatureState.swift
@@ -145,8 +145,9 @@ extension ProjectFeature.State {
   static func seconds(fromInterval text: String) -> Double? {
     let trimmed = text.trimmingCharacters(in: .whitespaces).lowercased()
     guard !trimmed.isEmpty else { return nil }
-    let digits = trimmed.hasSuffix("s") || trimmed.hasSuffix("m") || trimmed.hasSuffix("h")
-      || trimmed.hasSuffix("d") ? String(trimmed.dropLast()) : trimmed
+    let digits =
+      trimmed.hasSuffix("s") || trimmed.hasSuffix("m") || trimmed.hasSuffix("h")
+        || trimmed.hasSuffix("d") ? String(trimmed.dropLast()) : trimmed
     guard let value = Double(digits), value > 0 else { return nil }
     switch trimmed.last {
     case "s": return value


### PR DESCRIPTION
Exposes the existing child-creation flow (`.addChildNodeTapped`: parent's backend inherited, hand-off edge drawn on Create — the `+` connector handle's verb) through both right-click menus:

- **Canvas card** → *New Child Loop…* opens the creation form preset with that parent.
- **Sidebar loop row** → same, preceded by `.projectHeaderTapped` so the project's canvas is frontmost — the creation sheet presents from that canvas, and a form opened on a canvas that isn't showing opens nowhere.
- Hidden on **resolved** loops: their hand-off edges have already fired, so a child created now would sit blocked on a parent that can never release it (the stranded-blocked case `AttentionRollup` exists to catch).

Also carries a gate fix in its own commit: `swift format lint` failed on main after #138 (the interval parser's ternary; that PR's lint step was piped through `head` and didn't gate the chain) — formatted, no behavior change.

## Verification
Full suite **942 tests in 96 suites passed**; `swift format lint --strict` and `swiftlint` clean including the gate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)