### PR TITLE
Workspaces: separate graphs, daemon and loops per window

### DIFF
--- a/GraphcodeKit/Sources/DaemonBootstrap.swift
+++ b/GraphcodeKit/Sources/DaemonBootstrap.swift
@@ -27,7 +27,10 @@ public enum DaemonBootstrap {
     case failed(String)
   }
 
-  private static let label = "dev.graphcode.graphcoded"
+  /// One agent per workspace, so that opening a second one installs a daemon of its own
+  /// instead of rewriting the first's. The default workspace keeps the bare label it has
+  /// always had — an existing install must not see its agent renamed.
+  static var label: String { Workspace.current.daemonLabel }
   private static let appBundleIdentifier = "dev.graphcode.app"
   /// `graphcode` here is the CLI, not the app — a different product that happens to share
   /// the name a human types. Shipping it matters: `~/.graphcode/bin` is what the README
@@ -167,11 +170,20 @@ public enum DaemonBootstrap {
 
   /// Built here rather than shipped as a template file: the two paths it needs are already
   /// known at runtime, and a template would be one more thing to keep in sync.
+  ///
+  /// `workspace` decides both the label and whether the daemon is told where to look.
+  /// launchd starts an agent with its own minimal environment, so a named workspace's
+  /// daemon inherits nothing from the app that installed it and would compute
+  /// `~/.graphcode` — serving the default workspace's graphs under the second
+  /// workspace's label. The default workspace passes no `EnvironmentVariables` at all,
+  /// which keeps its plist byte-for-byte what it has always been: anything else and
+  /// `launchAgentIsCurrent` would report every existing install as stale and bounce a
+  /// daemon that was running perfectly well.
   static func launchAgentPlist(
-    daemonPath: String, supportDirectory: String
+    daemonPath: String, supportDirectory: String, workspace: Workspace = .current
   ) -> [String: Any] {
-    [
-      "Label": label,
+    var plist: [String: Any] = [
+      "Label": workspace.daemonLabel,
       "ProgramArguments": [daemonPath],
       "RunAtLoad": true,
       "KeepAlive": true,
@@ -185,6 +197,10 @@ public enum DaemonBootstrap {
       // exactly what an app installing a legacy plist should set.
       "AssociatedBundleIdentifiers": [appBundleIdentifier],
     ]
+    if !workspace.isDefault {
+      plist["EnvironmentVariables"] = [SupportDirectory.environmentKey: supportDirectory]
+    }
+    return plist
   }
 
   static func currentLaunchAgentPlist() -> [String: Any] {

--- a/GraphcodeKit/Sources/DaemonBootstrap.swift
+++ b/GraphcodeKit/Sources/DaemonBootstrap.swift
@@ -163,9 +163,27 @@ public enum DaemonBootstrap {
     removexattr(url.path, "com.apple.quarantine", 0)
   }
 
-  static var launchAgentURL: URL {
+  static var launchAgentURL: URL { launchAgentURL(forLabel: label) }
+
+  static func launchAgentURL(forLabel label: String) -> URL {
     URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
       .appendingPathComponent("Library/LaunchAgents/\(label).plist")
+  }
+
+  /// Takes a workspace's daemon out of launchd and removes its agent — the first step of
+  /// deleting a workspace, and the one that cannot be skipped: the agent is `KeepAlive`,
+  /// so a daemon left loaded over a deleted directory is restarted by launchd and
+  /// recreates it.
+  ///
+  /// Refuses the default workspace outright. There is no path through the UI that asks
+  /// for this, and the cost of being wrong is an install whose daemon is gone.
+  public static func removeLaunchAgent(for workspace: Workspace) {
+    guard !workspace.isDefault else { return }
+    let url = launchAgentURL(forLabel: workspace.daemonLabel)
+    launchctl(["bootout", "\(domainTarget)/\(workspace.daemonLabel)"])
+    // The legacy pair as well, for an agent loaded by a build old enough to have used it.
+    launchctl(["unload", url.path])
+    try? FileManager.default.removeItem(at: url)
   }
 
   /// Built here rather than shipped as a template file: the two paths it needs are already

--- a/GraphcodeKit/Sources/SupportDirectory.swift
+++ b/GraphcodeKit/Sources/SupportDirectory.swift
@@ -41,6 +41,16 @@ public enum SupportDirectory {
   /// second `graphcoded` started with the same value, or it will sit there unconnected.
   public static let environmentKey = "GRAPHCODE_SUPPORT_DIR"
 
+  /// `~/.graphcode` — the default workspace's directory, whatever the override says.
+  ///
+  /// Deliberately *not* affected by `GRAPHCODE_SUPPORT_DIR`: `Workspace` discovers the
+  /// other workspaces by scanning this directory's siblings, and a scan root that moved
+  /// with the override would leave every named workspace unable to see any of the others.
+  public static var defaultURL: URL {
+    URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+      .appendingPathComponent(".graphcode", isDirectory: true)
+  }
+
   /// `~/.graphcode`, unless `GRAPHCODE_SUPPORT_DIR` says otherwise.
   public static var url: URL {
     let home = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)

--- a/GraphcodeKit/Sources/Workspace.swift
+++ b/GraphcodeKit/Sources/Workspace.swift
@@ -191,6 +191,76 @@ extension Workspace {
     return .success(workspace)
   }
 
+  /// What deleting this workspace would take with it — shown in the confirmation, and
+  /// the source of the `zmx` sessions that have to be ended before the directory goes.
+  ///
+  /// Session names come from the terminal layouts as well as the graphs: a loop's first
+  /// surface is named after the node, but its extra tabs and splits are surfaces of their
+  /// own, and a session missed here is an agent left running against a workspace that no
+  /// longer exists.
+  public struct Contents: Equatable, Sendable {
+    public var projects = 0
+    public var loops = 0
+    public var sessionNames: [String] = []
+  }
+
+  public func contents(fileManager: FileManager = .default) -> Contents {
+    var contents = Contents()
+    var surfaceIDs = Set<UUID>()
+
+    let projectsDirectory = url.appendingPathComponent("projects", isDirectory: true)
+    for name in (try? fileManager.contentsOfDirectory(atPath: projectsDirectory.path)) ?? []
+    where name.hasSuffix(".json") {
+      guard let data = try? Data(contentsOf: projectsDirectory.appendingPathComponent(name)),
+        let graph = try? JSONDecoder().decode(LoopGraph.self, from: data)
+      else { continue }
+      contents.projects += 1
+      contents.loops += graph.nodes.count
+      surfaceIDs.formUnion(graph.nodes.map(\.id))
+    }
+
+    let layoutsDirectory = url.appendingPathComponent("terminal-layouts", isDirectory: true)
+    for name in (try? fileManager.contentsOfDirectory(atPath: layoutsDirectory.path)) ?? []
+    where name.hasSuffix(".json") {
+      guard let data = try? Data(contentsOf: layoutsDirectory.appendingPathComponent(name)),
+        let layout = try? JSONDecoder().decode(TerminalLayout.self, from: data)
+      else { continue }
+      surfaceIDs.formUnion(layout.tabs.flatMap(\.surfaces).map(\.id))
+    }
+
+    contents.sessionNames = surfaceIDs.map { "\(SurfaceRef.zmxSessionPrefix)\($0.uuidString)" }
+      .sorted()
+    return contents
+  }
+
+  /// Why a workspace cannot be deleted right now.
+  public enum DeletionRefusal: Error, Equatable, LocalizedError {
+    case isDefault
+    case isCurrent
+    case isOpen(pid: Int32)
+
+    public var errorDescription: String? {
+      switch self {
+      case .isDefault:
+        return "The default workspace can't be deleted."
+      case .isCurrent:
+        return "This is the workspace you're in. Switch to another one first."
+      case .isOpen(let pid):
+        return "That workspace is open in another window (pid \(pid)). Quit it first."
+      }
+    }
+  }
+
+  /// The three questions asked before anything is torn down. Deleting the workspace a
+  /// window is *using* would pull its graphs out from under a live app; deleting one
+  /// another instance has open is the same thing, one process away.
+  public func deletionRefusal(current: Workspace = .current) -> DeletionRefusal? {
+    if isDefault { return .isDefault }
+    if id == current.id { return .isCurrent }
+    if let pid = WorkspaceLock.holder(of: self) { return .isOpen(pid: pid) }
+    return nil
+  }
+
   /// What is wrong with a typed name, or `nil` when nothing is — the form the sheet wants
   /// while someone is still typing, where a `Result` would have it destructure a success
   /// it has no use for yet.

--- a/GraphcodeKit/Sources/Workspace.swift
+++ b/GraphcodeKit/Sources/Workspace.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+/// One workspace: a support directory with its own graphs, terminal layouts, daemon and
+/// loops, opened by its own app instance.
+///
+/// The mechanism is `GRAPHCODE_SUPPORT_DIR`, which has always been able to point a second
+/// graphcode at a directory of its own (see `SupportDirectory`). What this adds is the
+/// part that made it unusable as a product feature: a name, a way to find the ones that
+/// exist, and a daemon label per workspace — without which a second app rewrote the one
+/// launch agent `dev.graphcode.graphcoded` and took the first workspace's daemon with it.
+///
+/// **Why separate directories rather than more windows.** A window showing a different
+/// selection of the *same* graph is a different feature (and a much larger one — the app's
+/// state is a single store and a terminal surface is a single `NSView`). This is for the
+/// other need: keeping unrelated work apart, so that a hundred loops across three lines of
+/// work are three sidebars of a manageable size rather than one that can't be monitored.
+/// Nothing is shared between workspaces, which is the point — a loop in one is invisible
+/// in the other.
+///
+/// The default workspace is `~/.graphcode` and is left exactly as it always was: same
+/// path, same daemon label, same launch agent bytes. Everything here is additive, so an
+/// install that never creates a second workspace cannot tell this shipped.
+public struct Workspace: Equatable, Identifiable, Sendable {
+  /// Named workspaces are siblings of the default directory: `~/.graphcode-work`.
+  ///
+  /// Siblings rather than `~/.graphcode/workspaces/work` because the socket path has to
+  /// fit `sockaddr_un.sun_path`'s 104 bytes, and nesting spends 12 of them on every
+  /// workspace before its name is even counted. It also keeps the default workspace's
+  /// directory free of directories that are not its own.
+  public static let directoryPrefix = ".graphcode-"
+
+  /// The default workspace's launch agent label, unchanged since the daemon shipped. A
+  /// named workspace appends its slug; the default must never do so, or an existing
+  /// install would see its agent rewritten under a new label on first launch.
+  public static let daemonLabelBase = "dev.graphcode.graphcoded"
+
+  /// `sun_path` is 104 bytes *including* its terminator, so a socket path may use 103.
+  /// A workspace whose name would breach it is rejected at creation with something to
+  /// read, rather than binding nothing at runtime and looking like a dead daemon.
+  public static let maximumSocketPathLength = 103
+
+  /// Empty for the default workspace. Otherwise the directory suffix, which is also the
+  /// name shown in the UI and the suffix on the daemon label.
+  public let slug: String
+  public let url: URL
+
+  public init(slug: String, url: URL) {
+    self.slug = slug
+    self.url = url
+  }
+
+  public var id: String { url.path }
+  public var isDefault: Bool { slug.isEmpty }
+  public var name: String { isDefault ? "Default" : slug }
+
+  public var daemonLabel: String {
+    isDefault ? Self.daemonLabelBase : "\(Self.daemonLabelBase).\(slug)"
+  }
+
+  public var socketPath: String {
+    url.appendingPathComponent("graphcoded.sock").path
+  }
+}
+
+extension Workspace {
+  public static var `default`: Workspace {
+    Workspace(slug: "", url: SupportDirectory.defaultURL)
+  }
+
+  /// The workspace this process is running in, derived from wherever
+  /// `GRAPHCODE_SUPPORT_DIR` (if anywhere) has pointed it.
+  public static var current: Workspace {
+    workspace(for: SupportDirectory.url)
+  }
+
+  /// Recognizes a directory as a workspace.
+  ///
+  /// The third branch matters more than it looks: a developer running with
+  /// `GRAPHCODE_SUPPORT_DIR=~/.graphcode.dev` is in a directory this feature never
+  /// created, and before there were labels per workspace that build shared
+  /// `dev.graphcode.graphcoded` with the installed app — so launching it rewrote the
+  /// real agent and pointed launchd at a DerivedData daemon. Giving every non-default
+  /// directory a slug of its own is what stops that.
+  static func workspace(for url: URL, home: URL = URL(fileURLWithPath: NSHomeDirectory()))
+    -> Workspace
+  {
+    let path = url.standardizedFileURL.path
+    guard path != SupportDirectory.defaultURL.standardizedFileURL.path else { return .default }
+
+    let name = url.standardizedFileURL.lastPathComponent
+    let parent = url.standardizedFileURL.deletingLastPathComponent().path
+    if parent == home.standardizedFileURL.path, name.hasPrefix(directoryPrefix) {
+      return Workspace(slug: String(name.dropFirst(directoryPrefix.count)), url: url)
+    }
+    return Workspace(slug: slug(from: name), url: url)
+  }
+
+  public static func url(forSlug slug: String, home: URL = URL(fileURLWithPath: NSHomeDirectory()))
+    -> URL
+  {
+    home.appendingPathComponent(directoryPrefix + slug, isDirectory: true)
+  }
+
+  /// Every workspace on this machine: the default, plus the `~/.graphcode-*` siblings,
+  /// plus wherever this process itself is pointed.
+  ///
+  /// Discovered by scanning rather than kept in a registry file. A registry would have to
+  /// live in one workspace's directory — making every other workspace write into it,
+  /// which is the coupling this feature exists to avoid — and would go stale the moment
+  /// someone moved a directory by hand. The directory *is* the record.
+  public static func all(
+    home: URL = URL(fileURLWithPath: NSHomeDirectory()),
+    fileManager: FileManager = .default
+  ) -> [Workspace] {
+    // No `.skipsHiddenFiles`: every workspace directory is a dotfile, so that option
+    // would hide the whole result set.
+    let entries =
+      (try? fileManager.contentsOfDirectory(
+        at: home, includingPropertiesForKeys: [.isDirectoryKey], options: [])) ?? []
+
+    let named =
+      entries
+      .filter { $0.lastPathComponent.hasPrefix(directoryPrefix) }
+      .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? true }
+      .map { workspace(for: $0, home: home) }
+
+    var found = [Workspace.default] + named.sorted { $0.slug < $1.slug }
+    // The current workspace may be somewhere the scan can't see it — a developer's
+    // `GRAPHCODE_SUPPORT_DIR=/tmp/…`, say. A switcher that omits where you already are
+    // reads as a bug.
+    let current = Workspace.current
+    if !found.contains(where: { $0.id == current.id }) {
+      found.append(current)
+    }
+    return found
+  }
+
+  /// Turns what a human typed into something that is safe as a directory suffix, as a
+  /// launchd label suffix, and as a name to read back: lowercase ASCII alphanumerics and
+  /// single hyphens.
+  ///
+  /// Accents and non-Latin scripts are transliterated first, so "Café Zürich" becomes
+  /// `cafe-zurich` rather than a row of hyphens. ASCII-only is not fussiness: the slug
+  /// ends up in a launchd label, and a label is not a place to discover how launchd
+  /// handles a codepoint.
+  public static func slug(from name: String) -> String {
+    let latin = name.applyingTransform(.toLatin, reverse: false) ?? name
+    let plain = latin.applyingTransform(.stripDiacritics, reverse: false) ?? latin
+    let mapped = plain.lowercased().map { character -> Character in
+      character.isASCII && (character.isLetter || character.isNumber) ? character : "-"
+    }
+    let collapsed = String(mapped).split(separator: "-", omittingEmptySubsequences: true)
+    return String(collapsed.joined(separator: "-").prefix(32))
+  }
+
+  public enum NameProblem: Error, Equatable, LocalizedError {
+    case empty
+    case taken(String)
+    case pathTooLong(Int)
+
+    public var errorDescription: String? {
+      switch self {
+      case .empty:
+        return "Give the workspace a name — letters and numbers."
+      case .taken(let slug):
+        return "A workspace named \(slug) already exists."
+      case .pathTooLong(let length):
+        return
+          "That name makes a socket path of \(length) bytes; macOS allows "
+          + "\(Workspace.maximumSocketPathLength). Try a shorter one."
+      }
+    }
+  }
+
+  /// Validates a typed name without creating anything, so the sheet can say what is wrong
+  /// while it is still being typed.
+  public static func validate(
+    name: String, home: URL = URL(fileURLWithPath: NSHomeDirectory()),
+    fileManager: FileManager = .default
+  ) -> Result<Workspace, NameProblem> {
+    let slug = slug(from: name)
+    guard !slug.isEmpty else { return .failure(.empty) }
+
+    let url = url(forSlug: slug, home: home)
+    guard !fileManager.fileExists(atPath: url.path) else { return .failure(.taken(slug)) }
+
+    let workspace = Workspace(slug: slug, url: url)
+    let length = workspace.socketPath.utf8.count
+    guard length <= maximumSocketPathLength else { return .failure(.pathTooLong(length)) }
+
+    return .success(workspace)
+  }
+
+  /// What is wrong with a typed name, or `nil` when nothing is — the form the sheet wants
+  /// while someone is still typing, where a `Result` would have it destructure a success
+  /// it has no use for yet.
+  public static func problem(
+    name: String, home: URL = URL(fileURLWithPath: NSHomeDirectory()),
+    fileManager: FileManager = .default
+  ) -> NameProblem? {
+    switch validate(name: name, home: home, fileManager: fileManager) {
+    case .success: return nil
+    case .failure(let problem): return problem
+    }
+  }
+
+  /// Creates the directory. Everything else a workspace needs — `bin/`, the launch agent,
+  /// the daemon — is what the app instance opening it does on launch, exactly as it does
+  /// for a first install of the default workspace.
+  public static func create(
+    name: String, home: URL = URL(fileURLWithPath: NSHomeDirectory()),
+    fileManager: FileManager = .default
+  ) throws -> Workspace {
+    let workspace = try validate(name: name, home: home, fileManager: fileManager).get()
+    try fileManager.createDirectory(at: workspace.url, withIntermediateDirectories: true)
+    return workspace
+  }
+}

--- a/GraphcodeKit/Sources/WorkspaceLock.swift
+++ b/GraphcodeKit/Sources/WorkspaceLock.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Which process, if any, currently has a workspace open.
+///
+/// Two app instances over one support directory is the failure `SupportDirectory`'s own
+/// documentation warns about — the same graphs, the same terminal layouts, and therefore
+/// the same `zmx` session names, with both apps attaching to one session and taking it
+/// down under each other. Opening workspaces from a menu makes that a thing a human can
+/// now do by accident, so each instance records itself and the launcher raises the window
+/// that already exists instead of starting a second one.
+///
+/// A pid file rather than a lock: the answer this needs is "who", not "may I" — the
+/// launcher wants a process to activate. Staleness is decided by asking the kernel about
+/// the pid rather than by trusting the file, because a crashed app never gets to clean up.
+public enum WorkspaceLock {
+  public static func url(for workspace: Workspace) -> URL {
+    workspace.url.appendingPathComponent("app.pid")
+  }
+
+  /// Records this process as the workspace's. Called after `SupportDirectory.prepare()`,
+  /// which is what guarantees the directory exists.
+  public static func claim(
+    _ workspace: Workspace = .current, pid: Int32 = ProcessInfo.processInfo.processIdentifier
+  ) {
+    try? Data("\(pid)\n".utf8).write(to: url(for: workspace), options: .atomic)
+  }
+
+  /// Drops the claim, when the file still names this process. The guard matters on the
+  /// path where an instance quits *after* another has taken the workspace over — a
+  /// relaunch, say — where deleting unconditionally would erase the live claim.
+  public static func release(
+    _ workspace: Workspace = .current, pid: Int32 = ProcessInfo.processInfo.processIdentifier
+  ) {
+    guard recordedPID(for: workspace) == pid else { return }
+    try? FileManager.default.removeItem(at: url(for: workspace))
+  }
+
+  /// The live process holding this workspace, or `nil` — no file, unreadable, or a pid
+  /// nothing is running under any more.
+  ///
+  /// A pid that is alive is not proof it is *graphcode* — pids are reused. Callers that
+  /// can check (the app, which has `NSRunningApplication`) should; the worst a caller
+  /// that can't does is decline to open a workspace it could have opened.
+  public static func holder(of workspace: Workspace) -> Int32? {
+    guard let pid = recordedPID(for: workspace), isRunning(pid) else { return nil }
+    return pid
+  }
+
+  static func recordedPID(for workspace: Workspace) -> Int32? {
+    guard let text = try? String(contentsOf: url(for: workspace), encoding: .utf8) else {
+      return nil
+    }
+    return Int32(text.trimmingCharacters(in: .whitespacesAndNewlines))
+  }
+
+  /// `kill(pid, 0)` sends nothing; it just asks. `EPERM` means the process exists and
+  /// belongs to someone else, which for this question is still "alive".
+  static func isRunning(_ pid: Int32) -> Bool {
+    guard pid > 0 else { return false }
+    if kill(pid, 0) == 0 { return true }
+    return errno == EPERM
+  }
+}

--- a/GraphcodeKit/Sources/WorkspaceLock.swift
+++ b/GraphcodeKit/Sources/WorkspaceLock.swift
@@ -17,12 +17,22 @@ public enum WorkspaceLock {
     workspace.url.appendingPathComponent("app.pid")
   }
 
-  /// Records this process as the workspace's. Called after `SupportDirectory.prepare()`,
-  /// which is what guarantees the directory exists.
+  /// Records this process as the workspace's, unless a live process already holds it —
+  /// in which case that one is still the owner and this is the interloper.
+  ///
+  /// Claiming unconditionally looked simpler and was wrong: any second process that
+  /// touches a workspace (the test host launching the app, an instance started around the
+  /// guard) would overwrite the running app's claim with its own, and once *it* exited the
+  /// workspace would read as free while a real window was still using it.
+  ///
+  /// Returns whether the claim is now this process's.
+  @discardableResult
   public static func claim(
     _ workspace: Workspace = .current, pid: Int32 = ProcessInfo.processInfo.processIdentifier
-  ) {
+  ) -> Bool {
+    if let holder = holder(of: workspace), holder != pid { return false }
     try? Data("\(pid)\n".utf8).write(to: url(for: workspace), options: .atomic)
+    return true
   }
 
   /// Drops the claim, when the file still names this process. The guard matters on the

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ graphs and its own `graphcoded`. Nothing is shared between them — a loop in on
 other — and the switcher at the foot of the sidebar says which one you are in. The CLI follows the
 same variable the app sets: `GRAPHCODE_SUPPORT_DIR=~/.graphcode-work graphcode status <project>`.
 
+**⌥⌘1 … ⌥⌘9** switch between them in menu order and **⌥⌘N** makes a new one. **Delete Workspace**,
+in the same menu, ends that workspace's terminal sessions, stops its daemon, and moves its folder to
+the Trash — the default workspace and whichever one you are in are never offered.
+
 ## Building from source
 
 Needs [mise](https://mise.jdx.dev) (Xcode, tuist, swiftlint, zig come through it) and the submodules.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Releases are Developer ID signed and notarized.
 State lives in `~/.graphcode/` — graphs, recents, layouts, the daemon socket and logs, and the installed
 binaries. **Nothing is ever written inside a project folder you open.**
 
+## Workspaces
+
+**File ▸ Workspace ▸ New Workspace…** opens a second GraphCode with projects, loops and terminal
+sessions entirely its own — for keeping unrelated lines of work apart when one sidebar of loops has
+grown past what you can monitor. It is a separate window with its own Dock tile, so it can live on a
+second screen.
+
+A workspace is a directory: `~/.graphcode-<name>`, beside the default `~/.graphcode`, with its own
+graphs and its own `graphcoded`. Nothing is shared between them — a loop in one is invisible in the
+other — and the switcher at the foot of the sidebar says which one you are in. The CLI follows the
+same variable the app sets: `GRAPHCODE_SUPPORT_DIR=~/.graphcode-work graphcode status <project>`.
+
 ## Building from source
 
 Needs [mise](https://mise.jdx.dev) (Xcode, tuist, swiftlint, zig come through it) and the submodules.

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -30,6 +30,20 @@ project, then Q, and Back retraces Q → P → A regardless of where those loops
 Opening a loop after going back discards the forward trail, the way a browser does.
 Quick Chats count as places you have been. The trail survives quitting the app.
 
+## Workspaces
+
+A workspace is a separate set of projects and loops, in a window of its own — for keeping
+unrelated lines of work apart. **File ▸ Workspace** lists them.
+
+| Shortcut | Does |
+|---|---|
+| ⌥⌘1 … ⌥⌘9 | Switch to that workspace, in the order the menu lists them (⌥⌘1 is the default one). Raises its window, or opens it if it isn't running |
+| ⌥⌘N | New workspace — name it and it opens straight away |
+
+Deleting one is in the same menu, under **Delete Workspace**. It ends that workspace's
+terminal sessions, stops its daemon, and moves its folder to the Trash — a workspace that
+is currently open somewhere can't be deleted until that window is closed.
+
 ## Terminals
 
 Inside a loop's workspace, the panes are real terminals — these act on them:

--- a/graphcode/Sources/Clients/WorkspaceClient.swift
+++ b/graphcode/Sources/Clients/WorkspaceClient.swift
@@ -1,0 +1,63 @@
+import AppKit
+import Dependencies
+import Foundation
+import GraphcodeKit
+
+/// Finding, creating and opening workspaces — the app-side half of `Workspace`, which
+/// knows about directories but nothing about running apps.
+///
+/// A workspace is opened by launching a **second instance of this app** with
+/// `GRAPHCODE_SUPPORT_DIR` pointed at its directory. There is no in-process alternative:
+/// the support directory is resolved through a process-wide static that some thirty call
+/// sites read, from the graph store to the daemon socket to the `zmx` binary's path, so
+/// one process serves exactly one workspace. That instance gets its own Dock tile, which
+/// is also what makes a workspace draggable onto a second monitor.
+struct WorkspaceClient: Sendable {
+  var list: @Sendable () -> [Workspace]
+  var create: @Sendable (String) throws -> Workspace
+  /// Raises the instance that already has this workspace open, or launches one. Never
+  /// opens a second app over a workspace already in use — that is two apps sharing one
+  /// set of graphs and `zmx` session names, which is the failure `WorkspaceLock` exists
+  /// to prevent.
+  var open: @Sendable (Workspace) -> Void
+}
+
+extension WorkspaceClient: DependencyKey {
+  static let liveValue = WorkspaceClient(
+    list: { Workspace.all() },
+    create: { try Workspace.create(name: $0) },
+    open: { workspace in
+      if let existing = runningInstance(of: workspace) {
+        existing.activate()
+        return
+      }
+      let configuration = NSWorkspace.OpenConfiguration()
+      configuration.createsNewApplicationInstance = true
+      configuration.environment = [SupportDirectory.environmentKey: workspace.url.path]
+      NSWorkspace.shared.openApplication(
+        at: Bundle.main.bundleURL, configuration: configuration, completionHandler: nil)
+    })
+
+  static let testValue = WorkspaceClient(
+    list: { [.default] },
+    create: { Workspace(slug: $0, url: URL(fileURLWithPath: "/tmp/\($0)")) },
+    open: { _ in })
+
+  /// The pid file names a process; this checks it is actually one of ours before
+  /// activating it, since pids are reused and the recorded process may be long gone and
+  /// its number since handed to something unrelated.
+  private static func runningInstance(of workspace: Workspace) -> NSRunningApplication? {
+    guard let pid = WorkspaceLock.holder(of: workspace),
+      let application = NSRunningApplication(processIdentifier: pid),
+      application.bundleIdentifier == Bundle.main.bundleIdentifier
+    else { return nil }
+    return application
+  }
+}
+
+extension DependencyValues {
+  var workspaceClient: WorkspaceClient {
+    get { self[WorkspaceClient.self] }
+    set { self[WorkspaceClient.self] = newValue }
+  }
+}

--- a/graphcode/Sources/Clients/WorkspaceClient.swift
+++ b/graphcode/Sources/Clients/WorkspaceClient.swift
@@ -20,6 +20,10 @@ struct WorkspaceClient: Sendable {
   /// set of graphs and `zmx` session names, which is the failure `WorkspaceLock` exists
   /// to prevent.
   var open: @Sendable (Workspace) -> Void
+  /// Tears a workspace down: its daemon out of launchd, its `zmx` sessions ended, its
+  /// directory to the Trash. Throws `Workspace.DeletionRefusal` when it is not a
+  /// workspace this may touch.
+  var delete: @Sendable (Workspace) throws -> Void
 }
 
 extension WorkspaceClient: DependencyKey {
@@ -36,12 +40,46 @@ extension WorkspaceClient: DependencyKey {
       configuration.environment = [SupportDirectory.environmentKey: workspace.url.path]
       NSWorkspace.shared.openApplication(
         at: Bundle.main.bundleURL, configuration: configuration, completionHandler: nil)
+    },
+    delete: { workspace in
+      if let refusal = workspace.deletionRefusal() { throw refusal }
+
+      // Order matters. The agent is `KeepAlive`, so a daemon still loaded over a deleted
+      // directory is restarted by launchd and recreates it — the workspace comes back
+      // from the dead, empty. Take launchd out of it first.
+      DaemonBootstrap.removeLaunchAgent(for: workspace)
+
+      // Then the sessions. These are the running agents: `zmx` outlives every app, so a
+      // session missed here is a CLI left talking to a graph that no longer exists, for
+      // as long as the machine is up. Killed through *this* workspace's `zmx` binary
+      // because the one in the doomed directory is about to go — the server they both
+      // talk to is the same one either way.
+      endSessions(workspace.contents().sessionNames)
+
+      // Trash rather than delete: this is someone's work, and the directory is the only
+      // copy of it. Recoverable for as long as they haven't emptied the Trash.
+      var trashed: NSURL?
+      try FileManager.default.trashItem(at: workspace.url, resultingItemURL: &trashed)
     })
 
   static let testValue = WorkspaceClient(
     list: { [.default] },
     create: { Workspace(slug: $0, url: URL(fileURLWithPath: "/tmp/\($0)")) },
-    open: { _ in })
+    open: { _ in },
+    delete: { _ in })
+
+  /// `zmx kill` per session, best effort: a name that is already gone exits non-zero and
+  /// that is the healthy case, not something to abandon the deletion over.
+  private static func endSessions(_ names: [String]) {
+    guard ZmxLocator.isInstalled, !names.isEmpty else { return }
+    let process = Process()
+    process.executableURL = ZmxLocator.binaryURL
+    process.arguments = ["kill"] + names + ["--force"]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    try? process.run()
+    process.waitUntilExit()
+  }
 
   /// The pid file names a process; this checks it is actually one of ours before
   /// activating it, since pids are reused and the recorded process may be long gone and

--- a/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
@@ -19,11 +19,32 @@ extension AppFeature {
     /// What is wrong with `draftName`, said while it is being typed rather than after
     /// Create is pressed.
     var problem: String?
+    /// The workspace a Delete confirmation is up for, with what it would take with it —
+    /// counted when the dialog opens, since the numbers come off disk.
+    var pendingDeletion: PendingDeletion?
+    /// A refusal or a failure from the last deletion attempt, shown as an alert. Distinct
+    /// from `problem`, which is about a name being typed.
+    var deletionFailure: String?
 
     /// Whether to name the workspace in the UI at all. A machine with one workspace has
     /// no ambiguity to resolve, and a permanent "Default" chip would be noise on every
     /// install that never uses this.
     var isWorthShowing: Bool { !current.isDefault || known.count > 1 }
+  }
+
+  /// One workspace and what deleting it costs, held while the confirmation is up.
+  struct PendingDeletion: Equatable {
+    var workspace: Workspace
+    var contents: Workspace.Contents
+
+    /// "2 projects and 14 loops" — the sentence the dialog needs, with the plurals right
+    /// and an empty workspace saying so rather than reading "0 projects and 0 loops".
+    var summary: String {
+      guard contents.projects > 0 || contents.loops > 0 else { return "It has nothing in it" }
+      let projects = "\(contents.projects) project\(contents.projects == 1 ? "" : "s")"
+      let loops = "\(contents.loops) loop\(contents.loops == 1 ? "" : "s")"
+      return "It holds \(projects) and \(loops)"
+    }
   }
 
   /// The workspace half of the app's actions, nested so the whole surface costs
@@ -37,6 +58,10 @@ extension AppFeature {
     case createConfirmed
     /// Raise (or launch) the instance that owns this workspace.
     case switchRequested(Workspace)
+    case deleteRequested(Workspace)
+    case deleteConfirmed
+    case deleteCancelled
+    case deletionFailureDismissed
   }
 }
 
@@ -86,6 +111,34 @@ struct AppWorkspacesReducer: Reducer {
       case .workspaces(.switchRequested(let workspace)):
         guard workspace.id != state.workspaces.current.id else { return .none }
         return .run { [open = workspaces.open] _ in open(workspace) }
+
+      case .workspaces(.deleteRequested(let workspace)):
+        if let refusal = workspace.deletionRefusal(current: state.workspaces.current) {
+          state.workspaces.deletionFailure = refusal.localizedDescription
+          return .none
+        }
+        state.workspaces.pendingDeletion = AppFeature.PendingDeletion(
+          workspace: workspace, contents: workspace.contents())
+        return .none
+
+      case .workspaces(.deleteConfirmed):
+        guard let pending = state.workspaces.pendingDeletion else { return .none }
+        state.workspaces.pendingDeletion = nil
+        do {
+          try workspaces.delete(pending.workspace)
+        } catch {
+          state.workspaces.deletionFailure = error.localizedDescription
+        }
+        state.workspaces.known = workspaces.list()
+        return .none
+
+      case .workspaces(.deleteCancelled):
+        state.workspaces.pendingDeletion = nil
+        return .none
+
+      case .workspaces(.deletionFailureDismissed):
+        state.workspaces.deletionFailure = nil
+        return .none
 
       default:
         return .none

--- a/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
@@ -1,0 +1,95 @@
+import ComposableArchitecture
+import Dependencies
+import Foundation
+import GraphcodeKit
+
+extension AppFeature {
+  /// What this instance knows about the workspaces on the machine — the switcher's list,
+  /// which one is ours, and the New Workspace sheet while it is up.
+  @ObservableState
+  struct WorkspacesState: Equatable {
+    /// Refreshed when the switcher is opened rather than watched: workspaces are created
+    /// by a human every few weeks, and the alternative is a directory watcher on `$HOME`.
+    var known: [Workspace] = []
+    /// Read once. A running app cannot change workspace — that is what launching another
+    /// instance is for — so this is fixed for the life of the process.
+    let current: Workspace = .current
+    var isCreating = false
+    var draftName = ""
+    /// What is wrong with `draftName`, said while it is being typed rather than after
+    /// Create is pressed.
+    var problem: String?
+
+    /// Whether to name the workspace in the UI at all. A machine with one workspace has
+    /// no ambiguity to resolve, and a permanent "Default" chip would be noise on every
+    /// install that never uses this.
+    var isWorthShowing: Bool { !current.isDefault || known.count > 1 }
+  }
+
+  /// The workspace half of the app's actions, nested so the whole surface costs
+  /// `AppFeature.Action` a single case — same arrangement as `Worktrees`.
+  @CasePathable
+  enum Workspaces {
+    case listRequested
+    case newRequested
+    case draftNameChanged(String)
+    case createCancelled
+    case createConfirmed
+    /// Raise (or launch) the instance that owns this workspace.
+    case switchRequested(Workspace)
+  }
+}
+
+/// Listed alongside the app's other split-out reducers in `AppFeature.body`.
+struct AppWorkspacesReducer: Reducer {
+  typealias State = AppFeature.State
+  typealias Action = AppFeature.Action
+
+  @Dependency(\.workspaceClient) var workspaces
+
+  var body: some Reducer<AppFeature.State, AppFeature.Action> {
+    Reduce { state, action in
+      switch action {
+      case .workspaces(.listRequested):
+        state.workspaces.known = workspaces.list()
+        return .none
+
+      case .workspaces(.newRequested):
+        state.workspaces.draftName = ""
+        state.workspaces.problem = nil
+        state.workspaces.isCreating = true
+        return .none
+
+      case .workspaces(.draftNameChanged(let name)):
+        state.workspaces.draftName = name
+        // An empty field is not yet a mistake — it's a sheet that has just opened.
+        state.workspaces.problem =
+          name.isEmpty ? nil : Workspace.problem(name: name)?.localizedDescription
+        return .none
+
+      case .workspaces(.createCancelled):
+        state.workspaces.isCreating = false
+        return .none
+
+      case .workspaces(.createConfirmed):
+        do {
+          let created = try workspaces.create(state.workspaces.draftName)
+          state.workspaces.isCreating = false
+          state.workspaces.draftName = ""
+          state.workspaces.known = workspaces.list()
+          return .run { [open = workspaces.open] _ in open(created) }
+        } catch {
+          state.workspaces.problem = error.localizedDescription
+          return .none
+        }
+
+      case .workspaces(.switchRequested(let workspace)):
+        guard workspace.id != state.workspaces.current.id else { return .none }
+        return .run { [open = workspaces.open] _ in open(workspace) }
+
+      default:
+        return .none
+      }
+    }
+  }
+}

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -84,6 +84,10 @@ struct AppFeature {
     var worktreeStats: [String: WorktreeFolderStats] = [:]
     var projectSettingsPath: String?
 
+    /// Which workspace this instance is, and the others on the machine — see
+    /// `AppFeature+Workspaces.swift`.
+    var workspaces = WorkspacesState()
+
     /// Up on first launch (`.task` checks the persisted flag) and whenever the
     /// sidebar's help button asks for it again.
     var showingOnboarding = false
@@ -239,6 +243,8 @@ struct AppFeature {
     case updateRelaunchDismissed
     /// Worktree hygiene, one case for the whole surface — see `AppFeature+Worktrees.swift`.
     case worktrees(Worktrees)
+    /// Workspaces, likewise — see `AppFeature+Workspaces.swift`.
+    case workspaces(Workspaces)
     /// The Quick Chats section's actions — see `State.quickChats`.
     case newQuickChatTapped
     /// The Quick Chats header row: shows the chats' own canvas, the way a folder row
@@ -286,6 +292,7 @@ struct AppFeature {
     // graph, which the main reducer replaces. See `AppFeature+Worktrees.swift`.
     AppWorktreesReducer()
       .ifLet(\.worktreeSweep, action: \.worktrees.sweep) { WorktreeSweepFeature() }
+    AppWorkspacesReducer()
     Reduce { state, action in
       switch action {
       case .task:
@@ -587,7 +594,7 @@ struct AppFeature {
         recordPendingOpen(welcomeAction, into: &state)
         return .none
 
-      case .openLoop, .projects, .worktrees:
+      case .openLoop, .projects, .worktrees, .workspaces:
         return .none
       }
     }

--- a/graphcode/Sources/Features/App/AppSidebarView.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView.swift
@@ -209,6 +209,9 @@ struct AppSidebarView: View {
           .padding(8)
           .background(.thinMaterial)
       }
+      // Last, under everything: standing orientation rather than news. Two workspaces are
+      // two instances of one app, with one icon and no titlebar between them.
+      WorkspaceFooter(store: store)
     }
   }
 

--- a/graphcode/Sources/Features/App/AppView.swift
+++ b/graphcode/Sources/Features/App/AppView.swift
@@ -31,6 +31,14 @@ struct AppView: View {
       }
     }
     .onReceive(CanvasClock.tick) { now = $0 }
+    // The titlebar is hidden, but the title still names the window in Mission Control
+    // and the Window menu — which is where two workspaces on two screens are told apart.
+    .navigationTitle(windowTitle)
+  }
+
+  private var windowTitle: String {
+    let workspace = store.workspaces.current
+    return workspace.isDefault ? "GraphCode" : "GraphCode — \(workspace.name)"
   }
 
   private var split: some View {
@@ -144,6 +152,16 @@ struct AppView: View {
       JumpPaletteView(store: store)
     }
     .task { await store.send(.task).finish() }
+    // Which workspaces exist decides whether the sidebar names this one at all, so the
+    // list is wanted before anything is drawn rather than when the switcher opens.
+    .task { store.send(.workspaces(.listRequested)) }
+    .sheet(
+      isPresented: Binding(
+        get: { store.workspaces.isCreating },
+        set: { if !$0 { store.send(.workspaces(.createCancelled)) } })
+    ) {
+      NewWorkspaceFormView(store: store)
+    }
     .confirmationDialog(
       // Naming the loop matters here in a way it didn't on the canvas: from the sidebar
       // you may be several projects away from the thing you right-clicked.

--- a/graphcode/Sources/Features/App/AppView.swift
+++ b/graphcode/Sources/Features/App/AppView.swift
@@ -162,6 +162,42 @@ struct AppView: View {
     ) {
       NewWorkspaceFormView(store: store)
     }
+    // Another instance may have created or deleted one since this window last looked,
+    // and the File menu is built from this list — so it is refreshed whenever the window
+    // comes forward rather than only at launch.
+    .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
+    { _ in
+      store.send(.workspaces(.listRequested))
+    }
+    .confirmationDialog(
+      "Delete the “\(store.workspaces.pendingDeletion?.workspace.name ?? "")” workspace?",
+      isPresented: Binding(
+        get: { store.workspaces.pendingDeletion != nil },
+        set: { if !$0 { store.send(.workspaces(.deleteCancelled)) } }
+      ),
+      titleVisibility: .visible,
+      presenting: store.workspaces.pendingDeletion
+    ) { _ in
+      Button("Delete Workspace", role: .destructive) {
+        store.send(.workspaces(.deleteConfirmed))
+      }
+      Button("Cancel", role: .cancel) { store.send(.workspaces(.deleteCancelled)) }
+    } message: { pending in
+      Text(
+        "\(pending.summary). Its terminal sessions are ended and its daemon stopped; "
+          + "the folder moves to the Trash, where it stays recoverable.")
+    }
+    .alert(
+      "That workspace can't be deleted",
+      isPresented: Binding(
+        get: { store.workspaces.deletionFailure != nil },
+        set: { if !$0 { store.send(.workspaces(.deletionFailureDismissed)) } }
+      )
+    ) {
+      Button("OK", role: .cancel) { store.send(.workspaces(.deletionFailureDismissed)) }
+    } message: {
+      Text(store.workspaces.deletionFailure ?? "")
+    }
     .confirmationDialog(
       // Naming the loop matters here in a way it didn't on the canvas: from the sidebar
       // you may be several projects away from the thing you right-clicked.

--- a/graphcode/Sources/Features/App/GraphcodeCommands.swift
+++ b/graphcode/Sources/Features/App/GraphcodeCommands.swift
@@ -33,6 +33,13 @@ struct GraphcodeCommands: Commands {
     // not about any loop.
     CommandGroup(after: .newItem) {
       Divider()
+      // Beside New Window rather than in a menu of its own: a workspace is the other
+      // thing "new" can mean here, and the one that opens a window you can put on a
+      // second screen.
+      Menu("Workspace") {
+        WorkspaceMenuItems(store: store)
+      }
+      Divider()
       Button("Worktrees…") {
         guard let path = focusedFolderPath else { return }
         store.send(.worktrees(.sweepRequested(projectPath: path)))

--- a/graphcode/Sources/Features/App/GraphcodeCommands.swift
+++ b/graphcode/Sources/Features/App/GraphcodeCommands.swift
@@ -37,7 +37,7 @@ struct GraphcodeCommands: Commands {
       // thing "new" can mean here, and the one that opens a window you can put on a
       // second screen.
       Menu("Workspace") {
-        WorkspaceMenuItems(store: store)
+        WorkspaceMenuItems(store: store, showsShortcuts: true)
       }
       Divider()
       Button("Worktrees…") {

--- a/graphcode/Sources/Features/Workspaces/NewWorkspaceFormView.swift
+++ b/graphcode/Sources/Features/Workspaces/NewWorkspaceFormView.swift
@@ -1,0 +1,81 @@
+import ComposableArchitecture
+import GraphcodeKit
+import SwiftUI
+
+/// Name a workspace, and GraphCode opens it in a second window of its own.
+///
+/// The sheet shows the directory the name resolves to, because that directory *is* the
+/// workspace — it is where its graphs live, what a `GRAPHCODE_SUPPORT_DIR` on the CLI
+/// would point at, and what someone deleting a workspace later has to remove.
+struct NewWorkspaceFormView: View {
+  @Bindable var store: StoreOf<AppFeature>
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Text("New Workspace").font(.headline)
+
+      Text(
+        """
+        A workspace keeps its own projects, loops and terminal sessions. Nothing is \
+        shared with this one — it opens in a separate window you can put on another \
+        screen.
+        """
+      )
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .fixedSize(horizontal: false, vertical: true)
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      Form {
+        TextField(
+          "Name", text: name,
+          prompt: Text("client work")
+        )
+        .autocorrectionDisabled()
+        .onSubmit { if canCreate { store.send(.workspaces(.createConfirmed)) } }
+      }
+      .formStyle(.columns)
+      .fixedSize(horizontal: false, vertical: true)
+
+      Group {
+        if let problem = store.workspaces.problem {
+          Text(problem).foregroundStyle(.red)
+        } else if !directoryPath.isEmpty {
+          Text(directoryPath).foregroundStyle(.secondary)
+        }
+      }
+      .font(.caption)
+      .lineLimit(1)
+      .truncationMode(.middle)
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      HStack {
+        Button("Cancel") { store.send(.workspaces(.createCancelled)) }
+          .keyboardShortcut(.cancelAction)
+        Spacer()
+        Button("Create & Open") { store.send(.workspaces(.createConfirmed)) }
+          .keyboardShortcut(.defaultAction)
+          .disabled(!canCreate)
+      }
+    }
+    .padding(24)
+    .frame(width: 420)
+  }
+
+  private var name: Binding<String> {
+    Binding(
+      get: { store.workspaces.draftName },
+      set: { store.send(.workspaces(.draftNameChanged($0))) })
+  }
+
+  private var canCreate: Bool {
+    store.workspaces.problem == nil && !store.workspaces.draftName.isEmpty
+  }
+
+  /// Where the typed name lands, abbreviated the way a human writes it.
+  private var directoryPath: String {
+    guard case .success(let workspace) = Workspace.validate(name: store.workspaces.draftName)
+    else { return "" }
+    return (workspace.url.path as NSString).abbreviatingWithTildeInPath
+  }
+}

--- a/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
@@ -1,0 +1,62 @@
+import ComposableArchitecture
+import GraphcodeKit
+import SwiftUI
+
+/// The list of workspaces, as menu items — the same contents whether it is reached from
+/// the sidebar's foot or from the File menu.
+///
+/// Picking one raises the instance that has it open, or launches one. Picking the current
+/// workspace does nothing, so the row stays selectable-looking rather than dimmed: a
+/// checkmark says which one you are in.
+struct WorkspaceMenuItems: View {
+  @Bindable var store: StoreOf<AppFeature>
+
+  var body: some View {
+    ForEach(store.workspaces.known) { workspace in
+      Button {
+        store.send(.workspaces(.switchRequested(workspace)))
+      } label: {
+        if workspace.id == store.workspaces.current.id {
+          Label(workspace.name, systemImage: "checkmark")
+        } else {
+          Text(workspace.name)
+        }
+      }
+    }
+    Divider()
+    Button("New Workspace…") { store.send(.workspaces(.newRequested)) }
+  }
+}
+
+/// The sidebar's foot: which workspace this window is, and the way to another.
+///
+/// Present only once there is something to disambiguate (`isWorthShowing`) — and needed
+/// then, because two workspaces are two instances of the same app with the same icon and
+/// the same hidden titlebar, and nothing else on screen says which is which.
+struct WorkspaceFooter: View {
+  @Bindable var store: StoreOf<AppFeature>
+
+  var body: some View {
+    if store.workspaces.isWorthShowing {
+      Menu {
+        WorkspaceMenuItems(store: store)
+      } label: {
+        HStack(spacing: 6) {
+          Image(systemName: "square.stack.3d.up")
+            .imageScale(.small)
+          Text(store.workspaces.current.name)
+            .lineLimit(1)
+            .truncationMode(.middle)
+          Spacer(minLength: 0)
+        }
+        .contentShape(.rect)
+      }
+      .menuStyle(.borderlessButton)
+      .menuIndicator(.hidden)
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .padding(.horizontal, 12)
+      .padding(.vertical, 6)
+    }
+  }
+}

--- a/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
@@ -10,9 +10,13 @@ import SwiftUI
 /// checkmark says which one you are in.
 struct WorkspaceMenuItems: View {
   @Bindable var store: StoreOf<AppFeature>
+  /// Only the menu bar's copy carries them. The same items also render in the sidebar's
+  /// popup, and a key equivalent declared twice is one macOS resolves by picking a
+  /// winner — which is not a thing to leave to chance for a command that moves windows.
+  var showsShortcuts = false
 
   var body: some View {
-    ForEach(store.workspaces.known) { workspace in
+    ForEach(Array(store.workspaces.known.enumerated()), id: \.element.id) { index, workspace in
       Button {
         store.send(.workspaces(.switchRequested(workspace)))
       } label: {
@@ -22,9 +26,67 @@ struct WorkspaceMenuItems: View {
           Text(workspace.name)
         }
       }
+      // ⌥⌘1…9, in list order — ⌘1…9 belong to the terminal's tabs and ⌘⇧3/4/5 to the
+      // system's screenshots, which leaves this the free row of number keys. Past the
+      // ninth the rows stay clickable and simply carry no shortcut.
+      .modifier(WorkspaceShortcut(index: showsShortcuts ? index : nil))
     }
     Divider()
     Button("New Workspace…") { store.send(.workspaces(.newRequested)) }
+      .modifier(NewWorkspaceShortcut(isEnabled: showsShortcuts))
+    if !deletable.isEmpty {
+      Menu("Delete Workspace") {
+        ForEach(deletable) { workspace in
+          Button("\(workspace.name)…") { store.send(.workspaces(.deleteRequested(workspace))) }
+        }
+      }
+    }
+  }
+
+  /// Never the default, and never the one this window is using — the two `Workspace`
+  /// refuses anyway. Offering them and then explaining why not is worse than not offering.
+  private var deletable: [Workspace] {
+    store.workspaces.known.filter { !$0.isDefault && $0.id != store.workspaces.current.id }
+  }
+}
+
+/// The ⌥⌘<n> on a workspace row, for the first nine only.
+///
+/// A modifier rather than an inline `if`: `keyboardShortcut` has no conditional form, and
+/// branching in the `ForEach` body would give the two branches different view identities.
+private struct WorkspaceShortcut: ViewModifier {
+  /// `nil` for the sidebar's copy of the menu, which carries no shortcuts.
+  let index: Int?
+
+  func body(content: Content) -> some View {
+    if let index, index < 9, let key = KeyEquivalent(exactly: index + 1) {
+      content.keyboardShortcut(key, modifiers: [.command, .option])
+    } else {
+      content
+    }
+  }
+}
+
+/// ⌥⌘N — ⌘N is New Window, which SwiftUI gives every `WindowGroup` for free.
+private struct NewWorkspaceShortcut: ViewModifier {
+  let isEnabled: Bool
+
+  func body(content: Content) -> some View {
+    if isEnabled {
+      content.keyboardShortcut("n", modifiers: [.command, .option])
+    } else {
+      content
+    }
+  }
+}
+
+extension KeyEquivalent {
+  /// `KeyEquivalent("1")` from a digit, for building a run of number shortcuts.
+  fileprivate init?(exactly digit: Int) {
+    guard let scalar = String(digit).unicodeScalars.first, String(digit).count == 1 else {
+      return nil
+    }
+    self.init(Character(scalar))
   }
 }
 

--- a/graphcode/Sources/GraphcodeApp.swift
+++ b/graphcode/Sources/GraphcodeApp.swift
@@ -25,6 +25,14 @@ struct GraphcodeApp: App {
     unsetenv("ZMX_SESSION")
     AgentEnvironment.scrubInheritedAgentIdentity()
     SupportDirectory.prepare()
+    // Records this instance as the one holding this workspace, so opening the same
+    // workspace again raises this window instead of starting a second app over one set
+    // of graphs and `zmx` session names. Released on the way out; a crash leaves a pid
+    // nothing is running under, which reads the same as no claim at all.
+    WorkspaceLock.claim()
+    NotificationCenter.default.addObserver(
+      forName: NSApplication.willTerminateNotification, object: nil, queue: .main
+    ) { _ in WorkspaceLock.release() }
     // A packaged app carries `graphcoded` and `zmx` inside it, so dragging it to
     // /Applications is the whole installation — this is what puts them in place and starts
     // the daemon. No-op for a build run from Xcode, which has no bundled helpers, so a

--- a/graphcode/Tests/DaemonBootstrapTests.swift
+++ b/graphcode/Tests/DaemonBootstrapTests.swift
@@ -110,7 +110,8 @@ struct DaemonBootstrapTests {
     // Pointing launchd inside the app bundle would break the moment the app is replaced
     // or moved, and would keep a mounted disk image busy.
     let plist = DaemonBootstrap.launchAgentPlist(
-      daemonPath: "/Users/x/.graphcode/bin/graphcoded", supportDirectory: "/Users/x/.graphcode")
+      daemonPath: "/Users/x/.graphcode/bin/graphcoded", supportDirectory: "/Users/x/.graphcode",
+      workspace: .default)
 
     #expect(plist["Label"] as? String == "dev.graphcode.graphcoded")
     #expect(plist["ProgramArguments"] as? [String] == ["/Users/x/.graphcode/bin/graphcoded"])
@@ -130,7 +131,8 @@ struct DaemonBootstrapTests {
     // tells the user "Software from <a person they have never heard of> can run in the
     // background".
     let plist = DaemonBootstrap.launchAgentPlist(
-      daemonPath: "/Users/x/.graphcode/bin/graphcoded", supportDirectory: "/Users/x/.graphcode")
+      daemonPath: "/Users/x/.graphcode/bin/graphcoded", supportDirectory: "/Users/x/.graphcode",
+      workspace: .default)
 
     #expect(plist["AssociatedBundleIdentifiers"] as? [String] == ["dev.graphcode.app"])
   }
@@ -143,7 +145,8 @@ struct DaemonBootstrapTests {
     defer { try? FileManager.default.removeItem(at: directory) }
     let url = directory.appendingPathComponent("agent.plist")
     let expected = DaemonBootstrap.launchAgentPlist(
-      daemonPath: "/Users/x/.graphcode/bin/graphcoded", supportDirectory: "/Users/x/.graphcode")
+      daemonPath: "/Users/x/.graphcode/bin/graphcoded", supportDirectory: "/Users/x/.graphcode",
+      workspace: .default)
 
     #expect(!DaemonBootstrap.launchAgentIsCurrent(at: url, expected: expected))
 
@@ -156,6 +159,37 @@ struct DaemonBootstrapTests {
     try PropertyListSerialization.data(fromPropertyList: expected, format: .xml, options: 0)
       .write(to: url)
     #expect(DaemonBootstrap.launchAgentIsCurrent(at: url, expected: expected))
+  }
+
+  @Test
+  func theDefaultWorkspacesAgentIsUnchangedAndANamedOnesCarriesItsDirectory() {
+    // Two halves of one promise. launchd starts an agent with its own minimal
+    // environment, so a named workspace's daemon has to be *told* where to look or it
+    // computes `~/.graphcode` and serves the default workspace's graphs under the second
+    // workspace's label. And the default workspace must gain nothing at all: an extra key
+    // there would make `launchAgentIsCurrent` call every existing install stale and bounce
+    // a daemon that was running perfectly well.
+    let standard = DaemonBootstrap.launchAgentPlist(
+      daemonPath: "/Users/x/.graphcode/bin/graphcoded", supportDirectory: "/Users/x/.graphcode",
+      workspace: .default)
+    #expect(standard["EnvironmentVariables"] as? [String: String] == nil)
+    #expect(standard["Label"] as? String == "dev.graphcode.graphcoded")
+
+    let named = DaemonBootstrap.launchAgentPlist(
+      daemonPath: "/Users/x/.graphcode-work/bin/graphcoded",
+      supportDirectory: "/Users/x/.graphcode-work",
+      workspace: Workspace(slug: "work", url: URL(fileURLWithPath: "/Users/x/.graphcode-work")))
+    #expect(named["Label"] as? String == "dev.graphcode.graphcoded.work")
+    #expect(
+      named["EnvironmentVariables"] as? [String: String]
+        == ["GRAPHCODE_SUPPORT_DIR": "/Users/x/.graphcode-work"])
+    #expect(named["StandardOutPath"] as? String == "/Users/x/.graphcode-work/graphcoded.log")
+    // Still the app's own agent, whichever workspace it serves — this is what keeps
+    // macOS from naming the background item after the signing certificate.
+    #expect(named["AssociatedBundleIdentifiers"] as? [String] == ["dev.graphcode.app"])
+    #expect(
+      (try? PropertyListSerialization.data(fromPropertyList: named, format: .xml, options: 0))
+        != nil)
   }
 
   @Test

--- a/graphcode/Tests/WorkspaceTests.swift
+++ b/graphcode/Tests/WorkspaceTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// Workspaces — separate support directories, each with its own graphs, daemon and loops.
+///
+/// The load-bearing assertions here are the ones about the *default* workspace: it has to
+/// come out of this feature with the same directory, the same daemon label and the same
+/// launch agent bytes it had before, or every existing install would have its daemon
+/// bounced and its agent renamed on first launch.
+@Suite
+struct WorkspaceTests {
+  /// A short home, deliberately: `FileManager.temporaryDirectory` is a ~50-byte
+  /// `/var/folders/…` path, and a workspace socket under it breaches `sun_path` — which
+  /// the validator correctly refuses, failing every test that only wanted a scratch
+  /// directory.
+  private func makeHome() -> URL {
+    let home = URL(fileURLWithPath: "/tmp")
+      .appendingPathComponent("gcw-\(UUID().uuidString.prefix(8))", isDirectory: true)
+    try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    return home
+  }
+
+  @Test
+  func theDefaultWorkspaceKeepsTheDirectoryAndLabelItAlwaysHad() {
+    let workspace = Workspace.default
+
+    #expect(workspace.isDefault)
+    #expect(workspace.slug.isEmpty)
+    #expect(workspace.url.path == SupportDirectory.defaultURL.path)
+    #expect(workspace.url.lastPathComponent == ".graphcode")
+    #expect(workspace.daemonLabel == "dev.graphcode.graphcoded")
+  }
+
+  @Test
+  func theDefaultDirectoryIgnoresTheSupportDirectoryOverride() {
+    // `defaultURL` is the scan root for finding the other workspaces. Were it to follow
+    // `GRAPHCODE_SUPPORT_DIR` the way `url` does, a named workspace would look for its
+    // siblings inside itself and find none of them.
+    #expect(
+      SupportDirectory.defaultURL.path
+        == (NSHomeDirectory() as NSString).appendingPathComponent(".graphcode"))
+  }
+
+  @Test
+  func aNamedWorkspaceIsASiblingWithALabelOfItsOwn() {
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    let url = Workspace.url(forSlug: "client-work", home: home)
+    #expect(url.lastPathComponent == ".graphcode-client-work")
+
+    let workspace = Workspace.workspace(for: url, home: home)
+    #expect(!workspace.isDefault)
+    #expect(workspace.slug == "client-work")
+    #expect(workspace.name == "client-work")
+    #expect(workspace.daemonLabel == "dev.graphcode.graphcoded.client-work")
+  }
+
+  @Test
+  func aDirectoryThisFeatureNeverNamedStillGetsALabelOfItsOwn() {
+    // A developer running `GRAPHCODE_SUPPORT_DIR=~/.graphcode.dev` shared the installed
+    // app's label until now, so launching that build rewrote the real launch agent and
+    // pointed launchd at a DerivedData daemon.
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    let workspace = Workspace.workspace(
+      for: home.appendingPathComponent(".graphcode.dev", isDirectory: true), home: home)
+    #expect(!workspace.isDefault)
+    #expect(workspace.daemonLabel == "dev.graphcode.graphcoded.graphcode-dev")
+  }
+
+  @Test
+  func namesBecomeSlugsThatAreSafeAsDirectoriesAndLabels() {
+    #expect(Workspace.slug(from: "Client Work") == "client-work")
+    #expect(Workspace.slug(from: "  spaced  out  ") == "spaced-out")
+    #expect(Workspace.slug(from: "OSS/side—projects!") == "oss-side-projects")
+    #expect(Workspace.slug(from: "…") == "")
+    #expect(Workspace.slug(from: "Café Zürich") == "cafe-zurich")
+  }
+
+  @Test
+  func aNameThatIsAllPunctuationIsRejectedRatherThanTurnedIntoADotDirectory() {
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    #expect(Workspace.problem(name: "///", home: home) == .empty)
+    #expect(Workspace.problem(name: "", home: home) == .empty)
+  }
+
+  @Test
+  func anExistingWorkspaceIsNotSilentlyReused() throws {
+    // Creating over a live workspace would hand two apps one set of graphs — the exact
+    // thing this feature exists to keep apart.
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    _ = try Workspace.create(name: "work", home: home)
+    #expect(Workspace.problem(name: "work", home: home) == .taken("work"))
+    #expect(Workspace.problem(name: "WORK", home: home) == .taken("work"))
+  }
+
+  @Test
+  func aNameThatWouldOverflowTheSocketPathIsRefusedWithTheNumbers() {
+    // `sun_path` is 104 bytes on Darwin. Without this the bind just fails at runtime and
+    // the workspace looks like a daemon that won't start.
+    let home = URL(fileURLWithPath: "/Users/" + String(repeating: "u", count: 60))
+    let problem = Workspace.problem(
+      name: String(repeating: "w", count: 30), home: home,
+      fileManager: FileManager.default)
+
+    guard case .pathTooLong(let length) = problem else {
+      Issue.record("expected a path-length problem, got \(String(describing: problem))")
+      return
+    }
+    #expect(length > Workspace.maximumSocketPathLength)
+  }
+
+  @Test
+  func creatingAWorkspaceMakesItsDirectoryAndNothingElse() throws {
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    let workspace = try Workspace.create(name: "Side Projects", home: home)
+    #expect(workspace.slug == "side-projects")
+    #expect(FileManager.default.fileExists(atPath: workspace.url.path))
+    // Its `bin/`, launch agent and daemon are the opening instance's job, exactly as they
+    // are for a first install of the default workspace.
+    #expect(
+      (try? FileManager.default.contentsOfDirectory(atPath: workspace.url.path))?.isEmpty == true)
+  }
+
+  @Test
+  func theListIsTheDefaultPlusWhateverDirectoriesExist() throws {
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    _ = try Workspace.create(name: "work", home: home)
+    _ = try Workspace.create(name: "oss", home: home)
+    // Not a workspace: no prefix. The scan must not offer to open someone's dotfiles.
+    try FileManager.default.createDirectory(
+      at: home.appendingPathComponent(".ssh"), withIntermediateDirectories: true)
+
+    let slugs = Workspace.all(home: home).map(\.slug)
+    #expect(slugs.contains(""))
+    #expect(slugs.contains("work"))
+    #expect(slugs.contains("oss"))
+    #expect(!slugs.contains("ssh"))
+    // The default first, then alphabetical — a list that reorders itself between openings
+    // is a list nobody can build a habit on.
+    #expect(slugs.prefix(3) == ["", "oss", "work"])
+  }
+
+  @Test
+  func aWorkspaceRecordsWhichProcessHasItOpen() {
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let workspace = Workspace(slug: "work", url: home)
+
+    #expect(WorkspaceLock.holder(of: workspace) == nil)
+
+    WorkspaceLock.claim(workspace, pid: getpid())
+    #expect(WorkspaceLock.holder(of: workspace) == getpid())
+
+    // A pid nothing is running under is not a claim — this is what a crashed app leaves
+    // behind, and treating it as live would lock a workspace out until someone deleted a
+    // file they have never heard of.
+    WorkspaceLock.claim(workspace, pid: 999_999)
+    #expect(WorkspaceLock.holder(of: workspace) == nil)
+
+    // Releasing on behalf of a pid that no longer holds it must not clear the live claim:
+    // an instance quitting after another took the workspace over.
+    WorkspaceLock.claim(workspace, pid: getpid())
+    WorkspaceLock.release(workspace, pid: 4242)
+    #expect(WorkspaceLock.holder(of: workspace) == getpid())
+
+    WorkspaceLock.release(workspace, pid: getpid())
+    #expect(WorkspaceLock.holder(of: workspace) == nil)
+  }
+}

--- a/graphcode/Tests/WorkspaceTests.swift
+++ b/graphcode/Tests/WorkspaceTests.swift
@@ -154,6 +154,82 @@ struct WorkspaceTests {
   }
 
   @Test
+  func deletionIsRefusedForTheDefaultTheCurrentAndAnOpenWorkspace() {
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let work = Workspace(slug: "work", url: Workspace.url(forSlug: "work", home: home))
+    let other = Workspace(slug: "oss", url: Workspace.url(forSlug: "oss", home: home))
+    try? FileManager.default.createDirectory(at: work.url, withIntermediateDirectories: true)
+
+    // The default workspace is every existing install's whole state.
+    #expect(Workspace.default.deletionRefusal(current: work) == .isDefault)
+    // Deleting the workspace this window is using would pull its graphs out from under a
+    // live app.
+    #expect(work.deletionRefusal(current: work) == .isCurrent)
+    #expect(work.deletionRefusal(current: other) == nil)
+
+    // And the same thing one process away: another instance has it open.
+    WorkspaceLock.claim(work, pid: getpid())
+    #expect(work.deletionRefusal(current: other) == .isOpen(pid: getpid()))
+    WorkspaceLock.release(work, pid: getpid())
+    #expect(work.deletionRefusal(current: other) == nil)
+  }
+
+  @Test
+  func aWorkspacesContentsNameEverySessionItsDeletionMustEnd() throws {
+    // A session missed here is an agent left running against a workspace that no longer
+    // exists, for as long as the machine is up — zmx outlives every app. Extra tabs and
+    // splits are surfaces of their own, so the graphs alone are not the whole answer.
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let workspace = try Workspace.create(name: "work", home: home)
+
+    let node = LoopNode(title: "a loop")
+    var graph = LoopGraph(project: ProjectRef(path: "/tmp/project", name: "project"))
+    graph.nodes.append(node)
+    let projects = workspace.url.appendingPathComponent("projects", isDirectory: true)
+    try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+    try JSONEncoder().encode(graph)
+      .write(to: projects.appendingPathComponent("_tmp_project.json"))
+
+    let extraSurface = SurfaceRef(id: UUID(), launchesClaudeCode: false)
+    var layout = TerminalLayout.defaultLayout(forNode: node.id)
+    layout.tabs.append(TabLayout(primary: extraSurface))
+    let layouts = workspace.url.appendingPathComponent("terminal-layouts", isDirectory: true)
+    try FileManager.default.createDirectory(at: layouts, withIntermediateDirectories: true)
+    try JSONEncoder().encode(layout)
+      .write(to: layouts.appendingPathComponent("\(node.id.uuidString).json"))
+
+    let contents = workspace.contents()
+    #expect(contents.projects == 1)
+    #expect(contents.loops == 1)
+    #expect(contents.sessionNames.contains("graphcode-\(node.id.uuidString)"))
+    #expect(contents.sessionNames.contains("graphcode-\(extraSurface.id.uuidString)"))
+    #expect(contents.sessionNames.count == 2)
+  }
+
+  @Test
+  func aLiveClaimIsNotStolenByASecondProcess() {
+    // The test host launches the app, which claims the default workspace on the way up.
+    // Claiming unconditionally would have it overwrite a running window's pid, and once
+    // the host exited the workspace would read as free while that window still had it.
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let workspace = Workspace(slug: "work", url: home)
+
+    #expect(WorkspaceLock.claim(workspace, pid: getpid()))
+    #expect(!WorkspaceLock.claim(workspace, pid: 4242))
+    #expect(WorkspaceLock.holder(of: workspace) == getpid())
+
+    // A dead holder is no holder: a crashed app must not lock the workspace out forever.
+    WorkspaceLock.release(workspace, pid: getpid())
+    WorkspaceLock.claim(workspace, pid: 999_999)
+    #expect(WorkspaceLock.claim(workspace, pid: getpid()))
+    #expect(WorkspaceLock.holder(of: workspace) == getpid())
+    WorkspaceLock.release(workspace, pid: getpid())
+  }
+
+  @Test
   func aWorkspaceRecordsWhichProcessHasItOpen() {
     let home = makeHome()
     defer { try? FileManager.default.removeItem(at: home) }
@@ -166,7 +242,9 @@ struct WorkspaceTests {
 
     // A pid nothing is running under is not a claim — this is what a crashed app leaves
     // behind, and treating it as live would lock a workspace out until someone deleted a
-    // file they have never heard of.
+    // file they have never heard of. Released first because a claim is not stolen from a
+    // live holder; see `aLiveClaimIsNotStolenByASecondProcess`.
+    WorkspaceLock.release(workspace, pid: getpid())
     WorkspaceLock.claim(workspace, pid: 999_999)
     #expect(WorkspaceLock.holder(of: workspace) == nil)
 


### PR DESCRIPTION
## What this solves

One sidebar of loops stops being monitorable somewhere past a few dozen, and unrelated lines of work have no reason to share a graph. This adds **workspaces**: a support directory of its own — `~/.graphcode-<name>`, beside the default `~/.graphcode` — with its own projects, loops, terminal layouts and `graphcoded`.

**File ▸ Workspace ▸ New Workspace…** names one and opens it. It is a second app instance, so it gets its own Dock tile and can live on a second screen.

## Why it needed more than the environment variable

`GRAPHCODE_SUPPORT_DIR` has always been able to point a second graphcode elsewhere. Two things made it unusable as a product feature, both fixed here:

- **One hardcoded launch agent label.** A second app rewrote `dev.graphcode.graphcoded` and took the first workspace's daemon with it. Labels are now per workspace (`dev.graphcode.graphcoded.<slug>`).
- **launchd starts an agent with a minimal environment**, so the daemon it spawned computed `~/.graphcode` whatever the app was pointed at. A named workspace's agent now carries its directory in `EnvironmentVariables`.

## The default workspace is untouched

Same path, same label, and a plist with **no new keys** — an extra key there would make `launchAgentIsCurrent` report every existing install as stale and bounce a daemon that was running perfectly well. `theDefaultWorkspacesAgentIsUnchangedAndANamedOnesCarriesItsDirectory` pins both halves.

A side effect worth naming: a developer running `GRAPHCODE_SUPPORT_DIR=~/.graphcode.dev` shared the installed app's label until now, so launching that build rewrote the real agent and pointed launchd at a DerivedData daemon. Every non-default directory now gets a label of its own.

## Also here

- **A pid file per workspace** — opening one already open raises its window instead of starting a second app over one set of graphs and `zmx` session names.
- **Socket paths validated at naming time** against `sun_path`'s 104 bytes, with the numbers in the message, rather than failing to bind later and looking like a dead daemon.
- **A switcher at the foot of the sidebar** — the only thing on screen that says which workspace a window is; two instances share an icon and have no titlebar. Shown only once there is more than one workspace.
- Workspaces are found by scanning for `~/.graphcode-*` rather than kept in a registry file, which would have to live in one workspace and be written by all the others.

## Verification

- `xcodebuild … test` — **984 tests, all passing**; 12 of them new.
- `swift format lint --strict` clean over `GraphcodeKit` and `graphcode`.
- Launched a second instance of the built app through the same `NSWorkspace.OpenConfiguration` path the client uses, pointed at a probe directory, and confirmed on the live machine: `GRAPHCODE_SUPPORT_DIR` arrives in the child (with `PATH` intact — the configuration adds to the environment rather than replacing it), `app.pid` lands in the probe directory, no launch agent is written for an unpackaged build, and the installed workspace's agent checksum and running daemon are unchanged.

## Not in this PR

Deleting or renaming a workspace (remove the directory by hand for now), and any sharing between workspaces — a loop in one is invisible in the other, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)