### PR TITLE
fix: stop leaking a PTY on every failed process launch

### DIFF
--- a/GraphcodeKit/Sources/Sessions/PTYProcessSession.swift
+++ b/GraphcodeKit/Sources/Sessions/PTYProcessSession.swift
@@ -74,7 +74,17 @@ public final class PTYProcessSession: @unchecked Sendable {
     self.events = stream
     self.eventContinuation = continuation
 
-    try process.run()
+    do {
+      try process.run()
+    } catch {
+      // A launch that never happened still allocated a PTY pair, and the slave half is
+      // ours alone to close — leaving it open pins a `/dev/ttys*` for the lifetime of the
+      // process, which for `graphcoded` means until the machine reboots. `kern.tty.ptmx_max`
+      // is 511, so a caller whose launch reliably fails exhausts the host's PTYs outright.
+      close(slave)
+      continuation.finish()
+      throw error
+    }
     // The child has its own copy of the slave fd now; close ours so EOF on the
     // master side is detectable once the child exits.
     close(slave)

--- a/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
@@ -116,9 +116,17 @@ public enum SummaryModelWriter {
     _ beat: SummaryBeat, backend: CLISessionBackendKind, workingDirectory: String?
   ) async -> SummaryBeat {
     let invocation = invocation(forBackend: backend, prompt: prompt(beat: beat))
+    // Through the launcher's login shell, not `Process`'s own launch. `Process` resolves
+    // `executableURL` as a path and never searches `PATH`, so the bare `claude` above named
+    // a file in the working directory: every rewrite on every backend threw at launch, and
+    // a failed rewrite is silent by design — exactly the "feature looks switched off"
+    // outcome `invocation` was written to prevent. It also leaked the PTY each throw had
+    // already opened, which is what exhausted `graphcoded`'s share of `kern.tty.ptmx_max`.
+    let launch = ZmxSessionLauncher.loginShellInvocation(
+      of: invocation[0], arguments: Array(invocation.dropFirst()))
     guard
       let session = try? PTYProcessSession(
-        executable: invocation[0], arguments: Array(invocation.dropFirst()),
+        executable: launch[0], arguments: Array(launch.dropFirst()),
         workingDirectory: workingDirectory)
     else { return beat }
     let outcome = await withTaskGroup(of: (Bool, String)?.self) { group in

--- a/graphcode/Tests/PTYProcessSessionTests.swift
+++ b/graphcode/Tests/PTYProcessSessionTests.swift
@@ -27,6 +27,37 @@ struct PTYProcessSessionTests {
     }
   }
 
+  /// A launch that throws used to keep the slave half of the PTY it had already opened.
+  /// `graphcoded` ran one such caller on every summary poll, so a machine left running
+  /// bled `/dev/ttys*` entries until `kern.tty.ptmx_max` (511) was gone and nothing on the
+  /// host — graphcode or otherwise — could open a terminal. Counted by path rather than by
+  /// raw descriptor count so a sibling suite spawning its own processes cannot move the
+  /// number a leak would move by exactly `attempts`.
+  @Test
+  func aLaunchThatFailsKeepsNoPTY() {
+    func openTerminalDescriptors() -> Int {
+      var count = 0
+      var path = [CChar](repeating: 0, count: Int(PATH_MAX))
+      for name in (try? FileManager.default.contentsOfDirectory(atPath: "/dev/fd")) ?? [] {
+        guard let descriptor = Int32(name), fcntl(descriptor, F_GETPATH, &path) != -1 else {
+          continue
+        }
+        if String(cString: path).hasPrefix("/dev/ttys") { count += 1 }
+      }
+      return count
+    }
+
+    let attempts = 20
+    let before = openTerminalDescriptors()
+    for _ in 0..<attempts {
+      #expect(throws: (any Error).self) {
+        _ = try PTYProcessSession(executable: "/no/such/binary", arguments: [])
+      }
+    }
+
+    #expect(openTerminalDescriptors() - before < attempts)
+  }
+
   /// The full metric pipeline short of `GraphStore`: the evaluator's real login-shell
   /// invocation, then the parser that reads its last non-empty line.
   @Test

--- a/graphcode/Tests/SummaryStoreTests.swift
+++ b/graphcode/Tests/SummaryStoreTests.swift
@@ -232,6 +232,22 @@ struct SummaryStoreTests {
     }
   }
 
