### PR TITLE
feat: back/forward through the loops you have opened

### DIFF
--- a/GraphcodeKit/Sources/LoopHistory.swift
+++ b/GraphcodeKit/Sources/LoopHistory.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// Somewhere the workspace pane has been — a loop in a project, or a quick chat. Both
+/// open the same `LoopWorkspaceFeature`, so both belong in the same history; a Back that
+/// silently stepped over the chat you were just in would be a Back that lies.
+///
+/// A loop carries its project path as well as its node id because the id alone cannot be
+/// resolved: the app holds several projects at once and only the pair names a node.
+public enum LoopVisit: Codable, Equatable, Sendable {
+  case loop(projectPath: String, nodeID: UUID)
+  case quickChat(id: UUID)
+
+  public var nodeID: UUID {
+    switch self {
+    case .loop(_, let nodeID): return nodeID
+    case .quickChat(let id): return id
+    }
+  }
+}
+
+/// A browser's back/forward stack over visited loops.
+///
+/// Deliberately a plain value with no knowledge of graphs, projects or the store: the
+/// interesting behaviour here is the cursor arithmetic and the truncation rule, and both
+/// are worth testing without an app around them. Resolving a visit against live state —
+/// which projects are open, which nodes still exist — is the reducer's job, handed in as
+/// a predicate so a stale entry can be stepped over rather than dead-ending the stack.
+public struct LoopHistory: Codable, Equatable, Sendable {
+  /// Oldest first. `cursor` indexes the entry currently on screen; `nil` means the
+  /// history is empty or nothing from it is open.
+  public private(set) var entries: [LoopVisit]
+  public private(set) var cursor: Int?
+
+  /// Long enough to cover any session's worth of moving around, short enough that the
+  /// file stays trivial and a runaway loop of opens can't grow it without bound.
+  static let limit = 50
+
+  public init(entries: [LoopVisit] = [], cursor: Int? = nil) {
+    self.entries = entries
+    self.cursor = LoopHistory.clamp(cursor, to: entries)
+  }
+
+  /// A file written by a future build, or hand-edited, must not be able to put the
+  /// cursor outside the entries it indexes.
+  private static func clamp(_ cursor: Int?, to entries: [LoopVisit]) -> Int? {
+    guard let cursor, !entries.isEmpty else { return nil }
+    return min(max(cursor, 0), entries.count - 1)
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let entries = try container.decodeIfPresent([LoopVisit].self, forKey: .entries) ?? []
+    let cursor = try container.decodeIfPresent(Int.self, forKey: .cursor)
+    self.init(entries: entries, cursor: cursor)
+  }
+
+  public var canGoBack: Bool { (cursor ?? 0) > 0 && !entries.isEmpty }
+  public var canGoForward: Bool {
+    guard let cursor else { return false }
+    return cursor < entries.count - 1
+  }
+
+  public var current: LoopVisit? { cursor.map { entries[$0] } }
+
+  /// Records an arrival the human chose — a tap, the jump palette, the attention rollup.
+  ///
+  /// Truncating everything ahead of the cursor is what makes this a browser rather than
+  /// a ring: once you go back two loops and then open a third, the branch you left is
+  /// gone, exactly as a browser discards forward history on a new navigation.
+  ///
+  /// Re-opening the loop already on screen is not a visit. It happens constantly —
+  /// tapping the selected row, a rename re-selecting its own node — and each one would
+  /// otherwise pad the stack with a step that goes nowhere.
+  public mutating func record(_ visit: LoopVisit) {
+    if current == visit { return }
+    if let cursor, cursor < entries.count - 1 {
+      entries.removeSubrange((cursor + 1)...)
+    }
+    entries.append(visit)
+    if entries.count > LoopHistory.limit {
+      entries.removeFirst(entries.count - LoopHistory.limit)
+    }
+    cursor = entries.count - 1
+  }
+
+  /// The nearest entry behind the cursor that `isResolvable` accepts, moving the cursor
+  /// onto it. Entries that no longer resolve — a closed project, a deleted loop — are
+  /// stepped over rather than removed: the same file is read again next launch, when the
+  /// project may well be open, and a Back that deleted history on a transient miss would
+  /// quietly erase it.
+  ///
+  /// When nothing behind the cursor resolves, the cursor does not move and `nil` comes
+  /// back, so a dead tail cannot strand the user somewhere they never were.
+  public mutating func back(where isResolvable: (LoopVisit) -> Bool) -> LoopVisit? {
+    step(by: -1, where: isResolvable)
+  }
+
+  public mutating func forward(where isResolvable: (LoopVisit) -> Bool) -> LoopVisit? {
+    step(by: +1, where: isResolvable)
+  }
+
+  private mutating func step(by offset: Int, where isResolvable: (LoopVisit) -> Bool)
+    -> LoopVisit?
+  {
+    guard let cursor else { return nil }
+    var candidate = cursor + offset
+    while candidate >= 0 && candidate < entries.count {
+      if isResolvable(entries[candidate]) {
+        self.cursor = candidate
+        return entries[candidate]
+      }
+      candidate += offset
+    }
+    return nil
+  }
+}

