### PR TITLE
graphcoded survives a client that vanishes mid-broadcast (SIGPIPE)

### DIFF
--- a/GraphcodeKit/Sources/IPC/DaemonSocketClient.swift
+++ b/GraphcodeKit/Sources/IPC/DaemonSocketClient.swift
@@ -130,6 +130,18 @@ public struct DaemonSocketClient: Sendable {
       tv_usec: Int32((timeout - timeout.rounded(.down)) * 1_000_000))
     setsockopt(
       descriptor, SOL_SOCKET, SO_RCVTIMEO, &interval, socklen_t(MemoryLayout<timeval>.size))
+    applyNoSignal(to: descriptor)
+  }
+
+  /// The client half of the daemon's own `SIGPIPE` armour. Writing to a socket the
+  /// daemon has closed — it restarted, it was stopped mid-exchange — otherwise raises
+  /// SIGPIPE, and the default action kills the writer: the app, or a `graphcode`
+  /// invocation that would rather exit 75 and say so. With this the `write(2)` returns
+  /// `EPIPE`, `FramedMessageIO` throws, and every caller's existing error path runs.
+  private static func applyNoSignal(to descriptor: Int32) {
+    var enabled: Int32 = 1
+    setsockopt(
+      descriptor, SOL_SOCKET, SO_NOSIGPIPE, &enabled, socklen_t(MemoryLayout<Int32>.size))
   }
 
   public func send(_ command: DaemonCommand) throws {

--- a/graphcode/Tests/DaemonSocketClientTests.swift
+++ b/graphcode/Tests/DaemonSocketClientTests.swift
@@ -110,3 +110,31 @@ struct DaemonSocketClientTests {
     #expect(!DaemonSocketClient.isTransient(FramedMessageIO.IOError.connectionClosed))
   }
 }
+
+/// The contract the daemon's broadcast loop rests on: a write to a socket whose peer
+/// has gone must come back as a *thrown error*, so `GraphStore.send` can drop the dead
+/// connection. It is only an error if the process survives long enough to see it —
+/// `graphcoded` ignores `SIGPIPE` and sets `SO_NOSIGPIPE` on every accepted socket for
+/// exactly that reason, after the daemon was found dying with exit status -13 under a
+/// client that stopped reading and then vanished. `scripts/daemon-sigpipe-probe.py`
+/// reproduces that end to end against a built binary; this pins the layer below it.
+@Suite
+struct ClosedPeerWriteTests {
+  @Test
+  func writingToAClosedPeerThrowsRatherThanReportingSuccess() throws {
+    var pair: [Int32] = [0, 0]
+    #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &pair) == 0)
+    var enabled: Int32 = 1
+    setsockopt(
+      pair[0], SOL_SOCKET, SO_NOSIGPIPE, &enabled, socklen_t(MemoryLayout<Int32>.size))
+    close(pair[1])
+
+    // Large enough that the write cannot vanish into a socket buffer that no longer
+    // has a reader behind it.
+    let payload = Data(repeating: 0x41, count: 256 * 1024)
+    #expect(throws: FramedMessageIO.IOError.self) {
+      try FramedMessageIO.writeFrame(payload, to: pair[0])
+    }
+    close(pair[0])
+  }
+}

