### PR TITLE
Per-backend send pacing; Copilot gets a confirming Enter

### DIFF
--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -262,6 +262,34 @@ public enum ZmxSessionLauncher {
   /// and a lost message costs the whole point of sending it.
   static let submitDelay: Duration = .milliseconds(400)
 
+  /// How a delivery is paced into one backend's composer. The shared constants were
+  /// tuned on Claude Code's TUI; Copilot's composer ingests pasted PTY input more
+  /// slowly, and under the shared pacing its Enter could land mid-ingest — swallowed,
+  /// with the message sitting rendered-but-unsent in the input bar, or worse a partial
+  /// submit with the remainder stranded. The same composer race the split-out Enter
+  /// fixed for Claude, surfacing one backend later.
+  struct SendPacing {
+    /// Seconds between chunk writes — the TUI's time to drain one from the PTY queue.
+    let interChunkSeconds: Double
+    /// Seconds between the last chunk and the Enter.
+    let submitSeconds: Double
+    /// Seconds after the first Enter to send a second, for a composer that may have
+    /// eaten the first mid-ingest. On a composer the first Enter already emptied, the
+    /// second is a keystroke into an empty input box — a no-op. `nil` skips it.
+    let confirmSubmitSeconds: Double?
+
+    static func forBackend(_ backend: CLISessionBackendKind) -> SendPacing {
+      switch backend {
+      case .copilotCLI:
+        return SendPacing(
+          interChunkSeconds: 0.3, submitSeconds: 1.0, confirmSubmitSeconds: 0.8)
+      case .claudeCode, .codex:
+        return SendPacing(
+          interChunkSeconds: 0.15, submitSeconds: 0.4, confirmSubmitSeconds: nil)
+      }
+    }
+  }
+
   static func send(_ text: String, to node: LoopNode, projectPath: String? = nil) async -> Bool {
     // A remote loop's session lives in another host's zmx daemon — the local socket has
     // never heard of it, so a local send was a guaranteed failure (observed as every
@@ -277,8 +305,9 @@ public enum ZmxSessionLauncher {
     // the composer, exactly as the text and the later `\r` already do; nothing is
     // submitted until the one Enter below.
     let sessionName = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
+    let pacing = SendPacing.forBackend(node.backend)
     for (index, chunk) in messageChunks(text).enumerated() {
-      if index > 0 { try? await Task.sleep(for: interChunkDelay) }
+      if index > 0 { try? await Task.sleep(for: .seconds(pacing.interChunkSeconds)) }
       guard
         let session = try? PTYProcessSession(
           executable: ZmxLocator.binaryURL.path,
@@ -287,13 +316,22 @@ public enum ZmxSessionLauncher {
       guard await session.waitUntilFinished() else { return false }
     }
     // Typed is not sent: submit as a second, separate keystroke — see `submitArguments`.
-    try? await Task.sleep(for: submitDelay)
+    try? await Task.sleep(for: .seconds(pacing.submitSeconds))
     guard
       let submit = try? PTYProcessSession(
         executable: ZmxLocator.binaryURL.path,
         arguments: submitArguments(forNode: node))
     else { return false }
     let delivered = await submit.waitUntilFinished()
+    if delivered, let confirm = pacing.confirmSubmitSeconds {
+      try? await Task.sleep(for: .seconds(confirm))
+      if let second = try? PTYProcessSession(
+        executable: ZmxLocator.binaryURL.path,
+        arguments: submitArguments(forNode: node))
+      {
+        _ = await second.waitUntilFinished()
+      }
+    }
     // Typing into a Codex session starts a turn, and Codex has no way to say so itself.
     // Clearing the label here is that missing edge — see `codexPresence`.
     if delivered, node.backend == .codex { await clearPresenceLabel(of: node) }
@@ -1020,11 +1058,15 @@ public enum ZmxSessionLauncher {
     // ours — but chained into the one ssh round-trip, with the same drain beat
     // between writes.
     let sessionName = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
+    let pacing = SendPacing.forBackend(node.backend)
     let sends = messageChunks(text)
       .map { quotedCommand(["zmx", "send", sessionName, $0]) }
-      .joined(separator: " && sleep 0.15 && ")
+      .joined(separator: " && sleep \(pacing.interChunkSeconds) && ")
     let submit = quotedCommand(["zmx"] + submitArguments(forNode: node))
-    let script = "\(sends) && sleep 0.4 && \(submit)"
+    var script = "\(sends) && sleep \(pacing.submitSeconds) && \(submit)"
+    if let confirm = pacing.confirmSubmitSeconds {
+      script += " && sleep \(confirm) && \(submit)"
+    }
     return location.sshInvocation(remoteCommand: location.remoteLoginShellCommand(script))
   }
 

--- a/graphcode/Tests/ZmxSessionLauncherTests.swift
+++ b/graphcode/Tests/ZmxSessionLauncherTests.swift
@@ -305,3 +305,50 @@ struct ZmxSessionLauncherTests {
     #expect(chunks == ["line one line two"])
   }
 }
+
+/// Delivery pacing per backend: the shared constants were tuned on Claude Code's
+/// composer, and Copilot's slower ingest needed its own — plus a confirming Enter for
+/// the one it may have eaten mid-ingest (harmless on a composer the first already
+/// emptied). Pure table tests; the timing itself is not unit-testable.
+@Suite
+struct SendPacingTests {
+  @Test
+  func copilotGetsSlowerPacingAndAConfirmingEnter() {
+    let pacing = ZmxSessionLauncher.SendPacing.forBackend(.copilotCLI)
+    #expect(pacing.interChunkSeconds > 0.15)
+    #expect(pacing.submitSeconds > 0.4)
+    #expect(pacing.confirmSubmitSeconds != nil)
+  }
+
+  @Test
+  func claudeAndCodexKeepTheTunedSharedPacing() {
+    for backend in [CLISessionBackendKind.claudeCode, .codex] {
+      let pacing = ZmxSessionLauncher.SendPacing.forBackend(backend)
+      #expect(pacing.interChunkSeconds == 0.15)
+      #expect(pacing.submitSeconds == 0.4)
+      #expect(pacing.confirmSubmitSeconds == nil)
+    }
+  }
+
+  @Test
+  func theRemoteScriptCarriesTheSamePacingAsTheLocalPath() throws {
+    let location = try #require(
+      RemoteProjectLocation.parse(projectPath: "ssh://dev@host/workspace/app"))
+
+    let copilot = LoopNode(
+      title: "W", loopType: .timeBased, triggerPrompt: "/loop 1h x", backend: .copilotCLI)
+    let copilotScript = ZmxSessionLauncher.remoteSendInvocation(
+      "hello there", toNode: copilot, at: location
+    ).joined(separator: " ")
+    #expect(copilotScript.contains("sleep 1.0"))
+    #expect(copilotScript.contains("sleep 0.8"))
+
+    let claude = LoopNode(
+      title: "W", loopType: .timeBased, triggerPrompt: "/loop 1h x", backend: .claudeCode)
+    let claudeScript = ZmxSessionLauncher.remoteSendInvocation(
+      "hello there", toNode: claude, at: location
+    ).joined(separator: " ")
+    #expect(claudeScript.contains("sleep 0.4"))
+    #expect(!claudeScript.contains("sleep 0.8"))
+  }
+}


### PR DESCRIPTION
Fixes the reported regression: loop-to-loop messages to **Copilot** targets sometimes sat stuck in its input bar, or submitted partially. The delivery pacing (2KB chunks / 150ms apart / 400ms before the Enter) was tuned on Claude Code's composer — the same composer race the split-out Enter originally fixed for Claude, surfacing one backend later now that heartbeats, nudges, and follow-ups multiplied long multi-chunk sends.

- `SendPacing.forBackend`: Copilot gets **300ms** between chunks, **1s** before the Enter, and a **confirming second Enter 800ms later** — if the first was eaten mid-ingest, the second submits the settled text; if the first worked, the second lands on an empty composer as a no-op. Claude and Codex keep the tuned shared constants byte-for-byte.
- The remote ssh delivery script carries identical pacing, so Copilot loops on remote hosts get the same fix.
- Every delivery path benefits at once: `node send`, message edges, hand-off nudges, heartbeats, budget notices, stop requests — all ride the same `send`.

## Verification
Full suite **TEST SUCCEEDED**; new `SendPacingTests` pin the per-backend table and assert the remote script mirrors the local numbers; lint clean both tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)