### PR TITLE
Heartbeat is the default for new timed loops while the experiment is on

### DIFF
--- a/GraphcodeKit/Sources/Domain/SessionBriefing.swift
+++ b/GraphcodeKit/Sources/Domain/SessionBriefing.swift
@@ -44,8 +44,37 @@ public enum SessionBriefing {
   /// The briefing for a node in `projectPath`'s graph, or `nil` when there's no path to
   /// tell it about — every command the briefing describes takes one, so a briefing
   /// without it would describe commands the session can't run.
-  public static func text(projectPath: String?) -> String? {
+  public static func text(
+    projectPath: String?, settings: GraphcodeSettings = GraphcodeSettingsStore.load()
+  ) -> String? {
     guard let projectPath, !projectPath.isEmpty else { return nil }
+    // The daemon-heartbeat experiment flips the *default* for time-based loops, and
+    // the briefing has to teach whichever model is current — an agent following
+    // yesterday's cadence-in-prompt guidance under today's default would make loops
+    // the human just said they no longer want by default.
+    let timeBullet =
+      settings.daemonHeartbeatEnabled
+      ? """
+      - `--type time --heartbeat <seconds> --prompt <the bare task>` — for work that never
+        finishes because it repeats: watching, polling, monitoring, anything phrased as
+        "every hour", "keep checking", "each morning". Also starts immediately.
+        **The daemon drives it**: a heartbeat is typed into the session each interval, and
+        the prompt is the bare task — no `/loop`, no cron, no self-scheduling. Only when
+        the loop must own its own cadence (self-pacing, a complex schedule), omit
+        `--heartbeat` and write the directive into the prompt (`/loop 1h …`) instead.
+        Do not reach for this for one-off work: "check the build" is a goal, "check the
+        build every hour" is time-based.
+      """
+      : """
+      - `--type time --prompt <prompt carrying its own cadence>` — for work that never
+        finishes because it repeats: watching, polling, monitoring, anything phrased as
+        "every hour", "keep checking", "each morning". Also starts immediately.
+        **The cadence goes inside the prompt**, as a directive the session runs on itself
+        (`/loop 1h Check for new reports`, `/schedule …`) — graphcode holds no timer of its
+        own, so a time-based loop whose prompt carries no cadence just runs once and stops.
+        Do not reach for this for one-off work: "check the build" is a goal, "check the
+        build every hour" is time-based.
+      """
     return """
       # You are a loop in a graphcode graph
 
@@ -79,14 +108,7 @@ public enum SessionBriefing {
         finishes the goal. Add `--predicate <shell command>` only when a command can
         actually decide it (exit 0 means met, e.g. a test run); without one, finishing the
         work is what resolves it.
-      - `--type time --prompt <prompt carrying its own cadence>` — for work that never
-        finishes because it repeats: watching, polling, monitoring, anything phrased as
-        "every hour", "keep checking", "each morning". Also starts immediately.
-        **The cadence goes inside the prompt**, as a directive the session runs on itself
-        (`/loop 1h Check for new reports`, `/schedule …`) — graphcode holds no timer of its
-        own, so a time-based loop whose prompt carries no cadence just runs once and stops.
-        Do not reach for this for one-off work: "check the build" is a goal, "check the
-        build every hour" is time-based.
+      \(timeBullet.trimmingCharacters(in: .whitespacesAndNewlines))
       - `--type turn --check <what a human verifies>` — for work a **human** must review
         each turn before it continues. **A turn-based loop does not start on its own**:
         nothing runs until a person opens its terminal. Create one only when a human really
@@ -100,7 +122,7 @@ public enum SessionBriefing {
       | "spin up five loops and have each say hello" | `goal` ×5 | Nobody needs to approve a greeting, and it ends when it has been said. Turn-based ones would never even run. |
       | "fix each of these five issues" | `goal` ×5, `--predicate` if a test proves it | The work decides when it is done. |
       | "fix these five, I want to review each fix" | `turn` ×5 | You have been told a human stands between turns. |
-      | "watch for new issues every hour and triage them" | `time` ×1 | It recurs; the cadence goes in the prompt. One watcher that fans out beats five identical watchers. |
+      | "watch for new issues every hour and triage them" | `time` ×1 | It recurs. One watcher that fans out beats five identical watchers. |
 
       `graphcode status \(projectPath)` lists the loops that already exist. Check it before
       creating any, so you extend the graph rather than duplicating it.

--- a/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
+++ b/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
@@ -196,9 +196,9 @@ struct TimedDraftFields: View {
       if SettingsModel.shared.settings.daemonHeartbeatEnabled {
         DraftField(
           label: "Driven by", qualifier: "experimental",
-          help: "Heartbeat: the daemon wakes the loop each interval and holds the "
-            + "timer; the loop schedules nothing itself, and stopping it stops the "
-            + "timer. Off, the loop runs itself with /loop as always."
+          help: "Heartbeat (the default while the experiment is on): the daemon wakes "
+            + "the loop each interval and holds the timer; stopping the loop stops the "
+            + "timer. Pick /loop to have the loop schedule itself instead."
         ) {
           Picker("", selection: $store.draftUsesHeartbeat) {
             Text("Itself, with /loop").tag(false)

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -717,7 +717,13 @@ extension ProjectFeature {
     state.draftPausesBeforeWritesOnly = false
     state.draftSketchNote = ""
     state.draftInterval = .hourly
-    state.draftUsesHeartbeat = false
+    // While the experiment is on, the daemon heartbeat is the *default* for new timed
+    // loops — the /loop skill runs only when a person explicitly picks "Itself, with
+    // /loop" in the form. The toggle governing a default rather than mere availability
+    // is a deliberate, user-directed reversal of the earlier converts-nothing stance;
+    // existing loops are still never converted. Same settings read the defaultBackend
+    // line below already does.
+    state.draftUsesHeartbeat = GraphcodeSettingsStore.load().daemonHeartbeatEnabled
     state.draftCustomInterval = ""
     state.draftTimedTask = ""
     state.draftStopAfter = ""

--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -129,9 +129,10 @@ struct SettingsView: View {
           "Daemon heartbeat (experimental)",
           isOn: $model.settings.daemonHeartbeatEnabled)
         Text(
-          "Lets the daemon drive a time-based loop on its own timer: create one with "
-            + "--heartbeat <seconds> and it is ticked from outside instead of running "
-            + "/loop on itself. Off, existing heartbeat loops fall silent immediately."
+          "The daemon drives time-based loops on its own timer. On, new timed loops "
+            + "default to the heartbeat (pick \"Itself, with /loop\" in the form, or "
+            + "omit --heartbeat in the CLI, for the classic model). Off, existing "
+            + "heartbeat loops fall silent immediately; nothing is ever converted."
         )
         .font(.caption2)
         .foregroundStyle(.secondary)

--- a/graphcode/Tests/SessionBriefingTests.swift
+++ b/graphcode/Tests/SessionBriefingTests.swift
@@ -28,7 +28,8 @@ struct SessionBriefingTests {
     // mid-quote and the shell sat forever at a `>` continuation prompt. It goes in a file
     // now precisely because it cannot fit on a command line — asserting that keeps anyone
     // from "simplifying" it back onto one.
-    let briefing = try #require(SessionBriefing.text(projectPath: Self.project))
+    let briefing = try #require(
+      SessionBriefing.text(projectPath: Self.project, settings: GraphcodeSettings()))
     #expect(!SessionBriefing.isSafeToType(briefing))
     #expect(briefing.utf8.count > SessionBriefing.safeArgumentBudget)
   }
@@ -47,7 +48,8 @@ struct SessionBriefingTests {
 
   @Test
   func theBriefingNamesTheProjectAndTheCommandThatCreatesALoop() throws {
-    let briefing = try #require(SessionBriefing.text(projectPath: Self.project))
+    let briefing = try #require(
+      SessionBriefing.text(projectPath: Self.project, settings: GraphcodeSettings()))
     // The path has to be in it: every command it describes takes one, and a session that
     // has to guess its own project path will guess wrong.
     #expect(briefing.contains(Self.project))
@@ -61,7 +63,8 @@ struct SessionBriefingTests {
     // Issue #91: a Copilot session asked to create a child "node" did nothing, while
     // "child loop" worked — the briefing taught the command only under the word "loop".
     // The vocabulary bridge is the fix, so its absence has to fail a test.
-    let briefing = try #require(SessionBriefing.text(projectPath: Self.project))
+    let briefing = try #require(
+      SessionBriefing.text(projectPath: Self.project, settings: GraphcodeSettings()))
     #expect(briefing.contains("node is a loop"))
     #expect(briefing.contains("child node"))
   }
@@ -73,7 +76,8 @@ struct SessionBriefingTests {
     // nodes appear in the sidebar and none of them run until a person opens each one.
     // The first cut of this briefing led with `--type turn`, which made "spin up five
     // loops" produce exactly that.
-    let briefing = try #require(SessionBriefing.text(projectPath: Self.project))
+    let briefing = try #require(
+      SessionBriefing.text(projectPath: Self.project, settings: GraphcodeSettings()))
     let goalExample = try #require(briefing.range(of: "--type goal"))
     let turnExample = try #require(briefing.range(of: "--type turn"))
     #expect(goalExample.lowerBound < turnExample.lowerBound)
@@ -85,7 +89,8 @@ struct SessionBriefingTests {
     // graphcode holds no timer: the recurrence is a directive inside the session's own
     // prompt (`LoopNode.triggerPrompt`). A time-based loop created without one runs once
     // and stops, which looks like a broken schedule rather than a missing instruction.
-    let briefing = try #require(SessionBriefing.text(projectPath: Self.project))
+    let briefing = try #require(
+      SessionBriefing.text(projectPath: Self.project, settings: GraphcodeSettings()))
     #expect(briefing.contains("cadence goes inside the prompt"))
     #expect(briefing.contains("/loop 1h"))
   }
@@ -94,7 +99,8 @@ struct SessionBriefingTests {
   func theBriefingSaysWhenNotToSpawnLoops() throws {
     // The restraint matters more than the capability. An agent told only *how* to create
     // loops will create them for every subtask it can name.
-    let briefing = try #require(SessionBriefing.text(projectPath: Self.project))
+    let briefing = try #require(
+      SessionBriefing.text(projectPath: Self.project, settings: GraphcodeSettings()))
     #expect(briefing.contains("Do not create loops for ordinary subtasks"))
     #expect(briefing.contains("Never create a loop whose job is to create more loops"))
   }
@@ -105,7 +111,8 @@ struct SessionBriefingTests {
     // idea the CLI could stop, rewire, or share loops — "export this loop" read as a
     // command that didn't exist. Delete rides along only with its warning attached:
     // taught bare, it looks like the way to tidy up, and it erases a loop's memory.
-    let briefing = try #require(SessionBriefing.text(projectPath: Self.project))
+    let briefing = try #require(
+      SessionBriefing.text(projectPath: Self.project, settings: GraphcodeSettings()))
     #expect(briefing.contains("node stop \(Self.project)"))
     #expect(briefing.contains("irreversible"))
     #expect(briefing.contains("edge create \(Self.project)"))
@@ -358,5 +365,26 @@ struct SessionBriefingTests {
       toBriefingAt: "/Users/x/.graphcode/briefings/p/AGENTS.md")
     #expect(pointer.allSatisfy { $0.isASCII })
     #expect(pointer.contains("/Users/x/.graphcode/briefings/p/AGENTS.md and follow it."))
+  }
+}
+
+/// The briefing teaches whichever cadence model is the current default — an agent
+/// following yesterday's guidance under today's default would create loops the human
+/// just said they no longer want.
+@Suite
+struct BriefingCadenceGuidanceTests {
+  @Test
+  func theTimeLoopBulletFollowsTheHeartbeatExperiment() throws {
+    let off = try #require(
+      SessionBriefing.text(projectPath: "/tmp/p", settings: GraphcodeSettings()))
+    #expect(off.contains("The cadence goes inside the prompt"))
+    #expect(!off.contains("--heartbeat"))
+
+    let on = try #require(
+      SessionBriefing.text(
+        projectPath: "/tmp/p", settings: GraphcodeSettings(daemonHeartbeatEnabled: true)))
+    #expect(on.contains("--heartbeat <seconds>"))
+    #expect(on.contains("The daemon drives it"))
+    #expect(!on.contains("The cadence goes inside the prompt"))
   }
 }

--- a/graphcode/Tests/SkillDistillationTests.swift
+++ b/graphcode/Tests/SkillDistillationTests.swift
@@ -118,7 +118,8 @@ struct SkillDistillationTests {
 
   @Test
   func theBriefingTeachesTheSkillLibraryAndTheRefineVerb() throws {
-    let briefing = try #require(SessionBriefing.text(projectPath: "/tmp/distill"))
+    let briefing = try #require(
+      SessionBriefing.text(projectPath: "/tmp/distill", settings: GraphcodeSettings()))
     #expect(briefing.contains(".claude/skills"))
     #expect(briefing.contains("Project skills"))
     #expect(briefing.contains("node refine"))


### PR DESCRIPTION
User-directed change to the experiment's contract: the toggle now governs the **default**, not mere availability — switching it on means new time-based loops are daemon-driven, and the `/loop` skill runs only when explicitly asked for.

- **Form**: "Driven by" defaults to *Daemon heartbeat* while the toggle is on; *"Itself, with /loop"* is the explicit opt-out. Toggle off → classic default, control hidden.
- **Agents**: the session briefing now teaches whichever model is current — regenerated from live settings at every launch, so there is no stale-guidance window. With the toggle on, the time-loop bullet becomes `--type time --heartbeat <seconds> --prompt <bare task>` with self-scheduling as the documented exception; off, the classic cadence-in-prompt guidance returns verbatim.
- Existing loops are never converted in either direction.
- Briefing tests pin `GraphcodeSettings()` explicitly (the new live-settings read had just made their assertions machine-dependent), plus a new test covering both guidance branches.

## Verification
Full suite **946 tests in 97 suites passed**; `swift format lint --strict` exit 0 (verified by exit code, not eyeballed — the #138 lesson) and `swiftlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)