--- a/graphcoded/Sources/main.swift
+++ b/graphcoded/Sources/main.swift
@@ -72,6 +72,18 @@ guard listen(socketDescriptor, 8) == 0 else {
 
 FileHandle.standardOutput.write(Data("graphcoded: listening on \(path)\n".utf8))
 
+// A broadcast writes to every connected client, and a client can vanish without a
+// clean close — the app killed, a CLI exiting early, a pane crashing. The write then
+// raises SIGPIPE, whose default action *terminates the daemon*: observed as exit
+// status -13 in `launchctl list`, with every loop's in-flight send failing until
+// launchd restarted the process seconds later.
+//
+// Ignoring it turns that into what the code already handles correctly:
+// `FramedMessageIO.writeAll` sees write() return -1/EPIPE, throws, and
+// `GraphStore.send` drops the dead connection. The error path was always right; the
+// process just never lived long enough to run it.
+signal(SIGPIPE, SIG_IGN)
+
 signal(SIGTERM) { _ in
   unlink(path)
   exit(0)
@@ -135,6 +147,11 @@ DispatchQueue.global().async {
   while true {
     let clientDescriptor = accept(socketDescriptor, nil, nil)
     guard clientDescriptor >= 0 else { continue }
+    // Belt and braces beside the process-wide ignore above: this socket raises no
+    // SIGPIPE whatever any library does to the signal disposition later.
+    var noSignal: Int32 = 1
+    setsockopt(
+      clientDescriptor, SOL_SOCKET, SO_NOSIGPIPE, &noSignal, socklen_t(MemoryLayout<Int32>.size))
     handleConnection(clientDescriptor)
   }
 }

--- a/scripts/daemon-sigpipe-probe.py
+++ b/scripts/daemon-sigpipe-probe.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Does the daemon survive a client that stops reading and then vanishes mid-broadcast?
+
+Client A joins a project with a deliberately tiny receive buffer and never reads. B then
+mutates the graph repeatedly, so each broadcast carries the whole graph into A's socket
+until it fills and the daemon's blocking write stalls inside it. A is then closed — the
+stalled write returns EPIPE, and an unprotected daemon takes SIGPIPE there and dies.
+
+This is the shape of the real failure: a client that is busy, hung, or killed while the
+daemon is broadcasting, rather than one that closes cleanly and gets reaped by the read
+loop first.
+"""
+import json, os, shutil, socket, struct, subprocess, sys, time, uuid
+
+binary, support = sys.argv[1], sys.argv[2]
+shutil.rmtree(support, ignore_errors=True)
+os.makedirs(support, exist_ok=True)
+sock_path = os.path.join(support, "graphcoded.sock")
+project = os.path.join(support, "proj")
+os.makedirs(project, exist_ok=True)
+
+env = dict(os.environ, GRAPHCODE_SUPPORT_DIR=support)
+daemon = subprocess.Popen([binary], env=env,
+                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+for _ in range(50):
+    if os.path.exists(sock_path):
+        break
+    time.sleep(0.1)
+else:
+    print("FAIL: daemon never created its socket")
+    daemon.kill()
+    sys.exit(2)
+
+
+def connect(rcvbuf=None):
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    if rcvbuf:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, rcvbuf)
+    s.connect(sock_path)
+    return s
+
+
+def send(s, obj):
+    data = json.dumps(obj).encode()
+    s.sendall(struct.pack(">I", len(data)) + data)
+
+
+def recv(s):
+    header = s.recv(4, socket.MSG_WAITALL)
+    if len(header) < 4:
+        return None
+    return json.loads(s.recv(struct.unpack(">I", header)[0], socket.MSG_WAITALL))
+
+
+def make_node(s, title):
+    send(s, {"graphCommand": {"projectPath": project, "command": {"createNode": {"_0": {
+        "id": str(uuid.uuid4()), "title": title, "loopType": "sketch"}}}}})
+
+
+# A joins, then goes deaf: it never reads another byte.
+a = connect(rcvbuf=1024)
+send(a, {"openProject": {"path": project}})
+time.sleep(0.2)
+
+# B fills the graph. Every mutation broadcasts the whole graph to every joined client,
+# so A's small buffer fills and the daemon's write into it stalls.
+b = connect()
+send(b, {"openProject": {"path": project}})
+recv(b)
+for index in range(40):
+    make_node(b, f"Filler {index:02d}")
+    time.sleep(0.02)
+
+time.sleep(0.5)
+# A vanishes while the daemon is stalled writing into it.
+a.close()
+time.sleep(0.5)
+
+# One more mutation, in case the stalled write was already drained.
+try:
+    make_node(b, "After")
+except Exception:
+    pass
+time.sleep(0.7)
+
+alive = daemon.poll() is None
+if alive:
+    print("PASS: daemon survived the vanished reader")
+else:
+    code = daemon.returncode
+    signame = f"signal {-code}" + (" = SIGPIPE" if code == -13 else "")
+    print(f"FAIL: daemon died — {signame}")
+daemon.kill()
+daemon.wait()
+shutil.rmtree(support, ignore_errors=True)
+sys.exit(0 if alive else 1)


### PR DESCRIPTION
Reported by a peer loop: `graphcoded` died twice in a few minutes, and other loops' sends were failing intermittently. `launchctl list` showed the daemon's last exit status as **-13** — killed by **SIGPIPE** — with `runs = 10`.

## Cause
A broadcast writes the whole graph to every joined client with a blocking `write(2)`. When a client stops reading and then vanishes — the app busy or killed while a broadcast is streaming into its socket — the write returns `EPIPE` and raises `SIGPIPE`, whose default action terminates the daemon. launchd restarts it seconds later, which is why it left no obvious trace.

The error path was always correct: `FramedMessageIO.writeAll` throws and `GraphStore.send` drops the dead connection. The process simply never survived long enough to run it.

## Not a regression
`git log -S "SIGPIPE"` returns **zero commits** — SIGPIPE has never been handled in this repo. The signal block dates to the Phase 0 scaffold, the write path to Phase 3, and `0.1.40-beta3` has the identical hole (SIGTERM/SIGINT handled, SIGPIPE absent). What changed is how often clients now vanish mid-broadcast. This may also explain the recorded "graphcoded refuses connections under fanout — errno 61 is transient" symptom: that is the same death seen from outside, during the window before launchd restarts.

## Fix
- `graphcoded` ignores `SIGPIPE` and sets `SO_NOSIGPIPE` on every accepted socket.
- `DaemonSocketClient` sets `SO_NOSIGPIPE` too, so the app and the CLI are not killed by a daemon restart mid-exchange — the CLI can report exit 75 as designed instead of dying on a signal.

## Verification
- `scripts/daemon-sigpipe-probe.py` reproduces it end to end against a built binary: **installed daemon → died, signal 13 = SIGPIPE**; **fixed daemon → survived**, same probe. (An earlier, gentler probe that closed the client *cleanly* passed on the buggy binary — the read loop reaped it before any write — which is what makes the sharper reproduction meaningful.)
- Full suite: **951 tests in 98 suites passed**, including a new unit test pinning the throw-rather-than-succeed contract the broadcast loop depends on.
- `swift format lint --strict` exit 0; `swiftlint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)