### PR TITLE
docs: keep the two meanings of "workspace" apart

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Releases are Developer ID signed and notarized.
    over SSH (key auth and zmx on the server; loops run there while this Mac steers them).
 2. **Create a loop** — ⊕ on the canvas. Write the prompt and hit Create; the type chooser explains what
    each kind hands off, and a goal's done check has a **Test** button that runs it as the daemon will.
-3. **Open it** — click the node for its terminal workspace: tabs, splits, ⌘K to jump to any loop, ⌘⇧R to walk
+3. **Open it** — click the node for that loop's terminal workspace: tabs, splits, ⌘K to jump to any loop, ⌘⇧R to walk
    the ones asking for you ([shortcuts](https://graphcode.app/shortcuts.html)). You attach to the live session.
 4. **Connect loops** — drag between nodes. An edge is a hand-off by default (fires when the source
    resolves); it can also be a message or a spawn, with a condition and a cycle guard.
@@ -87,6 +87,9 @@ same variable the app sets: `GRAPHCODE_SUPPORT_DIR=~/.graphcode-work graphcode s
 **⌥⌘1 … ⌥⌘9** switch between them in menu order and **⌥⌘N** makes a new one. **Delete Workspace**,
 in the same menu, ends that workspace's terminal sessions, stops its daemon, and moves its folder to
 the Trash — the default workspace and whichever one you are in are never offered.
+
+Not to be confused with a loop's **terminal workspace**, which is the tabs and splits inside one
+loop. A workspace holds projects; a terminal workspace holds panes.
 
 ## Building from source
 

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -6,8 +6,12 @@ description: Every keyboard shortcut and mouse trick in GraphCode — the graph,
 # Keyboard shortcuts
 
 Everything here is also in the menu bar — **Loop** and **Terminal** are the two menus
-that appear once a workspace is open, and macOS draws each key beside its item. This
+that appear once a loop is open, and macOS draws each key beside its item. This
 page is the same information in one place.
+
+Two things in GraphCode are called a workspace, and this page keeps them apart. A
+**workspace** is a separate set of projects and loops in a window of its own. A loop's
+**terminal workspace** is the tabs and splits inside one loop.
 
 ## The graph
 
@@ -33,7 +37,9 @@ Quick Chats count as places you have been. The trail survives quitting the app.
 ## Workspaces
 
 A workspace is a separate set of projects and loops, in a window of its own — for keeping
-unrelated lines of work apart. **File ▸ Workspace** lists them.
+unrelated lines of work apart. Nothing is shared between them, and each gets its own Dock
+tile, so one can sit on a second screen. **File ▸ Workspace** lists them. (For the tabs
+and splits *inside* a loop, see [Terminals](#terminals).)
 
 | Shortcut | Does |
 |---|---|
@@ -46,12 +52,13 @@ is currently open somewhere can't be deleted until that window is closed.
 
 ## Terminals
 
-Inside a loop's workspace, the panes are real terminals — these act on them:
+A loop's **terminal workspace** is the pane area you get when you open it — real
+terminals, in tabs and splits. These act on them:
 
 | Shortcut | Does |
 |---|---|
 | ⌘T | New tab |
-| ⌘W | Close tab (a workspace always keeps its last one) |
+| ⌘W | Close tab (a loop always keeps its last one) |
 | ⌘1 … ⌘9 | Select that tab |
 | ⌘→ / ⌘← | Next / previous tab |
 | ⌘D | Split the pane right |


### PR DESCRIPTION
Shipping workspaces (#156) gave the word a second meaning, and the docs still used the old one in places where it now reads as the new one:

| Was | Meant | Now |
|---|---|---|
| "the two menus that appear once a **workspace** is open" | a loop | "once a **loop** is open" |
| "a **workspace** always keeps its last one" (⌘W) | a loop | "a **loop** always keeps its last one" |
| "Inside a loop's **workspace**, the panes are real terminals" | a loop's panes | "A loop's **terminal workspace** is the pane area you get when you open it" |
| "click the node for **its** terminal workspace" | the loop's | "click the node for **that loop's** terminal workspace" |

Both nouns are now defined in full where they first appear, and each section says which one it means and points at the other:

> A **workspace** is a separate set of projects and loops in a window of its own. A loop's **terminal workspace** is the tabs and splits inside one loop.

No in-app strings needed changing — every user-visible "workspace" in the app is already the new top-level one; the loop-level name survives only in code (`LoopWorkspaceFeature`, the rail's defaults keys), where it is unambiguous.

Docs only: `README.md` and `docs/shortcuts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)