+  /// `Process` resolves `executableURL` as a path and never consults `PATH`, so handing it
+  /// the bare `claude` of `invocation` named a file in the working directory and threw at
+  /// launch — every rewrite on every backend, silently, since the feature shipped. Reusing
+  /// the launcher's own login shell rather than a second spelling of it: `-i` is what makes
+  /// `~/.zshrc` (and so `~/.local/bin/claude`) visible, and the prompt rides in as a
+  /// positional so the agent's own sentence can never become shell syntax.
+  @Test
+  func theBackendIsLaunchedThroughTheLaunchersLoginShellSoItsNameResolves() {
+    let launch = ZmxSessionLauncher.loginShellInvocation(
+      of: "claude", arguments: ["-p", "it's $HOME; rm -rf /", "--model", "haiku"])
+
+    #expect(Array(launch.prefix(5)) == ["/bin/zsh", "-i", "-l", "-c", "exec claude \"$@\""])
+    #expect(
+      Array(launch.dropFirst(5)) == ["graphcode", "-p", "it's $HOME; rm -rf /", "--model", "haiku"])
+  }
+
   @Test
   func theBeatCarriesTheFactsAndTheInstructionRefusesInvention() {
     let prompt = SummaryModelWriter.prompt(


### PR DESCRIPTION
## The leak

`PTYProcessSession.init` opens a PTY pair, then closes the slave half **after** `process.run()` returns. A launch that throws skips that `close`, and nothing ever reclaims the descriptor — the master closes on dealloc, but the slave keeps its `/dev/ttys*` pinned for the lifetime of the process. For `graphcoded` that means until reboot.

`kern.tty.ptmx_max` is **511 for the entire machine**, so a caller whose launch reliably fails eventually exhausts the host's PTYs and nothing on it — graphcode or otherwise — can open a terminal.

Measured on this machine before the fix:

| Process | PTY masters held | PTY slaves held | Live children |
|---|---|---|---|
| `graphcoded` (17h uptime) | 0 | **30** | 0 |
| `graphcode.app` | 9 | 0 | 9 |

Thirty slaves, zero masters, zero children: every one is a launch that never happened. The app side is clean — one master per live surface.

## Why one caller always failed

`SummaryModelWriter.invocation` returns a bare `claude` / `copilot` / `codex`, and `Process` resolves `executableURL` as a *path* — it never searches `PATH`. So it named a file in the working directory and threw at launch:

```
Error Domain=NSCocoaErrorDomain Code=4 "The file “claude” doesn't exist."
UserInfo={NSFilePath=/Volumes/SCG/wd/graphcode/claude}
```

Every rewrite, on every backend, since the feature shipped — and a failed rewrite is silent by design, so it read as the feature being switched off rather than as a bug. That is exactly the failure the function's own doc comment was written to prevent.

It now goes through `ZmxSessionLauncher.loginShellInvocation`, the same interactive login shell the launcher starts backends with. `-i` is load-bearing: `claude` lives in `~/.local/bin`, which `.zshrc` puts on `PATH` and `zsh -l` alone never sees. The prompt rides in as a positional, so the agent's own sentence can never become shell syntax.

## Verification

- `aLaunchThatFailsKeepsNoPTY` counts the process's own `/dev/ttys*` descriptors by `F_GETPATH` across 20 failed launches. Confirmed to **fail on the unpatched code** and pass with the fix.
- Full suite: 956 tests in 98 suites, passing.
- `swift format lint --strict` clean; swiftlint unchanged (104 pre-existing warnings, 0 serious).

Note this makes the model-written summary rewrite actually run for the first time on machines with `summaryUsesModel` enabled — it is opt-in, and the per-call cost bound (`timeout` + `terminate()`) was already in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)