### PR TITLE
New Child Loop makes a custody child; blocked-but-live loops open

### DIFF
--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -279,6 +279,16 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
   /// downstream edges are waiting on. This is the presentation of that fact, not a
   /// revision of it.
   ///
+  /// Whether the last presence reading says a session actually exists to attach to.
+  /// `nil` and `.unknown` count as no: opening is what could *start* a session, and a
+  /// gate deciding whether that's safe must not treat "don't know" as "yes".
+  public var presenceShowsLiveSession: Bool {
+    switch presence?.presence {
+    case .busy, .idle, .awaitingInput: return true
+    case .absent, .unknown, nil: return false
+    }
+  }
+
   /// A backend that reports nothing leaves `presence` nil and this returns `state`
   /// untouched, which is exactly the behaviour every surface had before presence existed.
   public var displayState: LoopState {

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -504,8 +504,13 @@ struct AppFeature {
         // now its recurrence runs inside an ordinary interactive session (see
         // `LoopNode.triggerPrompt`), so there's a real terminal to attach to — which is
         // the point, since watching and steering a running loop is most of its value.
+        // A blocked node with a *live session* still opens: creation starts an
+        // unattended child's session before a follow-up hand-off edge marks it
+        // blocked, so blocked-but-running is a state people actually meet — and a
+        // terminal that exists must be reachable. What stays gated is the blocked
+        // node with no session, where opening would *start* sequenced work early.
         guard let node = state.projects[id: path]?.graph.nodes[id: nodeID],
-          node.state != .blocked
+          node.state != .blocked || node.presenceShowsLiveSession
         else { return .none }
         let layout = terminalLayoutStore.load(forNode: nodeID) ?? .defaultLayout(forNode: nodeID)
         state.openLoop = LoopWorkspaceFeature.State(

--- a/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
@@ -158,7 +158,7 @@ extension AppSidebarView {
     if !node.isResolved {
       Button("New Child Loop…") {
         store.send(.projectHeaderTapped(projectPath))
-        send(.addChildNodeTapped(node.id), to: projectPath)
+        send(.newChildLoopTapped(node.id), to: projectPath)
       }
     }
 

--- a/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
@@ -58,7 +58,7 @@ extension ProjectCanvasView {
     // resolved loop: its hand-off edges have already fired, so a child created now
     // would wait on a parent that can never release it.
     if !node.isResolved {
-      Button("New Child Loop…") { store.send(.addChildNodeTapped(node.id)) }
+      Button("New Child Loop…") { store.send(.newChildLoopTapped(node.id)) }
     }
     if node.loopType == .composite {
       // First, because it is the step everything else depends on: a composite with

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -92,6 +92,9 @@ struct ProjectFeature {
     /// hangs off. Creation then also draws a hand-off edge from it — see
     /// `createNodeConfirmed`.
     var draftParentNodeID: UUID?
+    /// Whether the open form makes a custody child (`.newChildLoopTapped`) rather
+    /// than a handed-off one (`.addChildNodeTapped`).
+    var draftParentIsCustodial = false
     /// Worktrees already present in this project's repository, loaded when the form
     /// opens. Empty for a folder that isn't a git repo — the picker then only offers
     /// "None" and "New branch", and creating one simply fails and reports why.
@@ -174,6 +177,12 @@ struct ProjectFeature {
     /// The + handle on a node card: opens the same form, and the created loop gets a
     /// hand-off edge from this node.
     case addChildNodeTapped(UUID)
+    /// The context menus' "New Child Loop…": a *custody* child — `createdBy` set, the
+    /// daemon draws the already-fired link, the loop starts now. Distinct from
+    /// `.addChildNodeTapped` (the + handle), which wires an unfired hand-off that
+    /// sequences the new loop *after* the parent — under a long-running parent that
+    /// meant a loop blocked indefinitely while its session already ran.
+    case newChildLoopTapped(UUID)
     case createNodeConfirmed
     case cancelNewNodeForm
     case nodeTapped(UUID)
@@ -313,90 +322,17 @@ struct ProjectFeature {
         return openNodeForm(
           &state, backend: state.graph.nodes[id: parentID]?.backend, parentNodeID: parentID)
 
+      case .newChildLoopTapped(let parentID):
+        return openNodeForm(
+          &state, backend: state.graph.nodes[id: parentID]?.backend, parentNodeID: parentID,
+          custodial: true)
+
       case .cancelNewNodeForm:
         state.showingNewNodeForm = false
         return .none
 
       case .createNodeConfirmed:
-        let draft = state.draft
-        // `isValid` carries the same rules the daemon enforces, so an incomplete form
-        // simply doesn't submit — the Create button is disabled on it too, and this is
-        // the backstop for the keyboard shortcut path.
-        guard draft.isValid else { return .none }
-        UserDefaults.standard.set(draft.loopType.rawValue, forKey: Self.lastLoopTypeKey)
-        let projectPath = state.graph.project.path
-        // A form opened from a node card's + handle also wires the new loop up: a
-        // default hand-off edge from the parent, created right after the node so the
-        // graph never broadcasts a child floating unconnected.
-        let parentNodeID = state.draftParentNodeID
-        state.draftParentNodeID = nil
-        state.showingNewNodeForm = false
-        // Inside a composite, the same commands are addressed at its sub-graph. This is
-        // the app half of "add loops inside" — the step the dialog's own strip promises.
-        let insideComposite = state.openCompositeID
-        // **Create & open**, honoured: a composite made from the project canvas opens
-        // straight away, which is what its button has always said it would do. Only from
-        // the top level — a composite created inside another would otherwise take the
-        // canvas somewhere the human didn't ask to go.
-        if draft.loopType == .composite, insideComposite == nil {
-          state.openCompositeID = draft.id
-        }
-        // A loop created from the form switches to itself once its broadcast lands —
-        // see `pendingCreatedNodeID`. Not composites: opening their sub-graph canvas
-        // (above) already is the switch. Not inside a composite either: the drilled-in
-        // canvas the human is looking at is where the new card appears, and workspace
-        // opening (`AppFeature`'s `.nodeTapped`) only reaches top-level nodes anyway.
-        if draft.loopType != .composite, insideComposite == nil {
-          state.pendingCreatedNodeID = draft.id
-        }
-
-        // Creating the worktree is the app's job, not the daemon's: `GitClient` lives
-        // here, and a failure needs somewhere to be shown. If it fails, the node is
-        // still created — unbound rather than not at all — since losing the loop over a
-        // branch that already exists would be the more annoying outcome.
-        let request = state.newWorktreeRequest
-        return .run { send in
-          var resolved = draft
-          if let request {
-            do {
-              resolved.worktree = try await gitClient.createWorktree(
-                request.repositoryPath, request.worktreePath, request.branch)
-            } catch {
-              await send(.worktreeCreationFailed(String(describing: error)))
-            }
-          }
-          func addressed(_ command: GraphCommand) -> GraphCommand {
-            insideComposite.map { .subGraphCommand(nodeID: $0, command: command) } ?? command
-          }
-          try? await orchestratorClient.send(
-            .graphCommand(projectPath: projectPath, command: addressed(.createNode(resolved))))
-          if let parentNodeID {
-            try? await orchestratorClient.send(
-              .graphCommand(
-                projectPath: projectPath,
-                command: addressed(
-                  .createEdge(from: parentNodeID, to: draft.id, spec: EdgeSpec()))))
-          }
-
-          // A blank title creates the node as "New Loop" and asks the loop's own
-          // backend for a real one — after creation, so a slow (or absent) CLI never
-          // holds the node itself hostage. The rename can target the node because the
-          // draft's id *is* the node's id (see `NodeDraft.id`); no answer just means
-          // the fallback name stays.
-          guard draft.title.trimmingCharacters(in: .whitespaces).isEmpty,
-            let basis = [
-              draft.checkDescription, draft.triggerPrompt, draft.goal?.summary,
-              draft.firstInstruction,
-            ]
-            .compactMap({ $0 })
-            .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }),
-            let title = await titleSuggestionClient.suggest(
-              draft.effectiveBackend, basis, loopTitleDirectory.allTitles())
-          else { return }
-          try? await orchestratorClient.send(
-            .graphCommand(
-              projectPath: projectPath, command: addressed(.renameNode(draft.id, title: title))))
-        }
+        return confirmCreateNode(&state)
 
       case .worktreeCreationFailed(let message):
         state.connectionError = "Couldn't create worktree: \(message)"
@@ -669,8 +605,99 @@ extension ProjectFeature {
     }
   }
 
+  /// The Create button's whole handler — in the trailing extension beside
+  /// `openNodeForm` and the rest of the form's helpers, and for the same reason.
+  private func confirmCreateNode(_ state: inout State) -> Effect<Action> {
+    let draft = state.draft
+    // `isValid` carries the same rules the daemon enforces, so an incomplete form
+    // simply doesn't submit — the Create button is disabled on it too, and this is
+    // the backstop for the keyboard shortcut path.
+    guard draft.isValid else { return .none }
+    UserDefaults.standard.set(draft.loopType.rawValue, forKey: Self.lastLoopTypeKey)
+    let projectPath = state.graph.project.path
+    // A form opened from a node card's + handle also wires the new loop up: a
+    // default hand-off edge from the parent, created right after the node so the
+    // graph never broadcasts a child floating unconnected.
+    let parentNodeID = state.draftParentNodeID
+    let custodial = state.draftParentIsCustodial
+    state.draftParentNodeID = nil
+    state.draftParentIsCustodial = false
+    state.showingNewNodeForm = false
+    // Inside a composite, the same commands are addressed at its sub-graph. This is
+    // the app half of "add loops inside" — the step the dialog's own strip promises.
+    let insideComposite = state.openCompositeID
+    // **Create & open**, honoured: a composite made from the project canvas opens
+    // straight away, which is what its button has always said it would do. Only from
+    // the top level — a composite created inside another would otherwise take the
+    // canvas somewhere the human didn't ask to go.
+    if draft.loopType == .composite, insideComposite == nil {
+      state.openCompositeID = draft.id
+    }
+    // A loop created from the form switches to itself once its broadcast lands —
+    // see `pendingCreatedNodeID`. Not composites: opening their sub-graph canvas
+    // (above) already is the switch. Not inside a composite either: the drilled-in
+    // canvas the human is looking at is where the new card appears, and workspace
+    // opening (`AppFeature`'s `.nodeTapped`) only reaches top-level nodes anyway.
+    if draft.loopType != .composite, insideComposite == nil {
+      state.pendingCreatedNodeID = draft.id
+    }
+
+    // Creating the worktree is the app's job, not the daemon's: `GitClient` lives
+    // here, and a failure needs somewhere to be shown. If it fails, the node is
+    // still created — unbound rather than not at all — since losing the loop over a
+    // branch that already exists would be the more annoying outcome.
+    let request = state.newWorktreeRequest
+    return .run { send in
+      var resolved = draft
+      // A custody child carries its parent on the draft; the daemon draws the
+      // fired-at-birth link and writes the report-back memo, exactly as it does
+      // for a CLI-created child. No separate edge command, so nothing blocks.
+      if custodial, let parentNodeID { resolved.createdBy = parentNodeID }
+      if let request {
+        do {
+          resolved.worktree = try await gitClient.createWorktree(
+            request.repositoryPath, request.worktreePath, request.branch)
+        } catch {
+          await send(.worktreeCreationFailed(String(describing: error)))
+        }
+      }
+      func addressed(_ command: GraphCommand) -> GraphCommand {
+        insideComposite.map { .subGraphCommand(nodeID: $0, command: command) } ?? command
+      }
+      try? await orchestratorClient.send(
+        .graphCommand(projectPath: projectPath, command: addressed(.createNode(resolved))))
+      if let parentNodeID, !custodial {
+        try? await orchestratorClient.send(
+          .graphCommand(
+            projectPath: projectPath,
+            command: addressed(
+              .createEdge(from: parentNodeID, to: draft.id, spec: EdgeSpec()))))
+      }
+
+      // A blank title creates the node as "New Loop" and asks the loop's own
+      // backend for a real one — after creation, so a slow (or absent) CLI never
+      // holds the node itself hostage. The rename can target the node because the
+      // draft's id *is* the node's id (see `NodeDraft.id`); no answer just means
+      // the fallback name stays.
+      guard draft.title.trimmingCharacters(in: .whitespaces).isEmpty,
+        let basis = [
+          draft.checkDescription, draft.triggerPrompt, draft.goal?.summary,
+          draft.firstInstruction,
+        ]
+        .compactMap({ $0 })
+        .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }),
+        let title = await titleSuggestionClient.suggest(
+          draft.effectiveBackend, basis, loopTitleDirectory.allTitles())
+      else { return }
+      try? await orchestratorClient.send(
+        .graphCommand(
+          projectPath: projectPath, command: addressed(.renameNode(draft.id, title: title))))
+    }
+  }
+
   private func openNodeForm(
-    _ state: inout State, backend: CLISessionBackendKind?, parentNodeID: UUID?
+    _ state: inout State, backend: CLISessionBackendKind?, parentNodeID: UUID?,
+    custodial: Bool = false
   ) -> Effect<Action> {
     state.draftID = UUID()
     state.draftLoopType = Self.rememberedLoopType
@@ -702,6 +729,7 @@ extension ProjectFeature {
     state.draftWorktree = .none
     state.draftBranch = ""
     state.draftParentNodeID = parentNodeID
+    state.draftParentIsCustodial = custodial
     state.showingNewNodeForm = true
     let repositoryPath = state.graph.project.path
     return .run { send in

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -274,6 +274,104 @@ struct ProjectFeatureTests {
     // fallback is the same hour a blank custom /loop interval gets.
     #expect(state.draft.heartbeatIntervalSeconds == 3600)
   }
+
+  /// "New Child Loop…" makes a *custody* child: `createdBy` rides the draft (the
+  /// daemon draws the fired-at-birth link) and no separate edge command follows — a
+  /// hand-off from a long-running parent left the child blocked indefinitely while
+  /// its session already ran.
+  @Test
+  @MainActor
+  func newChildLoopCreatesACustodyChildNotAHandoff() async {
+    let parent = LoopNode(
+      title: "Parent", loopType: .goalBased, goal: GoalSpec(summary: "run forever"),
+      state: .running)
+    let sent = SentGraphCommandsBox()
+    let store = TestStore(
+      initialState: ProjectFeature.State(
+        graph: LoopGraph(project: Self.testProject, nodes: [parent]))
+    ) {
+      ProjectFeature()
+    } withDependencies: {
+      $0.gitClient.listWorktrees = { _ in [] }
+      $0.orchestratorClient.send = { command in await sent.append(command) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.newChildLoopTapped(parent.id))
+    await store.send(.binding(.set(\.draftTitle, "Child")))
+    await store.send(.binding(.set(\.draftGoal, "help out")))
+    await store.send(.createNodeConfirmed)
+    await store.finish()
+
+    let commands = await sent.commands
+    guard case .graphCommand(_, .createNode(let draft)) = commands.first else {
+      return #expect(Bool(false), "expected a createNode command, got \(commands)")
+    }
+    #expect(draft.createdBy == parent.id)
+    #expect(draft.backend == parent.backend)
+    let edgeCommands = commands.filter {
+      if case .graphCommand(_, .createEdge) = $0 { return true } else { return false }
+    }
+    #expect(edgeCommands.isEmpty)
+  }
+
+  /// The + handle keeps its sequencing semantic: an unfired hand-off from the parent,
+  /// and no custody claim on the draft.
+  @Test
+  @MainActor
+  func thePlusHandleStillWiresAHandoff() async {
+    let parent = LoopNode(
+      title: "Parent", loopType: .goalBased, goal: GoalSpec(summary: "finish soon"),
+      state: .running)
+    let sent = SentGraphCommandsBox()
+    let store = TestStore(
+      initialState: ProjectFeature.State(
+        graph: LoopGraph(project: Self.testProject, nodes: [parent]))
+    ) {
+      ProjectFeature()
+    } withDependencies: {
+      $0.gitClient.listWorktrees = { _ in [] }
+      $0.orchestratorClient.send = { command in await sent.append(command) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.addChildNodeTapped(parent.id))
+    await store.send(.binding(.set(\.draftTitle, "Next")))
+    await store.send(.binding(.set(\.draftGoal, "take over")))
+    await store.send(.createNodeConfirmed)
+    await store.finish()
+
+    let commands = await sent.commands
+    guard case .graphCommand(_, .createNode(let draft)) = commands.first else {
+      return #expect(Bool(false), "expected a createNode command, got \(commands)")
+    }
+    #expect(draft.createdBy == nil)
+    #expect(
+      commands.contains {
+        guard case .graphCommand(_, .createEdge(let from, let to, _)) = $0 else { return false }
+        return from == parent.id && to == draft.id
+      })
+  }
+
+  /// The workspace gate's live-session reading: presence is the only honest signal
+  /// for "there is a terminal to attach to", and "don't know" must not open a blocked
+  /// node — opening is what could start sequenced work early.
+  @Test
+  @MainActor
+  func blockedNodesOpenExactlyWhenPresenceShowsALiveSession() {
+    func node(_ presence: Presence?) -> LoopNode {
+      LoopNode(
+        title: "B", loopType: .timeBased, triggerPrompt: "/loop 1h x",
+        presence: presence.map { PresenceReading(presence: $0, confidence: .reported) },
+        state: .blocked)
+    }
+    #expect(node(.busy).presenceShowsLiveSession)
+    #expect(node(.idle).presenceShowsLiveSession)
+    #expect(node(.awaitingInput).presenceShowsLiveSession)
+    #expect(!node(.absent).presenceShowsLiveSession)
+    #expect(!node(.unknown).presenceShowsLiveSession)
+    #expect(!node(nil).presenceShowsLiveSession)
+  }
 }
 
 private actor SentGraphCommandsBox {


### PR DESCRIPTION
Fixes the stuck state reported with a right-click-created child (`Recurring Greeting`: blocked indefinitely under a long-running parent, unclickable, while its session sat live at a prompt).

## Defect 1 — the menus delivered the wrong semantic
"New Child Loop…" (#139) reused `.addChildNodeTapped` — the `+` connector handle's flow, which wires an **unfired hand-off** ("start after the parent finishes"). Under a parent that won't finish, that's an indefinitely blocked child. The name promises what CLI children get.

**Fix:** a new `.newChildLoopTapped` action for both menus: `createdBy` rides the draft, the daemon draws the **fired-at-birth custody link** and writes the report-back memo — identical to `graphcode node create` from inside a loop — and no edge command is sent, so nothing can block. The `+` handles keep the sequencing semantic, now the only place that has it.

## Defect 2 — the click gate assumed blocked = no session
Creation starts an unattended child's session *before* the follow-up edge marks it blocked, so blocked-but-running is reachable in practice — and `nodeTapped` refused it flat, making a live terminal unreachable.

**Fix:** `LoopNode.presenceShowsLiveSession` — the gate opens a blocked node when presence reads `busy`/`idle`/`awaitingInput`. `absent`/`unknown`/never-reported stay gated: opening could *start* sequenced work early, and "don't know" must not read as "yes".

## Rider
`createNodeConfirmed`'s handler moved whole into the trailing extension — the additions tipped `ProjectFeature` over swiftlint's type-body budget a third time; a real extraction beats another one-line shave.

## Verification
Full suite **945 tests in 96 suites passed**, including three new tests: custody children send `createdBy` and zero edge commands; the `+` handle still wires its hand-off; the presence truth-table for the gate. Lint clean (both tools, exit codes checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)