### PR TITLE
Composite never owns the form's landing type

### DIFF
--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -557,8 +557,15 @@ extension ProjectFeature {
   /// Landing on any committed type puts a whole form in front of a person who never
   /// picked it. A stored value nothing can decode (an old build's spelling, a
   /// hand-edited defaults write) gets the same treatment as none.
+  ///
+  /// Composite is filtered on read as well as never written: the key is app-wide and
+  /// only form-creates update it, so one composite made months ago in another project
+  /// owned every project's form until the next form-create — the "why does this keep
+  /// opening on Composite" report. Values written by older builds are exactly why the
+  /// write-side skip alone isn't enough.
   static func loopType(remembered raw: String?) -> LoopType {
-    raw.flatMap(LoopType.init(rawValue:)) ?? .sketch
+    let remembered = raw.flatMap(LoopType.init(rawValue:))
+    return remembered == .composite ? .sketch : (remembered ?? .sketch)
   }
 
   /// Resets the promotion form's one field and opens it for the chosen target — only
@@ -621,7 +628,12 @@ extension ProjectFeature {
     // simply doesn't submit — the Create button is disabled on it too, and this is
     // the backstop for the keyboard shortcut path.
     guard draft.isValid else { return .none }
-    UserDefaults.standard.set(draft.loopType.rawValue, forKey: Self.lastLoopTypeKey)
+    // Composite is deliberately not remembered: creating one is a rare, structural
+    // act, and the *next* loop is almost never another composite — remembering it
+    // made the heaviest type the default everywhere (see `loopType(remembered:)`).
+    if draft.loopType != .composite {
+      UserDefaults.standard.set(draft.loopType.rawValue, forKey: Self.lastLoopTypeKey)
+    }
     let projectPath = state.graph.project.path
     // A form opened from a node card's + handle also wires the new loop up: a
     // default hand-off edge from the parent, created right after the node so the

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -365,7 +365,37 @@ struct ProjectFeatureTests {
     #expect(ProjectFeature.loopType(remembered: nil) == .sketch)
     #expect(ProjectFeature.loopType(remembered: "not-a-type") == .sketch)
     #expect(ProjectFeature.loopType(remembered: "goalBased") == .goalBased)
-    #expect(ProjectFeature.loopType(remembered: LoopType.composite.rawValue) == .composite)
+    // A remembered composite reads as Sketch: the key is app-wide, only form-creates
+    // update it, and one composite must not own every project's form until the next
+    // form-create. "proactive" is composite's stored spelling.
+    #expect(ProjectFeature.loopType(remembered: "proactive") == .sketch)
+    #expect(ProjectFeature.loopType(remembered: LoopType.composite.rawValue) == .sketch)
+  }
+
+  /// The write side of the same rule: creating a composite leaves the memory alone.
+  @Test
+  @MainActor
+  func creatingACompositeIsNotRemembered() async {
+    UserDefaults.standard.set(LoopType.goalBased.rawValue, forKey: ProjectFeature.lastLoopTypeKey)
+    let store = TestStore(
+      initialState: ProjectFeature.State(graph: LoopGraph(project: Self.testProject))
+    ) {
+      ProjectFeature()
+    } withDependencies: {
+      $0.gitClient.listWorktrees = { _ in [] }
+      $0.orchestratorClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.addNodeButtonTapped(parentBackend: nil))
+    await store.send(.binding(.set(\.draftLoopType, LoopType.composite)))
+    await store.send(.binding(.set(\.draftTitle, "Nightly sweep")))
+    await store.send(.createNodeConfirmed)
+    await store.finish()
+
+    #expect(
+      UserDefaults.standard.string(forKey: ProjectFeature.lastLoopTypeKey)
+        == LoopType.goalBased.rawValue)
   }
 
   /// The workspace gate's live-session reading: presence is the only honest signal


### PR DESCRIPTION
Completes #143. The reporter's machine had `lastCreatedLoopType = "proactive"` — one composite created through the dialog, sometime, in some project — and because the key is **app-wide** and only *form*-creates update it, that single composite owned every project's New Loop form indefinitely (CLI/agent/child creates never touch the key).

- **Read side**: a remembered composite reads as **Sketch** — retroactively cures machines whose defaults already hold `"proactive"`, no defaults surgery needed.
- **Write side**: creating a composite is no longer remembered — a rare structural act whose *next* loop is almost never another composite.
- Composite remains fully selectable in the chooser; it just never wins by default.
- Truth-table test extended (`"proactive"` included) plus a create-a-composite flow asserting the memory is untouched.

## Verification
Full suite **TEST SUCCEEDED**; `swift format lint --strict` exit 0; `swiftlint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)