### PR TITLE
A folder opened from outside the app reaches a running sidebar

### DIFF
--- a/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
+++ b/GraphcodeKit/Sources/IPC/DaemonProtocol.swift
@@ -17,6 +17,12 @@ public enum DaemonCommand: Codable, Sendable, Equatable {
   /// dialled again is joined to nothing until it asks a second time. The daemon replies
   /// with one `.graphChanged` per project, which is exactly what `.openProject` produces,
   /// so the app needs no separate restore path.
+  ///
+  /// Asking for the whole set is also what identifies a client as a *sidebar*: from then
+  /// on the daemon joins it to any project another client opens, so a folder added by the
+  /// CLI (`graphcode status <folder>`, what an editor plugin drives) shows up in a running
+  /// app rather than only at its next launch. A one-shot CLI connection, which asks for
+  /// one named project and reads until that project's snapshot, is deliberately not one.
   case restoreOpenProjects
   /// Join the one always-resident global Orchestrator Graph. It arrives as an ordinary
   /// `.graphChanged` like any project's, distinguishable by its reserved

--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -13,6 +13,10 @@ import Foundation
 /// `connectionProjectPaths` tracks that set so a full disconnect can detach from every
 /// joined `GraphStore`, not just one.
 ///
+/// The open set is shared, not per-connection: whoever opens a folder — the app, the CLI,
+/// an editor plugin driving the CLI — adds it for everyone, so every attached sidebar is
+/// joined to it there and then (`joinSidebars`) instead of finding out at its next launch.
+///
 /// The registry also owns which projects the sidebar should show on next launch, kept in
 /// `open-projects.json` separately from the recents index. That separation is what gives
 /// the sidebar's context menu three distinct verbs: `.closeProject` drops a project from
@@ -23,6 +27,9 @@ public actor ProjectRegistry {
   private var stores: [String: GraphStore] = [:]
   private var connectionFileDescriptors: [UUID: Int32] = [:]
   private var connectionProjectPaths: [UUID: Set<String>] = [:]
+  /// Connections that asked for the whole open set (`.restoreOpenProjects`) rather than
+  /// one named project — see `sidebarSubscribers`.
+  private var sidebarConnections: Set<UUID> = []
   private let ensureSession: (@Sendable (LoopNode, String?) -> Void)?
   private let terminateSession: (@Sendable (LoopNode, String?) -> Void)?
   private let evaluatePredicate: (@Sendable (ShellPredicate) async -> Bool)?
@@ -89,6 +96,7 @@ public actor ProjectRegistry {
     }
     connectionFileDescriptors.removeValue(forKey: id)
     connectionProjectPaths.removeValue(forKey: id)
+    sidebarConnections.remove(id)
     if connectionFileDescriptors.isEmpty { stopPresencePolling() }
   }
 
@@ -206,6 +214,10 @@ public actor ProjectRegistry {
       // paths were openable when they were added, and a project on an unmounted volume
       // has to come back when the volume does. Nothing is deleted from the stored set
       // either way — `close` is the only thing that removes from it.
+      // Asking for the whole open set is what marks a client as a sidebar: from here on
+      // it is joined to projects *other* clients open, so `graphcode status <new folder>`
+      // puts a row in a running app instead of one that only appears next launch.
+      sidebarConnections.insert(connectionID)
       for path in persistence.loadOpenProjects() where Self.isWellFormedProjectPath(path) {
         await open(path, for: connectionID, fileDescriptor: fileDescriptor)
       }
@@ -259,7 +271,30 @@ public actor ProjectRegistry {
     let project = await store.graph.project
     persistence.recordOpened(
       ProjectRef(path: project.path, name: project.name, lastOpenedAt: Date()))
-    rememberOpen(canonicalPath)
+    guard rememberOpen(canonicalPath) else { return }
+    await joinSidebars(to: store, at: canonicalPath, excluding: connectionID)
+  }
+
+  /// Joins every attached sidebar client to a project one of *them* — or the CLI, or a
+  /// plugin driving it — just added to the open set, so it arrives as an ordinary
+  /// `.graphChanged` snapshot.
+  ///
+  /// The open set is one shared list, not a per-connection view: `graphcode status
+  /// <folder>` persists the folder for everyone, and every sidebar restores the same set
+  /// at launch. Without this that shared list only reached a *running* app on relaunch,
+  /// which is precisely how a folder added from outside the app looked like it hadn't
+  /// been added at all.
+  ///
+  /// Only sidebars, and only on the open that was new. A one-shot CLI connection reads
+  /// frames until the `.graphChanged` for the project it named (`runAndPrintGraph`, and
+  /// the same loop in the remote python shim), so joining it to an unrelated project
+  /// would hand it another project's graph to print.
+  private func joinSidebars(to store: GraphStore, at path: String, excluding opener: UUID) async {
+    for id in sidebarConnections where id != opener {
+      guard let fileDescriptor = connectionFileDescriptors[id] else { continue }
+      connectionProjectPaths[id, default: []].insert(path)
+      await store.addConnection(id: id, fileDescriptor: fileDescriptor)
+    }
   }
 
   private func close(_ canonicalPath: String, for connectionID: UUID) async {
@@ -272,11 +307,18 @@ public actor ProjectRegistry {
 
   /// Append rather than insert-at-front: the sidebar should come back in the order it
   /// was built up, not most-recent-first — that's what the recents list is for.
-  private func rememberOpen(_ canonicalPath: String) {
+  ///
+  /// Returns whether this was the open that added the project, which is what tells
+  /// `open` there is news to push to the other sidebars: a re-open of something already
+  /// in the set (every restored project, every `graphcode status` on a folder the app is
+  /// already showing) is not.
+  @discardableResult
+  private func rememberOpen(_ canonicalPath: String) -> Bool {
     var open = persistence.loadOpenProjects()
-    guard !open.contains(canonicalPath) else { return }
+    guard !open.contains(canonicalPath) else { return false }
     open.append(canonicalPath)
     persistence.saveOpenProjects(open)
+    return true
   }
 
   // MARK: - The global Orchestrator Graph
@@ -404,7 +446,11 @@ public actor ProjectRegistry {
     return exists && isDirectory.boolValue
   }
 
-  private static func canonicalize(_ path: String) -> String {
+  /// The one spelling of a project's path — every store, every persisted entry and every
+  /// `.graphChanged` is keyed on it. Public because the app has to key on it too: a
+  /// project it asked for by the path a folder picker handed it comes back named by this,
+  /// and `/tmp` vs `/private/tmp` is enough to make the two look like different projects.
+  public static func canonicalize(_ path: String) -> String {
     guard path != LoopGraphScope.globalPath,
       RemoteProjectLocation.parse(projectPath: path) == nil
     else { return path }

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -36,6 +36,12 @@ struct AppFeature {
 
     var detailSelection: DetailSelection?
 
+    /// Folders this app has asked the daemon to open and hasn't seen come back yet —
+    /// what separates "I opened this" from "someone else did" when a project arrives.
+    /// Canonicalized on the way in, because the daemon names the project by the path it
+    /// resolved, not the one the picker handed us.
+    var pendingOpenPaths: Set<String> = []
+
     /// The selected *folder*, when the selection is one. Every caller that only ever
     /// deals in projects — opening one, closing one, following a node tap — keeps
     /// reading and writing selection through this; `nil` now also covers "Quick Chats",
@@ -332,6 +338,14 @@ struct AppFeature {
             } else {
               state.projects.append(ProjectFeature.State(graph: graph))
             }
+            // Selection follows only a project *this* app asked for. A folder can now
+            // also arrive because someone else opened it — `graphcode status <folder>`
+            // from a loop or an editor plugin joins every running sidebar to it — and
+            // that is a row appearing, not a reason to close the terminal a human is
+            // working in.
+            guard state.pendingOpenPaths.remove(path) != nil || graph.isGlobal else {
+              return .none
+            }
             state.selectedProjectPath = path
             state.openLoop = nil
             return .none
@@ -581,7 +595,11 @@ struct AppFeature {
         guard let path = state.openLoop?.projectPath else { return .none }
         return .send(.projects(.element(id: path, action: .nodeTapped(nodeID))))
 
-      case .openLoop, .welcome, .projects, .worktrees:
+      case .welcome(let welcomeAction):
+        recordPendingOpen(welcomeAction, into: &state)
+        return .none
+
+      case .openLoop, .projects, .worktrees:
         return .none
       }
     }
@@ -597,6 +615,28 @@ struct AppFeature {
 // The reducer's helpers — an extension so the type body stays inside the lint budget as
 // the state and actions above keep growing.
 extension AppFeature {
+  /// Notes that one of Welcome's four ways to open a folder — picked, recent, freshly
+  /// cloned, remote — has just sent an `.openProject`, so the snapshot it comes back as
+  /// is recognisable as this app's own doing (see the `graphChanged` handler). Every
+  /// case that sends one is listed here; a fifth would have to be added, which is why
+  /// the `switch` is exhaustive rather than a `default`.
+  private func recordPendingOpen(_ action: WelcomeFeature.Action, into state: inout State) {
+    let path: String?
+    switch action {
+    case .folderPickerResult(.success(let url)): path = url.path
+    case .recentProjectTapped(let project): path = project.path
+    case .cloneFinished(let clonedPath): path = clonedPath
+    case .remoteValidated(let projectPath): path = projectPath
+    case .binding, .openFolderButtonTapped, .folderPickerResult(.failure), .openProjectFailed,
+      .setOpenPanelPresented, .cloneRepositoryButtonTapped, .cloneLocationPicked, .cloneSubmitted,
+      .cloneCancelled, .cloneProgress, .cloneFailed, .addRemoteRepositoryButtonTapped,
+      .remoteConnectionRequested, .remoteSubmitted, .remoteCancelled, .remoteValidationFailed:
+      path = nil
+    }
+    guard let path else { return }
+    state.pendingOpenPaths.insert(ProjectRegistry.canonicalize(path))
+  }
+
   /// Steps the open workspace to another loop, in the order the sidebar draws them —
   /// every open project's nodes, flattened — wrapping at the ends and skipping blocked
   /// nodes, the same rule a direct `.nodeTapped` applies. With no workspace open it

--- a/graphcode/Tests/AppFeatureTests.swift
+++ b/graphcode/Tests/AppFeatureTests.swift
@@ -14,6 +14,9 @@ import Testing
 /// `LoopWorkspaceFeature`) replaced a cross-loop tab bar in the follow-up after that.
 @Suite
 struct AppFeatureTests {
+  // These have to be spelled the way `ProjectRegistry.canonicalize` leaves them, which
+  // for `/tmp` is unchanged: the daemon names a project by its resolved path, and
+  // selection now turns on matching that against the path the app asked for.
   private static let projectA = ProjectRef(path: "/tmp/project-a", name: "project-a")
   private static let projectB = ProjectRef(path: "/tmp/project-b", name: "project-b")
 
@@ -26,18 +29,54 @@ struct AppFeatureTests {
   @Test
   @MainActor
   func openingTwoDifferentProjectsAddsBothAndAutoSelectsTheSecond() async {
+    let sentCommands = SentCommandsBox()
     let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()
+    } withDependencies: {
+      $0.orchestratorClient.send = { command in await sentCommands.append(command) }
     }
     store.exhaustivity = .off
 
+    // Each folder is asked for the way a human asks for one — the graph that comes back
+    // is the daemon answering *this* app, which is what earns the selection.
+    await store.send(.welcome(.recentProjectTapped(Self.projectA)))
     await store.send(.daemonEvent(.graphChanged(LoopGraph(project: Self.projectA))))
     #expect(store.state.projects.count == 1)
     #expect(store.state.selectedProjectPath == Self.projectA.path)
 
+    await store.send(.welcome(.recentProjectTapped(Self.projectB)))
     await store.send(.daemonEvent(.graphChanged(LoopGraph(project: Self.projectB))))
     #expect(store.state.projects.count == 2)
     #expect(store.state.selectedProjectPath == Self.projectB.path)
+  }
+
+  /// A project can arrive because *another* client opened it — `graphcode status
+  /// <folder>`, which is how an editor plugin adds one, joins every running sidebar to
+  /// the folder it persists. The row has to appear; the human's open terminal and their
+  /// place in the sidebar must not move for it.
+  @Test
+  @MainActor
+  func aProjectOpenedByAnotherClientAppearsWithoutStealingTheOpenWorkspace() async {
+    let node = LoopNode(title: "Research", checkDescription: "Sound?")
+    var state = AppFeature.State()
+    state.projects.append(
+      ProjectFeature.State(graph: LoopGraph(project: Self.projectA, nodes: [node])))
+    state.selectedProjectPath = Self.projectA.path
+    state.openLoop = LoopWorkspaceFeature.State(
+      node: node, layout: .defaultLayout(forNode: node.id), projectPath: Self.projectA.path,
+      projectName: Self.projectA.name)
+
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.daemonEvent(.graphChanged(LoopGraph(project: Self.projectB))))
+
+    #expect(store.state.projects.count == 2)
+    #expect(store.state.projects[id: Self.projectB.path] != nil)
+    #expect(store.state.selectedProjectPath == Self.projectA.path)
+    #expect(store.state.openLoop?.node.id == node.id)
   }
 
   @Test

--- a/graphcode/Tests/LoopDeletionFromSidebarTests.swift
+++ b/graphcode/Tests/LoopDeletionFromSidebarTests.swift
@@ -114,8 +114,8 @@ struct LoopDeletionFromSidebarTests {
       node: node, layout: .defaultLayout(forNode: node.id), projectPath: Self.project.path,
       projectName: Self.project.name)
     // A second project that is *already* open. (A graph for a project the app has never
-    // seen is a different case entirely — that's "project opened", which deliberately
-    // switches away from whatever was showing.)
+    // seen is a different case entirely — that's "project opened", which switches away
+    // from whatever was showing when this app is the one that asked for it.)
     let other = ProjectRef(path: "/tmp/other", name: "other")
     let otherGraph = LoopGraph(project: other, nodes: [LoopNode(title: "Elsewhere")])
     state.projects.append(ProjectFeature.State(graph: otherGraph))

--- a/graphcode/Tests/ProjectRegistryTests.swift
+++ b/graphcode/Tests/ProjectRegistryTests.swift
@@ -23,6 +23,7 @@ struct ProjectRegistryTests {
   init() throws {
     for name in [
       "project-a", "project-b", "project-c", "project-d", "project-e", "project-f", "project-g",
+      "project-h", "project-i",
     ] {
       try FileManager.default.createDirectory(
         atPath: "/tmp/\(name)", withIntermediateDirectories: true)
@@ -343,11 +344,95 @@ struct ProjectRegistryTests {
     #expect(persistence.loadGraph(path: "/tmp/project-g") == nil)
   }
 
+  /// The bug this guards: a folder added from outside the app — `graphcode status
+  /// <folder>`, which is how an editor plugin adds one — was persisted into the open set
+  /// but reached no *running* app, so it appeared to have been ignored and only showed up
+  /// after a quit and relaunch, when the app asked for the whole set back.
+  @Test
+  func aProjectOpenedByAnotherClientReachesAnAlreadyRunningSidebar() async throws {
+    var fds: [Int32] = [0, 0]
+    #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &fds) == 0)
+    let (daemonEnd, sidebarEnd) = (fds[0], fds[1])
+    defer {
+      close(daemonEnd)
+      close(sidebarEnd)
+    }
+
+    let (registry, _) = makeRegistryAndPersistence()
+    let sidebar = UUID()
+    let cli = UUID()
+
+    async let driver: Void = {
+      await registry.addConnection(id: sidebar, fileDescriptor: daemonEnd)
+      // The app's launch sequence, against an empty open set: nothing to restore, but
+      // this is what says "I am a sidebar" — the only thing that makes the open below
+      // any of its business.
+      await registry.handle(.restoreOpenProjects, connectionID: sidebar)
+      await registry.addConnection(id: cli, fileDescriptor: -1)
+      await registry.handle(.openProject(path: "/tmp/project-h"), connectionID: cli)
+    }()
+
+    let event = try JSONDecoder().decode(
+      DaemonEvent.self, from: try await readFrameOffThread(sidebarEnd))
+    guard case .graphChanged(let graph) = event else {
+      Issue.record("expected a graphChanged event, got \(event)")
+      return
+    }
+    #expect(URL(fileURLWithPath: graph.project.path).lastPathComponent == "project-h")
+
+    await driver
+  }
+
+  /// The other half of the same rule, and the reason it isn't simply "tell everyone":
+  /// `graphcode`'s own connection reads frames until the project it named comes back
+  /// (`runAndPrintGraph`), so a project someone else opened arriving on that socket would
+  /// be printed as if it were the answer.
+  @Test
+  func aOneShotCLIConnectionIsNotJoinedToProjectsItDidNotOpen() async throws {
+    var fds: [Int32] = [0, 0]
+    #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &fds) == 0)
+    let (daemonEnd, cliEnd) = (fds[0], fds[1])
+    defer {
+      close(daemonEnd)
+      close(cliEnd)
+    }
+
+    let (registry, _) = makeRegistryAndPersistence()
+    let firstCLI = UUID()
+    let secondCLI = UUID()
+
+    async let driver: Void = {
+      await registry.addConnection(id: firstCLI, fileDescriptor: daemonEnd)
+      await registry.handle(.openProject(path: "/tmp/project-h"), connectionID: firstCLI)
+      await registry.addConnection(id: secondCLI, fileDescriptor: -1)
+      await registry.handle(.openProject(path: "/tmp/project-i"), connectionID: secondCLI)
+    }()
+
+    let event = try JSONDecoder().decode(
+      DaemonEvent.self, from: try await readFrameOffThread(cliEnd))
+    guard case .graphChanged(let graph) = event else {
+      Issue.record("expected a graphChanged event, got \(event)")
+      return
+    }
+    #expect(URL(fileURLWithPath: graph.project.path).lastPathComponent == "project-h")
+
+    await driver
+    #expect(!hasPendingBytes(cliEnd))
+  }
+
   /// Paths round-trip through `resolvingSymlinksInPath()`, so compare the leaf rather
   /// than assuming `/tmp` survives as written.
   private static func names(_ paths: [String]) -> [String] {
     paths.map { URL(fileURLWithPath: $0).lastPathComponent }
   }
+}
+
+/// Whether anything at all is waiting to be read — how "this socket was told nothing
+/// more" is asserted, without a timeout that would make the test slow when it passes.
+private func hasPendingBytes(_ fileDescriptor: Int32) -> Bool {
+  var byte: UInt8 = 0
+  let peeked = recv(fileDescriptor, &byte, 1, MSG_PEEK | MSG_DONTWAIT)
+  return peeked > 0
 }
 
 @Sendable


### PR DESCRIPTION
## The bug

`graphcode status <folder>` is the only way to add a project from outside the app — there is no `graphcode project add`; `status` opens and persists the folder as a side effect, and that is what an editor plugin drives. It persisted the folder into the shared open set and told nobody: `ProjectRegistry.open` joined only the connection that asked, so the `.graphChanged` snapshot went to the CLI and no further. A running app learned about the folder at its next launch, when it asks for the whole set back with `.restoreOpenProjects` — which is exactly the reported symptom: *the plugin's folder doesn't get added; it only appears after quitting and restarting the app.*

## The fix

**Daemon.** Asking for the whole open set now also identifies that connection as a *sidebar*. A project newly added to the set joins every attached sidebar there and then, arriving as the ordinary `.graphChanged` the app already treats as "project opened".

Deliberately not every connection: `graphcode`'s own socket reads frames until the project it named comes back (`runAndPrintGraph`, and the same loop in the remote Python shim), so joining it to an unrelated project would have it print another project's graph.

**App.** Selection now follows only a project this app asked for, tracked by canonical path (`/tmp` vs `/private/tmp` is enough to make one project look like two). A row appearing because a loop or a plugin opened a folder must not close the terminal a human is working in.

## Tests

| Test | Guards |
| --- | --- |
| `aProjectOpenedByAnotherClientReachesAnAlreadyRunningSidebar` | the reported bug — a real socket pair, sidebar sees the CLI's open |
| `aOneShotCLIConnectionIsNotJoinedToProjectsItDidNotOpen` | the CLI does not get other projects' graphs |
| `aProjectOpenedByAnotherClientAppearsWithoutStealingTheOpenWorkspace` | the row appears; selection and the open terminal stay put |
| `openingTwoDifferentProjectsAddsBothAndAutoSelectsTheSecond` | in-app Add Folder still selects what it opened |

Full suite: 954 tests pass. `make check` exits 0.

Not covered, and unchanged by this: closing/forgetting a project still only affects the window that did it. No client other than the app can close one, so there is no cross-client case to propagate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)