### PR TITLE
fix: reload graphcoded when launchd has lost the agent

### DIFF
--- a/GraphcodeKit/Sources/DaemonBootstrap.swift
+++ b/GraphcodeKit/Sources/DaemonBootstrap.swift
@@ -12,13 +12,17 @@ import Foundation
 ///
 /// Re-runs only when the bundled binaries differ from what's installed, tracked by a stamp
 /// file. That makes app updates carry daemon updates without a reinstall, and makes
-/// ordinary launches cost one small file read.
+/// ordinary launches cost one small file read — plus one `launchctl print`, because a
+/// launch also has to answer the question no file on disk can: whether the daemon the
+/// stamp vouches for is actually loaded.
 public enum DaemonBootstrap {
   public enum Outcome: Equatable {
     /// Not a packaged build, so there was nothing to install.
     case notPackaged
     /// Already installed and current.
     case upToDate
+    /// Installed and current on disk, but launchd had lost the agent; it was loaded again.
+    case reloaded
     case installed
     case failed(String)
   }
@@ -81,7 +85,13 @@ public enum DaemonBootstrap {
     let expected = stamp(forHelpersIn: bundled)
     let current = try? String(contentsOf: stampURL, encoding: .utf8)
     if current == expected, helpersInstalled(), launchAgentIsCurrent() {
-      return .upToDate
+      // Everything a file can record is right. The one thing no file records is whether
+      // launchd still has the agent, and it routinely does not: an agent loaded the
+      // legacy way is not re-bootstrapped into the next login session, so a reboot or a
+      // logout leaves a correct install with no daemon behind it and nothing to say so.
+      if daemonIsLoaded() { return .upToDate }
+      reloadDaemon()
+      return .reloaded
     }
 
     do {
@@ -208,21 +218,47 @@ public enum DaemonBootstrap {
     try data.write(to: url, options: .atomic)
   }
 
-  /// Unload then load. The unload is what makes an app update actually take: without it,
-  /// launchd keeps running the daemon binary it already started, and the freshly installed
-  /// one never gets used.
+  static var domainTarget: String { "gui/\(getuid())" }
+  static var serviceTarget: String { "\(domainTarget)/\(label)" }
+
+  /// Whether launchd currently holds the agent in this login session.
+  ///
+  /// Asking the plist, the helpers or the stamp cannot answer this — all three describe
+  /// the disk, and the disk stays perfectly correct while the daemon is gone. `print`
+  /// exits non-zero with "Could not find service" when the label is absent from the
+  /// domain, which is the only durable signal there is.
+  static func daemonIsLoaded(probe: ([String]) -> Int32 = launchctlStatus) -> Bool {
+    probe(["print", serviceTarget]) == 0
+  }
+
+  /// Bootout then bootstrap. The teardown is what makes an app update actually take:
+  /// without it, launchd keeps running the daemon binary it already started, and the
+  /// freshly installed one never gets used.
+  ///
+  /// `bootstrap`/`bootout` rather than `load`/`unload` because the legacy pair registers
+  /// the agent only for the session it is run in — the reason a reboot could strand a
+  /// healthy install without a daemon. The legacy pair stays as a fallback for the case
+  /// where the modern one is refused.
   private static func reloadDaemon() {
-    launchctl(["unload", launchAgentURL.path])
-    launchctl(["load", launchAgentURL.path])
+    launchctl(["bootout", serviceTarget])
+    if launchctlStatus(["bootstrap", domainTarget, launchAgentURL.path]) != 0 {
+      launchctl(["unload", launchAgentURL.path])
+      launchctl(["load", launchAgentURL.path])
+    }
   }
 
   private static func launchctl(_ arguments: [String]) {
+    _ = launchctlStatus(arguments)
+  }
+
+  static func launchctlStatus(_ arguments: [String]) -> Int32 {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
     process.arguments = arguments
     process.standardOutput = FileHandle.nullDevice
     process.standardError = FileHandle.nullDevice
-    try? process.run()
+    do { try process.run() } catch { return -1 }
     process.waitUntilExit()
+    return process.terminationStatus
   }
 }

--- a/graphcode/Tests/DaemonBootstrapTests.swift
+++ b/graphcode/Tests/DaemonBootstrapTests.swift
@@ -157,6 +157,42 @@ struct DaemonBootstrapTests {
       .write(to: url)
     #expect(DaemonBootstrap.launchAgentIsCurrent(at: url, expected: expected))
   }
+
+  @Test
+  func theLoadedCheckAsksLaunchdAboutThisUsersOwnAgent() {
+    // A domain target naming the wrong uid answers about someone else's login session,
+    // which on a shared machine is a probe that can only ever say "not loaded".
+    #expect(DaemonBootstrap.domainTarget == "gui/\(getuid())")
+    #expect(DaemonBootstrap.serviceTarget == "gui/\(getuid())/dev.graphcode.graphcoded")
+
+    var asked: [[String]] = []
+    _ = DaemonBootstrap.daemonIsLoaded { arguments in
+      asked.append(arguments)
+      return 0
+    }
+    #expect(asked == [["print", "gui/\(getuid())/dev.graphcode.graphcoded"]])
+  }
+
+  @Test
+  func anAgentLaunchdHasLostReadsAsNotLoaded() {
+    // The whole of issue #152: the stamp, the helpers and the plist all still say the
+    // install is good, so the only thing that can notice a daemon dropping out of
+    // launchd — a reboot the legacy-loaded agent did not survive — is a non-zero exit
+    // from `print`.
+    #expect(DaemonBootstrap.daemonIsLoaded { _ in 0 })
+    #expect(!DaemonBootstrap.daemonIsLoaded { _ in 113 })
+    #expect(!DaemonBootstrap.daemonIsLoaded { _ in -1 })
+  }
+
+  @Test
+  func launchctlReportsAMissingServiceAsAFailure() {
+    // Pins the exit-code contract the check above rests on against the real tool: a
+    // label no one has ever loaded must not come back as zero, or the self-heal is a
+    // branch that never runs.
+    #expect(
+      DaemonBootstrap.launchctlStatus(
+        ["print", "gui/\(getuid())/dev.graphcode.definitely-not-a-real-agent"]) != 0)
+  }
 }
 
 /// Anchors `Bundle(for:)` on the test bundle, which has no embedded helpers.