--- a/GraphcodeKit/Sources/LoopHistoryStore.swift
+++ b/GraphcodeKit/Sources/LoopHistoryStore.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Reads/writes the back/forward stack — one JSON file under `<baseDirectory>`. Same
+/// shape as `QuickChatStore` and for the same reason: small local file I/O, app-side
+/// state the daemon has no reason to know about.
+///
+/// Nothing is validated on the way in. Which loops still exist is a question only the
+/// live graphs can answer, and at load time none of them have arrived from the daemon
+/// yet — a validating load would throw away a perfectly good history every launch.
+/// `LoopHistory.back(where:)` steps over what no longer resolves instead.
+public struct LoopHistoryStore: Sendable {
+  private let fileURL: URL
+
+  public init(baseDirectory: URL) {
+    try? FileManager.default.createDirectory(
+      at: baseDirectory, withIntermediateDirectories: true)
+    fileURL = baseDirectory.appendingPathComponent("loop-history.json")
+  }
+
+  public func load() -> LoopHistory {
+    guard let data = try? Data(contentsOf: fileURL) else { return LoopHistory() }
+    return (try? JSONDecoder().decode(LoopHistory.self, from: data)) ?? LoopHistory()
+  }
+
+  public func save(_ history: LoopHistory) {
+    guard let data = try? JSONEncoder().encode(history) else { return }
+    try? data.write(to: fileURL, options: .atomic)
+  }
+}

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -15,6 +15,7 @@ page is the same information in one place.
 |---|---|
 | ⌘K | Jump to any loop by name, across every open project. ↑/↓ to choose, ⏎ to open |
 | ⌘⇧R | Review what needs you — works the attention queue oldest-first, from anywhere |
