### PR TITLE
The form lands on Sketch when no loop type is remembered

### DIFF
--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -549,8 +549,16 @@ extension ProjectFeature {
   static let lastLoopTypeKey = "lastCreatedLoopType"
 
   static var rememberedLoopType: LoopType {
-    UserDefaults.standard.string(forKey: lastLoopTypeKey)
-      .flatMap(LoopType.init(rawValue:)) ?? .goalBased
+    loopType(remembered: UserDefaults.standard.string(forKey: lastLoopTypeKey))
+  }
+
+  /// No remembered choice lands on Sketch — the type that demands nothing decided
+  /// yet, which is the honest opening for someone who hasn't expressed a preference.
+  /// Landing on any committed type puts a whole form in front of a person who never
+  /// picked it. A stored value nothing can decode (an old build's spelling, a
+  /// hand-edited defaults write) gets the same treatment as none.
+  static func loopType(remembered raw: String?) -> LoopType {
+    raw.flatMap(LoopType.init(rawValue:)) ?? .sketch
   }
 
   /// Resets the promotion form's one field and opens it for the chosen target — only

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 import GraphcodeKit
 import Testing
 
@@ -54,7 +55,10 @@ struct ProjectFeatureTests {
     }
     store.exhaustivity = .off
 
-    // The form opens on its default type — goal-based — and only the goal is typed.
+    // Pinned rather than inherited: the form opens on the *remembered* type, and this
+    // test's subject is the title flow, not the memory. Without the pin it read
+    // whatever earlier runs left in UserDefaults.
+    UserDefaults.standard.set(LoopType.goalBased.rawValue, forKey: ProjectFeature.lastLoopTypeKey)
     await store.send(.addNodeButtonTapped(parentBackend: nil))
     #expect(store.state.draftLoopType == .goalBased)
     await store.send(.binding(.set(\.draftGoal, "Say hello")))
@@ -351,6 +355,17 @@ struct ProjectFeatureTests {
         guard case .graphCommand(_, .createEdge(let from, let to, _)) = $0 else { return false }
         return from == parent.id && to == draft.id
       })
+  }
+
+  /// No remembered preference — a fresh machine, or a stored spelling nothing can
+  /// decode — lands the form on Sketch, the type that demands nothing decided yet.
+  @Test
+  @MainActor
+  func noRememberedPreferenceLandsOnSketch() {
+    #expect(ProjectFeature.loopType(remembered: nil) == .sketch)
+    #expect(ProjectFeature.loopType(remembered: "not-a-type") == .sketch)
+    #expect(ProjectFeature.loopType(remembered: "goalBased") == .goalBased)
+    #expect(ProjectFeature.loopType(remembered: LoopType.composite.rawValue) == .composite)
   }
 
   /// The workspace gate's live-session reading: presence is the only honest signal


### PR DESCRIPTION
Reported from a second machine: the New Loop form opened on **Composite** with no previous preference selected. The chooser binds by type equality so it cannot mis-highlight; the cause is the remembered-type path — `lastCreatedLoopType` holding a stale value, with a `.goalBased` fallback that in no case matched the reporter's expectation.

- **No remembered preference → Sketch**, the type that demands nothing decided yet — the honest opening for someone who hasn't expressed a choice. A stored value nothing can decode gets the same treatment as none.
- Creating a loop still updates the memory; only the empty/invalid case changes.
- The fallback is extracted to a pure `loopType(remembered:)` with a truth-table test, and the existing form test that silently depended on whatever earlier test runs left in `UserDefaults` now pins its key (it was order-dependent all along).

## Verification
Full suite green (**TEST SUCCEEDED**); `swift format lint --strict` exit 0; `swiftlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)