### PR DESCRIPTION
Fixes #152.

## The gap

`DaemonBootstrap.installIfNeeded()` decided an install was current from three things — the stamp, the installed helpers, and the plist content. All three describe the disk, and the disk stays perfectly correct while `graphcoded` is gone from launchd. Once the stamp was written, every later launch returned `.upToDate` and `reloadDaemon()` was never reached.

`launchctl load` registers an agent only for the session it runs in, so a reboot or logout could strand a healthy install with no daemon and nothing to say why.

## The fix

- `daemonIsLoaded()` probes `launchctl print gui/<uid>/dev.graphcode.graphcoded` before the `.upToDate` short-circuit; when the label is absent the agent is reloaded and a new `.reloaded` outcome is returned.
- `reloadDaemon()` moves from `unload`/`load` to `bootout`/`bootstrap gui/<uid>`, the supported API that registers the agent for auto-load at login. The legacy pair stays as a fallback if the modern one is refused.

## Verification

Exit-code contract checked against the real tool on macOS 26:

| Command | Exit |
|---|---|
| `print` on a missing label | 113 |
| `print` on a loaded label | 0 |
| `bootout` on a not-loaded label | 3 (ignored) |
| `bootstrap` of an absent agent | 0, service appears |

Three tests added. Full suite: 959 tests passed. `swift format lint --strict` clean; swiftlint reports no violations in either changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1aPiJc3UHzEf2JfRjZ1Bz