+| ⌥⌘← / ⌥⌘→ | Back / forward through the loops you have opened, in the order you opened them |
 | ⌘⇧] / ⌘⇧[ | Next / previous loop, in sidebar order across projects |
 | ⌥G | Show or hide the loop panel — the downstream rail with the one-hop minimap and metric sparkline |
 | ⌘= / ⌘− | Zoom the canvas in / out |
@@ -22,6 +23,12 @@ page is the same information in one place.
 | ⌘9 | Fit the whole graph |
 | ⌘O | Open a project folder (from the Welcome window) |
 | ⌘, | Settings |
+
+The two pairs answer different questions. ⌘⇧] / ⌘⇧[ walk the sidebar — what sits
+*beside* the loop you are on. ⌥⌘← / ⌥⌘→ walk your own trail: open A, then P in another
+project, then Q, and Back retraces Q → P → A regardless of where those loops live.
+Opening a loop after going back discards the forward trail, the way a browser does.
+Quick Chats count as places you have been. The trail survives quitting the app.
 
 ## Terminals
 

--- a/graphcode/Sources/Clients/LoopHistoryClient.swift
+++ b/graphcode/Sources/Clients/LoopHistoryClient.swift
@@ -1,0 +1,26 @@
+import Dependencies
+import Foundation
+import GraphcodeKit
+
+/// Retroactive `DependencyKey` conformance for `GraphcodeKit`'s `LoopHistoryStore` —
+/// here rather than in `GraphcodeKit` for the same reason as `QuickChatStore`'s:
+/// `GraphcodeKit` never imports `Dependencies`, and where a human has been is app-UI-only.
+extension LoopHistoryStore: DependencyKey {
+  public static let liveValue = LoopHistoryStore(baseDirectory: SupportDirectory.url)
+
+  /// A throwaway directory per access, so the dozens of tests that merely *open a loop*
+  /// on their way to asserting something else don't each have to override this — and so
+  /// none of them can read or write the developer's own history file.
+  public static var testValue: LoopHistoryStore {
+    LoopHistoryStore(
+      baseDirectory: FileManager.default.temporaryDirectory
+        .appendingPathComponent("graphcode-history-tests-\(UUID().uuidString)", isDirectory: true))
+  }
+}
+
+extension DependencyValues {
+  var loopHistoryStore: LoopHistoryStore {
+    get { self[LoopHistoryStore.self] }
+    set { self[LoopHistoryStore.self] = newValue }
+  }
+}

--- a/graphcode/Sources/Features/App/AppFeature+History.swift
+++ b/graphcode/Sources/Features/App/AppFeature+History.swift
@@ -1,0 +1,105 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+
+/// ⌥⌘← / ⌥⌘→ — where this human has actually been, as opposed to what sits next to what.
+///
+/// `selectNextLoop`/`selectPreviousLoop` walk sidebar order, which answers "what is
+/// beside this loop". Clicking A, then P in another project, then Q answers a different
+/// question entirely, and until now nothing in the app could retrace it. This is that
+/// second answer: a browser's back/forward stack, with the same truncation rule.
+///
+/// Kept out of `AppFeature.swift` because that type is at swiftlint's body-length limit,
+/// and because the recording rule reads better next to the walking rule than a hundred
+/// lines from it.
+extension AppFeature {
+  /// Opens what a history step landed on, *without* recording it.
+  ///
+  /// This is the whole reason back/forward doesn't go through `.nodeTapped`: that action
+  /// records, and a Back that recorded would append the place it just came from, so the
+  /// next Back would return there and the stack would oscillate between two loops
+  /// forever. Two entry points, one of which records, is clearer than a flag saying
+  /// "don't record this one" that every future caller has to remember to set.
+  var historyReducer: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      // The predicate closes over a snapshot taken before `&state` is borrowed —
+      // building it inside the call would be two overlapping accesses to the same
+      // variable, one of them exclusive.
+      case .historyBackTapped:
+        let isResolvable = canResolve(state)
+        return step(&state) { $0.back(where: isResolvable) }
+
+      case .historyForwardTapped:
+        let isResolvable = canResolve(state)
+        return step(&state) { $0.forward(where: isResolvable) }
+
+      default:
+        return .none
+      }
+    }
+  }
+
+  private func step(
+    _ state: inout State, _ move: (inout LoopHistory) -> LoopVisit?
+  ) -> Effect<Action> {
+    var history = state.loopHistory
+    guard let visit = move(&history) else { return .none }
+    state.loopHistory = history
+    loopHistoryStore.save(history)
+    switch visit {
+    case .loop(let projectPath, let nodeID):
+      openLoopWithoutRecording(&state, projectPath: projectPath, nodeID: nodeID)
+    case .quickChat(let id):
+      guard let chat = state.quickChats[id: id] else { return .none }
+      openQuickChat(chat, &state)
+    }
+    return .none
+  }
+
+  /// Whether a remembered visit can still be opened *right now*. A closed project or a
+  /// deleted loop makes an entry unreachable rather than wrong, so the walk steps over
+  /// it and the entry stays in the file — the project may well be open again next
+  /// launch, and a history that erased itself on a transient miss would be worse than
+  /// no history.
+  ///
+  /// The blocked-node rule is the one `.nodeTapped` applies, repeated rather than shared
+  /// because the two differ in what they do when it fails: a tap on a blocked loop is
+  /// ignored, a Back onto one keeps walking.
+  private func canResolve(_ state: State) -> (LoopVisit) -> Bool {
+    { visit in
+      switch visit {
+      case .loop(let projectPath, let nodeID):
+        guard let node = state.projects[id: projectPath]?.graph.nodes[id: nodeID] else {
+          return false
+        }
+        return node.state != .blocked || node.presenceShowsLiveSession
+      case .quickChat(let id):
+        return state.quickChats[id: id] != nil
+      }
+    }
+  }
+
+  private func openLoopWithoutRecording(
+    _ state: inout State, projectPath: String, nodeID: UUID
+  ) {
+    guard let project = state.projects[id: projectPath],
+      let node = project.graph.nodes[id: nodeID]
+    else { return }
+    let layout = terminalLayoutStore.load(forNode: nodeID) ?? .defaultLayout(forNode: nodeID)
+    state.openLoop = LoopWorkspaceFeature.State(
+      node: node,
+      graph: project.graph,
+      layout: layout,
+      projectPath: projectPath,
+      projectName: project.graph.project.name)
+    state.selectedProjectPath = projectPath
+  }
+
+  /// Records an arrival the human chose. Called from the two places a workspace opens on
+  /// purpose — a loop tap and a quick chat tap — and from neither of the history steps.
+  func recordVisit(_ visit: LoopVisit, _ state: inout State) {
+    state.loopHistory.record(visit)
+    loopHistoryStore.save(state.loopHistory)
+  }
+}

