### PR TITLE
Keypress on the dead agent pane closes the workspace and deletes the loop

### DIFF
--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -539,6 +539,30 @@ struct AppFeature {
             .graphCommand(projectPath: projectPath, command: command))
         }
 
+      // The keypress on the agent pane's "Press any key to close" screen. The session
+      // was already resolved when it exited (above) — this is the human dismissing what
+      // remains, so the workspace closes *and* the node leaves the graph. Deleting via
+      // the daemon rather than locally, the same way the sidebar's delete does: the
+      // resulting broadcast is what removes the card everywhere, and `GraphStore` also
+      // kills the loop's zmx session. Closed here as well rather than waiting for that
+      // broadcast, so the dead pane goes away even with the daemon unreachable.
+      case .openLoop(.primaryExitAcknowledged):
+        guard let id = state.openLoop?.node.id, let projectPath = state.openLoop?.projectPath
+        else { return .none }
+        // A chat is not a node in any graph — there is nothing to delete, and the chat
+        // itself should outlive its session. Just put the dead terminal away.
+        guard !state.isQuickChat(id) else {
+          closeOpenWorkspace(&state)
+          state.detailSelection = .quickChats
+          return .none
+        }
+        closeOpenWorkspace(&state)
+        state.selectedProjectPath = projectPath
+        return .run { _ in
+          try? await orchestratorClient.send(
+            .graphCommand(projectPath: projectPath, command: .deleteNode(id)))
+        }
+
       case .openLoop(.stopLoopTapped):
         guard let id = state.openLoop?.node.id, let path = state.openLoop?.projectPath
         else { return .none }

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
@@ -68,6 +68,11 @@ struct LoopWorkspaceFeature {
     case focusPreviousPane
     case paneClosed(tabID: UUID, surfaceID: UUID)
     case primarySurfaceExited(succeeded: Bool)
+    /// A keypress on the agent pane's "Process exited. Press any key to close." screen —
+    /// the human agreeing the loop is over. Declared here (the surface is this feature's
+    /// to wire) and handled by `AppFeature`, which owns both the workspace's dismissal
+    /// and the daemon connection the deletion goes out on.
+    case primaryExitAcknowledged
     /// The loop bar's Stop loop and Show in graph, and the right rail's downstream rows.
     /// All three are `AppFeature`'s to carry out — stopping talks to the daemon, and both
     /// of the others change what the whole window is showing — so they are declared here
@@ -240,7 +245,7 @@ struct LoopWorkspaceFeature {
         state.seenBeatID = state.node.summary?.current?.id
         return .none
 
-      case .stopLoopTapped, .showInGraphTapped, .railTargetTapped:
+      case .stopLoopTapped, .showInGraphTapped, .railTargetTapped, .primaryExitAcknowledged:
         // Handled by `AppFeature`'s parent `Reduce` — see the actions' own doc comment.
         return .none
       }

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
@@ -311,7 +311,15 @@ struct LoopWorkspaceView: View {
       // are told so and stop drawing entirely — without that they render frames nobody
       // can see, at the same thread priority as the pane you're actually looking at.
       isVisible: tab.id == store.layout.selectedTabID,
-      onFocusRequested: { store.send(.paneFocused(tabID: tab.id, surfaceID: ref.id)) }
+      onFocusRequested: { store.send(.paneFocused(tabID: tab.id, surfaceID: ref.id)) },
+      // Only the agent pane lingers after its process exits (it holds the loop's
+      // resolution, so `.primarySurfaceExited` leaves it mounted) — which left the
+      // "Press any key to close" screen with no key that did anything. The keypress is
+      // the human agreeing the loop is over: the workspace closes and the node goes
+      // with it. A plain shell's exit already closes its pane, so it has no screen to
+      // acknowledge.
+      onExitAcknowledged: ref.launchesClaudeCode
+        ? { store.send(.primaryExitAcknowledged) } : nil
     ) { succeeded in
       if ref.launchesClaudeCode {
         store.send(.primarySurfaceExited(succeeded: succeeded))

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView.swift
@@ -17,6 +17,18 @@ final class GhosttyTerminalNSView: NSView {
   private(set) var surface: ghostty_surface_t!
   var onProcessExited: ((Bool) -> Void)?
 
+  /// Called on the first keypress after the process has exited — the "Press any key to
+  /// close the terminal." screen being taken up on its offer. Keystrokes stop reaching
+  /// the surface once the process is gone (see `keyDown`), so without this the message
+  /// was a promise nobody kept: libghostty re-requested a close the app had already
+  /// handled, and the dead pane stayed on screen.
+  var onExitAcknowledged: (() -> Void)?
+
+  /// Set once `handleSurfaceClosed` reports the process gone, and never unset: a
+  /// surface's child does not come back to life, and every keystroke after this belongs
+  /// to `onExitAcknowledged` rather than to a shell that no longer exists.
+  private(set) var processHasExited = false
+
   /// Called when the user clicks into this surface, so the workspace can record which
   /// pane of a split they meant.
   ///
@@ -132,6 +144,7 @@ final class GhosttyTerminalNSView: NSView {
   /// process is still alive — so "succeeded" here means "the surface closed because the
   /// command finished on its own," not a real exit status.
   func handleSurfaceClosed(processAlive: Bool) {
+    if !processAlive { processHasExited = true }
     onProcessExited?(!processAlive)
   }
 
@@ -243,6 +256,14 @@ final class GhosttyTerminalNSView: NSView {
   // MARK: - Keyboard
 
   override func keyDown(with event: NSEvent) {
+    // "Any key" means any key: taken here, before the surface, because the process the
+    // surface would encode it for is gone. Left to libghostty, only keys that encode a
+    // character would count, and each one re-requested a close the app had already
+    // acted on — the screen that says "Press any key to close" doing nothing at all.
+    if processHasExited {
+      onExitAcknowledged?()
+      return
+    }
     // Zoom first, and never forwarded. libghostty binds these same keys itself, so letting
     // the event through as well would apply the step twice — and would apply the second
     // one to this surface alone, which is the per-surface behaviour the app-wide zoom
@@ -262,6 +283,8 @@ final class GhosttyTerminalNSView: NSView {
   }
 
   override func keyUp(with event: NSEvent) {
+    // The release of the acknowledging press — swallowed for the reason below.
+    guard !processHasExited else { return }
     // Swallowed to match the press. A release whose press the surface never saw is exactly
     // the sort of thing the kitty keyboard protocol reports to the program on the other
     // end, and a shell being told about a key nobody pressed is worse than being told

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -61,6 +61,10 @@ struct GhosttyTerminalView: NSViewRepresentable {
   var isVisible: Bool = true
   /// The user clicked into this surface. See `GhosttyTerminalNSView.onFocusRequested`.
   var onFocusRequested: (() -> Void)?
+  /// The user pressed a key on the "Process exited. Press any key to close." screen.
+  /// See `GhosttyTerminalNSView.onExitAcknowledged`. `nil` for a plain-shell pane, whose
+  /// exit closes the pane outright (`.paneClosed`) so the screen never lingers.
+  var onExitAcknowledged: (() -> Void)?
   let onProcessExited: (Bool) -> Void
 
   /// Carries `initialPrompt` into the shell as a variable instead of interpolating it
@@ -113,6 +117,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
     view.isActive = isActive
     view.isVisible = isVisible
     view.onFocusRequested = onFocusRequested
+    view.onExitAcknowledged = onExitAcknowledged
     view.onProcessExited = onProcessExited
   }
 

--- a/graphcode/Tests/AppFeatureTests.swift
+++ b/graphcode/Tests/AppFeatureTests.swift
@@ -309,6 +309,63 @@ struct AppFeatureTests {
       ])
   }
 
+  /// The keypress on the "Process exited. Press any key to close." screen: the dead
+  /// workspace closes immediately, and the loop's node is deleted from the graph.
+  @Test
+  @MainActor
+  func acknowledgingAPrimaryExitClosesTheWorkspaceAndDeletesTheNode() async {
+    let node = LoopNode(title: "Hello", checkDescription: "Said?")
+    var state = AppFeature.State()
+    state.projects.append(
+      ProjectFeature.State(graph: LoopGraph(project: Self.projectA, nodes: [node])))
+    state.selectedProjectPath = Self.projectA.path
+    state.openLoop = LoopWorkspaceFeature.State(
+      node: node, layout: .defaultLayout(forNode: node.id), projectPath: Self.projectA.path,
+      projectName: Self.projectA.name)
+
+    let sentCommands = SentCommandsBox()
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.orchestratorClient.send = { command in await sentCommands.append(command) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openLoop(.primaryExitAcknowledged))
+    #expect(store.state.openLoop == nil)
+    #expect(store.state.selectedProjectPath == Self.projectA.path)
+    #expect(
+      await sentCommands.all == [
+        .graphCommand(projectPath: Self.projectA.path, command: .deleteNode(node.id))
+      ])
+  }
+
+  /// A quick chat's session ending the same way just puts the dead terminal away — a
+  /// chat is not a node in any graph, and the chat itself outlives its session.
+  @Test
+  @MainActor
+  func acknowledgingAQuickChatsExitOnlyClosesTheWorkspace() async {
+    let chat = QuickChat(title: "Chat")
+    var state = AppFeature.State()
+    state.quickChats.append(chat)
+    let node = LoopNode(id: chat.id, title: chat.title, loopType: .composite)
+    state.openLoop = LoopWorkspaceFeature.State(
+      node: node, layout: .defaultLayout(forNode: node.id), projectPath: "",
+      projectName: chat.title)
+
+    let sentCommands = SentCommandsBox()
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.orchestratorClient.send = { command in await sentCommands.append(command) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openLoop(.primaryExitAcknowledged))
+    #expect(store.state.openLoop == nil)
+    #expect(await sentCommands.all.isEmpty)
+  }
+
   /// ⇧⌘]/⇧⌘[ walk the same flattened list the sidebar draws — across projects, skipping
   /// blocked loops, wrapping at the ends — and go through `.nodeTapped` rather than a
   /// path of their own, so what the shortcut opens is exactly what a click would.


### PR DESCRIPTION
## Problem

Ctrl+c (or any exit) in a loop's agent session leaves the pane showing libghostty's
"Process exited. Press any key to close the terminal." — but pressing a key did
nothing: the close request it triggers was already handled at exit (it only marks
the node resolved), and the dead pane stayed mounted.

## Fix

- `GhosttyTerminalNSView` remembers its process exited; the next keypress fires a
  new `onExitAcknowledged` callback instead of feeding the dead surface (whose
  re-requested close the app had already acted on).
- The agent pane wires it to a new `LoopWorkspaceFeature.primaryExitAcknowledged`
  action; plain-shell panes keep their existing close-on-exit behavior.
- `AppFeature` handles it by closing the workspace immediately and sending
  `deleteNode` to the daemon — same path as the sidebar's delete, so the broadcast
  removes the card everywhere and the loop's zmx session is killed. Quick chats
  just close (no graph node to delete).

## Tests

Two new `AppFeatureTests`; full suite: 948 tests in 97 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)