--- a/graphcode/Sources/Features/App/AppFeature+QuickChats.swift
+++ b/graphcode/Sources/Features/App/AppFeature+QuickChats.swift
@@ -21,6 +21,7 @@ extension AppFeature {
         state.quickChats.append(chat)
         quickChatStore.save(Array(state.quickChats))
         openQuickChat(chat, &state)
+        recordVisit(.quickChat(id: chat.id), &state)
         return .none
 
       case .quickChatsTapped:
@@ -32,6 +33,7 @@ extension AppFeature {
         guard let chat = state.quickChats[id: id] else { return .none }
         guard state.openLoop?.node.id != id else { return .none }
         openQuickChat(chat, &state)
+        recordVisit(.quickChat(id: id), &state)
         return .none
 
       case .quickChatRenameRequested(let id):
@@ -100,7 +102,7 @@ extension AppFeature {
   /// node's id is the chat's, so the workspace attaches to the chat's own long-lived
   /// zmx session, scrollback and all. Home as the working directory — a chat belongs
   /// to no project on purpose.
-  private func openQuickChat(_ chat: QuickChat, _ state: inout State) {
+  func openQuickChat(_ chat: QuickChat, _ state: inout State) {
     let node = LoopNode(
       id: chat.id,
       title: chat.title,

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -88,6 +88,9 @@ struct AppFeature {
     /// sidebar's help button asks for it again.
     var showingOnboarding = false
 
+    /// Where the workspace pane has been, for ⌥⌘← / ⌥⌘→ — see `AppFeature+History.swift`.
+    var loopHistory = LoopHistory()
+
     /// The loop ⌘⇧R landed on last, so pressing it again moves to the next one waiting
     /// instead of re-opening the same loop forever. View state only, and deliberately
     /// not persisted: a queue position is about this sitting, not about this graph.
@@ -201,6 +204,10 @@ struct AppFeature {
     /// across every open project. See `stepOpenLoop`.
     case selectNextLoop
     case selectPreviousLoop
+    /// ⌥⌘← / ⌥⌘→ — retrace the loops this human actually opened, in the order they
+    /// opened them. See `AppFeature+History.swift`.
+    case historyBackTapped
+    case historyForwardTapped
     /// The stop/kill affordance docs/05-orchestrator.md asks the monitor for.
     case stopNodeTapped(projectPath: String, nodeID: UUID)
     /// The first-launch terminology primer — see `OnboardingView`.
@@ -262,6 +269,7 @@ struct AppFeature {
   /// `TerminalSurfaceStore` — but a deleted loop, or a closed project, is never coming
   /// back, and its terminals shouldn't sit in the cache waiting to age out.
   @Dependency(\.terminalSurfaceClient) var terminalSurfaceClient
+  @Dependency(\.loopHistoryStore) var loopHistoryStore
 
   var body: some ReducerOf<Self> {
     Scope(state: \.welcome, action: \.welcome) {
@@ -273,6 +281,7 @@ struct AppFeature {
     quickChatsReducer
     jumpPaletteReducer
     updatesReducer
+    historyReducer
     // Before the main Reduce on purpose: its `.graphChanged` diff needs the previous
     // graph, which the main reducer replaces. See `AppFeature+Worktrees.swift`.
     AppWorktreesReducer()
@@ -280,34 +289,7 @@ struct AppFeature {
     Reduce { state, action in
       switch action {
       case .task:
-        state.quickChats = IdentifiedArray(uniqueElements: quickChatStore.load())
-        // Once, not every launch: the primer's value is on day one, and re-showing it
-        // to someone who has loops running would read as the app forgetting them.
-        if !UserDefaults.standard.bool(forKey: "hasSeenOnboarding") {
-          state.showingOnboarding = true
-        }
-        return .merge(
-          .run { send in
-            for await event in orchestratorClient.connect() {
-              await send(.daemonEvent(event))
-            }
-          }
-          .cancellable(id: CancelID.daemonSubscription),
-          .run { _ in try? await orchestratorClient.send(.listRecentProjects) },
-          // Without this the sidebar comes up empty on every launch even though the
-          // daemon has been persisting every project all along — the app just never
-          // asked for them back. Each restored project arrives as an ordinary
-          // `.graphChanged`, handled below.
-          .run { _ in try? await orchestratorClient.send(.restoreOpenProjects) },
-          // The global Orchestrator Graph is always resident, so the app joins it every
-          // launch rather than restoring it — it isn't a folder anyone opened, and its
-          // triggers have been running whether or not this window existed.
-          .run { _ in try? await orchestratorClient.send(.openGlobalGraph) },
-          // Quietly ask whether there's a newer build, so the sidebar banner can offer
-          // it without waiting for someone to open the menu. Silent on failure and on
-          // "up to date" — a launch must never raise an alert about updates.
-          .send(.checkForUpdatesInBackground)
-        )
+        return start(&state)
 
       case .daemonEvent(let event):
         switch event {
@@ -485,6 +467,11 @@ struct AppFeature {
         UserDefaults.standard.set(true, forKey: "hasSeenOnboarding")
         return .none
 
+      // Both handled by `historyReducer`, in `AppFeature+History.swift` — listed here
+      // only so this switch stays exhaustive.
+      case .historyBackTapped, .historyForwardTapped:
+        return .none
+
       // Every update action is handled by `updatesReducer`, in
       // `AppFeature+Updates.swift` — listed here only so this switch stays exhaustive.
       case .checkForUpdatesTapped, .checkForUpdatesInBackground, .updateFoundInBackground,
@@ -534,6 +521,7 @@ struct AppFeature {
           projectPath: path,
           projectName: state.projects[id: path]?.graph.project.name ?? path)
         state.selectedProjectPath = path
+        recordVisit(.loop(projectPath: path, nodeID: nodeID), &state)
         return .none
 
       // A loop's own primary Claude Code session exiting *is* its resolution — no
@@ -615,6 +603,47 @@ struct AppFeature {
 // The reducer's helpers — an extension so the type body stays inside the lint budget as
 // the state and actions above keep growing.
 extension AppFeature {
+
+  /// Everything a launch has to do: restore the app-local lists, decide whether the
+  /// primer is due, and open the daemon subscription the whole app hangs off.
+  ///
+  /// In the extension rather than the switch because the type body is at swiftlint's
+  /// limit, and this case was by some distance the longest one in it.
+  private func start(_ state: inout State) -> Effect<Action> {
+    state.quickChats = IdentifiedArray(uniqueElements: quickChatStore.load())
+    // Not validated against live graphs here: no project has arrived from the daemon
+    // yet, so every entry would look stale and the whole history would be thrown
+    // away on every launch. `LoopHistory.back(where:)` resolves lazily instead.
+    state.loopHistory = loopHistoryStore.load()
+    // Once, not every launch: the primer's value is on day one, and re-showing it
+    // to someone who has loops running would read as the app forgetting them.
+    if !UserDefaults.standard.bool(forKey: "hasSeenOnboarding") {
+      state.showingOnboarding = true
+    }
+    return .merge(
+      .run { send in
+        for await event in orchestratorClient.connect() {
+          await send(.daemonEvent(event))
+        }
+      }
+      .cancellable(id: CancelID.daemonSubscription),
+      .run { _ in try? await orchestratorClient.send(.listRecentProjects) },
+      // Without this the sidebar comes up empty on every launch even though the
+      // daemon has been persisting every project all along — the app just never
+      // asked for them back. Each restored project arrives as an ordinary
+      // `.graphChanged`, handled below.
+      .run { _ in try? await orchestratorClient.send(.restoreOpenProjects) },
+      // The global Orchestrator Graph is always resident, so the app joins it every
+      // launch rather than restoring it — it isn't a folder anyone opened, and its
+      // triggers have been running whether or not this window existed.
+      .run { _ in try? await orchestratorClient.send(.openGlobalGraph) },
+      // Quietly ask whether there's a newer build, so the sidebar banner can offer
+      // it without waiting for someone to open the menu. Silent on failure and on
+      // "up to date" — a launch must never raise an alert about updates.
+      .send(.checkForUpdatesInBackground)
+    )
+  }
+
   /// Notes that one of Welcome's four ways to open a folder — picked, recent, freshly
   /// cloned, remote — has just sent an `.openProject`, so the snapshot it comes back as
   /// is recognisable as this app's own doing (see the `graphChanged` handler). Every

--- a/graphcode/Sources/Features/App/GraphcodeCommands.swift
+++ b/graphcode/Sources/Features/App/GraphcodeCommands.swift
@@ -49,6 +49,17 @@ struct GraphcodeCommands: Commands {
 
       Divider()
 
+      // Where you have been, as opposed to what sits beside what — the two below walk
+      // sidebar order, these walk the order loops were actually opened in.
+      Button("Back") { store.send(.historyBackTapped) }
+        .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
+        .disabled(!store.loopHistory.canGoBack)
+      Button("Forward") { store.send(.historyForwardTapped) }
+        .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
+        .disabled(!store.loopHistory.canGoForward)
+
+      Divider()
+
       Button("Next Loop") { store.send(.selectNextLoop) }
         .keyboardShortcut("]", modifiers: [.command, .shift])
       Button("Previous Loop") { store.send(.selectPreviousLoop) }

--- a/graphcode/Tests/LoopHistoryTests.swift
+++ b/graphcode/Tests/LoopHistoryTests.swift
@@ -1,0 +1,225 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// The back/forward stack behind ⌥⌘← / ⌥⌘→ (#154).
+///
+/// The rules worth pinning are the ones that separate a browser from a ring: a new visit
+/// discards the forward branch, a repeat of the current place is not a visit at all, and
+/// a step walks past what can no longer be opened instead of dead-ending on it.
+@Suite
+struct LoopHistoryTests {
+  private let alpha = UUID()
+  private let papa = UUID()
+  private let quebec = UUID()
+
+  private func visit(_ id: UUID, project: String = "/a") -> LoopVisit {
+    .loop(projectPath: project, nodeID: id)
+  }
+
+  private let anythingResolves: (LoopVisit) -> Bool = { _ in true }
+
+  @Test
+  func backAndForwardRetraceTheOrderLoopsWereOpenedIn() {
+    // The issue's own example: A, P, Q clicked across different projects, then back to
+    // Q -> P -> A and forward again.
+    var history = LoopHistory()
+    history.record(visit(alpha, project: "/one"))
+    history.record(visit(papa, project: "/two"))
+    history.record(visit(quebec, project: "/three"))
+
+    #expect(history.current == visit(quebec, project: "/three"))
+    #expect(history.back(where: anythingResolves) == visit(papa, project: "/two"))
+    #expect(history.back(where: anythingResolves) == visit(alpha, project: "/one"))
+    #expect(!history.canGoBack)
+    #expect(history.back(where: anythingResolves) == nil)
+
+    #expect(history.forward(where: anythingResolves) == visit(papa, project: "/two"))
+    #expect(history.forward(where: anythingResolves) == visit(quebec, project: "/three"))
+    #expect(!history.canGoForward)
+    #expect(history.forward(where: anythingResolves) == nil)
+  }
+
+  @Test
+  func openingSomewhereNewDiscardsTheForwardTrail() {
+    // What makes this a browser rather than a ring. Go back to A, open Q, and P is gone
+    // — the branch was left, exactly as a browser drops forward history on a new
+    // navigation.
+    var history = LoopHistory()
+    history.record(visit(alpha))
+    history.record(visit(papa))
+    _ = history.back(where: anythingResolves)
+
+    history.record(visit(quebec))
+
+    #expect(history.entries == [visit(alpha), visit(quebec)])
+    #expect(!history.canGoForward)
+    #expect(history.back(where: anythingResolves) == visit(alpha))
+  }
+
+  @Test
+  func revisitingALoopAlreadyInTheStackPushesAgain() {
+    // Browser-faithful rather than most-recent-wins: A is in the stack twice, so one
+    // Back from the second A still lands on Q rather than skipping to P.
+    var history = LoopHistory()
+    history.record(visit(alpha))
+    history.record(visit(papa))
+    history.record(visit(quebec))
+    history.record(visit(alpha))
+
+    #expect(history.entries == [visit(alpha), visit(papa), visit(quebec), visit(alpha)])
+    #expect(history.back(where: anythingResolves) == visit(quebec))
+  }
+
+  @Test
+  func reopeningTheLoopAlreadyOnScreenIsNotAVisit() {
+    // This happens constantly — tapping the selected row, a rename re-selecting its own
+    // node — and each one would otherwise pad the stack with a step that goes nowhere.
+    var history = LoopHistory()
+    history.record(visit(alpha))
+    history.record(visit(papa))
+    history.record(visit(papa))
+    history.record(visit(papa))
+
+    #expect(history.entries == [visit(alpha), visit(papa)])
+    #expect(history.back(where: anythingResolves) == visit(alpha))
+  }
+
+  @Test
+  func aStepWalksPastLoopsThatCanNoLongerBeOpened() {
+    // A closed project or a deleted loop must not dead-end the stack. P is gone, so one
+    // Back from Q lands on A rather than stopping.
+    var history = LoopHistory()
+    history.record(visit(alpha))
+    history.record(visit(papa))
+    history.record(visit(quebec))
+
+    let missingPapa: (LoopVisit) -> Bool = { $0.nodeID != self.papa }
+    #expect(history.back(where: missingPapa) == visit(alpha))
+    #expect(history.current == visit(alpha))
+  }
+
+  @Test
+  func anUnreachableEntryIsSteppedOverNotDeleted() {
+    // Unreachable is not the same as wrong: the project may well be open again next
+    // launch. A history that erased itself on a transient miss would be worse than no
+    // history at all.
+    var history = LoopHistory()
+    history.record(visit(alpha))
+    history.record(visit(papa))
+    history.record(visit(quebec))
+
+    _ = history.back(where: { $0.nodeID != self.papa })
+    #expect(history.entries.contains(visit(papa)))
+
+    // Once its project is back, the entry works again.
+    #expect(history.forward(where: anythingResolves) == visit(papa))
+  }
+
+  @Test
+  func aStepThatFindsNothingReachableLeavesTheCursorAlone() {
+    // The alternative — moving anyway — would drop the user somewhere they never were.
+    var history = LoopHistory()
+    history.record(visit(alpha))
+    history.record(visit(papa))
+
+    #expect(history.back(where: { _ in false }) == nil)
+    #expect(history.current == visit(papa))
+    #expect(history.canGoBack)
+  }
+
+  @Test
+  func quickChatsShareTheStackWithLoops() {
+    // They open the same workspace, so a Back that stepped over the chat you were just
+    // in would be a Back that lies.
+    let chat = UUID()
+    var history = LoopHistory()
+    history.record(visit(alpha))
+    history.record(.quickChat(id: chat))
+    history.record(visit(papa))
+
+    #expect(history.back(where: anythingResolves) == .quickChat(id: chat))
+    #expect(history.back(where: anythingResolves) == visit(alpha))
+  }
+
+  @Test
+  func aDeletedChatIsSteppedOverLikeAnyOtherUnreachableEntry() {
+    let chat = UUID()
+    var history = LoopHistory()
+    history.record(visit(alpha))
+    history.record(.quickChat(id: chat))
+    history.record(visit(papa))
+
+    #expect(history.back(where: { $0 != .quickChat(id: chat) }) == visit(alpha))
+  }
+
+  @Test
+  func theStackIsBoundedAndDropsItsOldestEntriesFirst() {
+    // A runaway loop of opens must not grow the file without bound; the oldest end is
+    // the one nobody is walking back to.
+    var history = LoopHistory()
+    let ids = (0..<(LoopHistory.limit + 10)).map { _ in UUID() }
+    for id in ids { history.record(visit(id)) }
+
+    #expect(history.entries.count == LoopHistory.limit)
+    #expect(history.entries.first == visit(ids[10]))
+    #expect(history.entries.last == visit(ids[ids.count - 1]))
+    #expect(history.current == visit(ids[ids.count - 1]))
+  }
+
+  @Test
+  func anEmptyHistoryOffersNeitherDirection() {
+    let history = LoopHistory()
+    #expect(!history.canGoBack)
+    #expect(!history.canGoForward)
+    #expect(history.current == nil)
+  }
+
+  @Test
+  func aHistoryRoundTripsThroughItsFile() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("graphcode-history-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let store = LoopHistoryStore(baseDirectory: directory)
+
+    #expect(store.load() == LoopHistory())
+
+    var history = LoopHistory()
+    history.record(visit(alpha, project: "/one"))
+    history.record(.quickChat(id: papa))
+    history.record(visit(quebec, project: "/three"))
+    _ = history.back(where: anythingResolves)
+    store.save(history)
+
+    let restored = store.load()
+    #expect(restored == history)
+    #expect(restored.current == .quickChat(id: papa))
+    #expect(restored.canGoForward)
+  }
+
+  @Test
+  func aCorruptOrOutOfRangeFileDoesNotStrandTheCursor() throws {
+    // The file is small, local and hand-editable, and a cursor pointing past the end
+    // would crash the walk rather than merely losing history.
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("graphcode-history-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let store = LoopHistoryStore(baseDirectory: directory)
+
+    try Data("not json".utf8)
+      .write(to: directory.appendingPathComponent("loop-history.json"))
+    #expect(store.load() == LoopHistory())
+
+    let overshot = LoopHistory(entries: [visit(alpha), visit(papa)], cursor: 99)
+    #expect(overshot.cursor == 1)
+    #expect(!overshot.canGoForward)
+
+    let undershot = LoopHistory(entries: [visit(alpha)], cursor: -5)
+    #expect(undershot.cursor == 0)
+    #expect(!undershot.canGoBack)
+
+    #expect(LoopHistory(entries: [], cursor: 3).cursor == nil)
+  }
+}


### PR DESCRIPTION
Closes #154.

## The gap

`⌘⇧]` / `⌘⇧[` call `stepOpenLoop` — a flattened list of every non-blocked node across all projects, stepped by ±1. That answers "what sits beside this loop". Open A, then P in another project, then Q, and nothing in the app could retrace that trail.

## What this adds

`⌥⌘←` / `⌥⌘→` — a browser's back/forward stack over the loops and quick chats actually opened, in the order they were opened. The adjacency shortcuts are unchanged.

- **Browser-faithful truncation.** Going back and then opening somewhere new discards the forward branch.
- **Revisits push.** A loop already in the stack gets a fresh entry rather than being moved, so Back stays predictable.
- **Re-opening the current loop is not a visit.** Tapping the selected row, a rename re-selecting its own node — these happen constantly and would pad the stack with steps that go nowhere.
- **Quick Chats count.** They open the same `LoopWorkspaceFeature`, so a Back that stepped over one would be a Back that lies.
- **Persists across launches**, in `loop-history.json` beside `quick-chats.json`.

## Two decisions worth flagging

**Back/forward do not route through `.nodeTapped`.** That action records; a Back that used it would append the place it just came from, so the next Back would return there and the stack would oscillate between two loops forever. Two entry points — one records, one doesn't — beats a "don't record this one" flag every future caller has to remember to set.

**The stack is not validated at load.** Projects arrive from the daemon asynchronously, so at `.task` time every entry looks stale and a validating load would empty the history on every launch. `LoopHistory.back(where:)` resolves lazily instead: it steps over what a closed project or deleted loop has made unreachable, and leaves the entry in the file for the launch where it works again. A step that finds nothing reachable leaves the cursor alone rather than dropping the user somewhere they never were.

## Notes

- `.task`'s handler moved to the trailing extension — the two new actions and their state tipped `AppFeature` over swiftlint's 350-line body limit (356). Now 340.
- `LoopHistoryStore` gets a `testValue` over a throwaway directory, so the many tests that merely open a loop en route to asserting something else don't each need an override.

## Verification

| Check | Result |
|---|---|
| Full suite | 972 tests passed |
| New `LoopHistoryTests` | 13 passed |
| `swift format lint --strict` | clean |
| swiftlint | 0 serious |

Docs updated in `docs/shortcuts.md`, including why the two pairs exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1aPiJc3UHzEf2JfRjZ1Bz