### PR TITLE
fix: serialize frame writes per socket, not per writer

### DIFF
--- a/GraphcodeKit/Sources/IPC/FramedMessageIO.swift
+++ b/GraphcodeKit/Sources/IPC/FramedMessageIO.swift
@@ -9,10 +9,21 @@ import Foundation
 /// connection handlers and the app's `OrchestratorClient` so both sides always agree
 /// on where one message ends and the next begins.
 ///
-/// Blocking, on purpose: every call site runs this on a background thread/queue
-/// dedicated to one connection, not the main thread, so blocking `read`/`write` is the
-/// simplest correct thing here — no need for `Network.framework` or a custom
-/// `DispatchIO` setup at this scale (a handful of local connections).
+/// Blocking, on purpose: every call site runs this on a background thread/queue, not the
+/// main thread, so blocking `read`/`write` is the simplest correct thing here — no need
+/// for `Network.framework` or a custom `DispatchIO` setup at this scale (a handful of
+/// local connections).
+///
+/// Writes are serialized per descriptor, which is not a detail: a frame goes out as two
+/// `write` calls, and *nothing* in this codebase gives a connection a single writer. The
+/// app sends every command from `DispatchQueue.global()`; the daemon answers from two
+/// separate actors (`ProjectRegistry`, `GraphStore`) plus the version-skew reply in
+/// `graphcoded/main.swift`. Two of those overlapping on one socket puts header A in front
+/// of body B, and the reader — having consumed a length that belongs to someone else's
+/// message — is wrong from that byte onward. That is what "unrecognized command —
+/// graphcoded may be older than the client that sent it" was really reporting when a new
+/// workspace opened (0.1.46-beta1): its three launch commands wait together on the
+/// just-bootstrapped daemon and are released at the same instant.
 public enum FramedMessageIO {
   public enum IOError: Error, Equatable {
     case connectionClosed
@@ -21,6 +32,10 @@ public enum FramedMessageIO {
   }
 
   public static func writeFrame(_ data: Data, to fileDescriptor: Int32) throws {
+    let lock = writeLocks.lock(forDescriptor: fileDescriptor)
+    lock.lock()
+    defer { lock.unlock() }
+
     let length = UInt32(data.count)
     let header: [UInt8] = [
       UInt8((length >> 24) & 0xff),
@@ -40,6 +55,30 @@ public enum FramedMessageIO {
       | (UInt32(header[header.startIndex + 2]) << 8)
       | UInt32(header[header.startIndex + 3])
     return try readExactly(Int(length), from: fileDescriptor)
+  }
+
+  /// One lock per descriptor rather than one for the whole process: a write blocks while
+  /// its socket buffer is full, and the daemon broadcasts to every connected client — a
+  /// single lock would let one wedged client stall the writes to all the others.
+  ///
+  /// Locks are kept rather than reclaimed on close. Descriptor numbers are small and the
+  /// kernel reuses them, so the table stays about as large as the peak connection count,
+  /// and a reused number simply gets the same lock back — correct either way, where
+  /// discarding one a concurrent writer still holds would not be.
+  private static let writeLocks = DescriptorLocks()
+
+  private final class DescriptorLocks: @unchecked Sendable {
+    private var locks: [Int32: NSLock] = [:]
+    private let tableLock = NSLock()
+
+    func lock(forDescriptor descriptor: Int32) -> NSLock {
+      tableLock.lock()
+      defer { tableLock.unlock() }
+      if let existing = locks[descriptor] { return existing }
+      let created = NSLock()
+      locks[descriptor] = created
+      return created
+    }
   }
 
   private static func writeAll(_ data: Data, to fileDescriptor: Int32) throws {

--- a/graphcode/Tests/FramedMessageIOTests.swift
+++ b/graphcode/Tests/FramedMessageIOTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// Framing over a socket, and the property the whole protocol rests on: a frame written
+/// while another frame is being written to the same connection must not interleave with
+/// it.
+@Suite
+struct FramedMessageIOTests {
+  /// Creates a connected pair of sockets, standing in for a client and `graphcoded`.
+  private func makeSocketPair() -> (Int32, Int32) {
+    var descriptors: [Int32] = [0, 0]
+    #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
+    return (descriptors[0], descriptors[1])
+  }
+
+  @Test
+  func aFrameSurvivesTheRoundTrip() throws {
+    let (writer, reader) = makeSocketPair()
+    defer {
+      close(writer)
+      close(reader)
+    }
+
+    let payload = Data("{\"command\":\"listRecentProjects\"}".utf8)
+    try FramedMessageIO.writeFrame(payload, to: writer)
+    #expect(try FramedMessageIO.readFrame(from: reader) == payload)
+  }
+
+  @Test
+  func concurrentWritersDoNotInterleaveTheirFrames() throws {
+    // The 0.1.46-beta1 bug, reproduced. A frame goes out as two writes — a 4-byte length
+    // header, then the body — and `AppFeature`'s launch effect sends three commands at
+    // once, each hopping onto the global queue. Interleave two of those and the daemon
+    // reads header A followed by body B, fails to decode it, and answers "unrecognized
+    // command — graphcoded may be older than the client that sent it". Nothing is out of
+    // date; the bytes were spliced.
+    //
+    // It showed up on a *new workspace* because the three sends pile up behind the
+    // connect retry while the just-bootstrapped daemon comes up, then resume together.
+    //
+    // Bodies are far larger than a socket buffer so a single write cannot complete in one
+    // syscall — that makes the interleaving certain rather than occasional, which is what
+    // a regression test needs.
+    let (writer, reader) = makeSocketPair()
+    defer {
+      close(writer)
+      close(reader)
+    }
+
+    let writerCount = 8
+    let bodySize = 64 * 1024
+    let payloads = (0..<writerCount).map { index in
+      Data(("\(index):" + String(repeating: "\(index)", count: bodySize)).utf8)
+    }
+
+    // The reader has to run alongside the writers: the socket buffer is a few kilobytes,
+    // so nobody finishes writing until somebody starts draining.
+    let received = Mutex<[Data]>([])
+    let readerFinished = DispatchSemaphore(value: 0)
+    DispatchQueue.global().async {
+      for _ in 0..<writerCount {
+        guard let frame = try? FramedMessageIO.readFrame(from: reader) else { break }
+        received.withLock { $0.append(frame) }
+      }
+      readerFinished.signal()
+    }
+
+    DispatchQueue.concurrentPerform(iterations: writerCount) { index in
+      try? FramedMessageIO.writeFrame(payloads[index], to: writer)
+    }
+
+    #expect(readerFinished.wait(timeout: .now() + 30) == .success)
+
+    // Every frame arrives whole, and each is one of the payloads — a spliced frame fails
+    // both halves of that: the wrong length is read, and the bytes belong to two writers.
+    let frames = received.withLock { $0 }
+    #expect(frames.count == writerCount)
+    #expect(Set(frames) == Set(payloads))
+  }
+}
+
+/// A minimal lock box, so the reader thread can hand its frames back without the test
+/// needing an actor (and the `await` that would come with one).
+private final class Mutex<Value>: @unchecked Sendable {
+  private var value: Value
+  private let lock = NSLock()
+
+  init(_ value: Value) { self.value = value }
+
+  func withLock<Result>(_ body: (inout Value) -> Result) -> Result {
+    lock.lock()
+    defer { lock.unlock() }
+    return body(&value)
+  }
+}


### PR DESCRIPTION
Fixes the "unrecognised command — graphcoded may be older than the client" error seen on first open of a **new workspace** in 0.1.46-beta1, which a quit and relaunch clears.

## It isn't version skew

Nothing is out of date — the bytes are spliced. A frame goes out as **two writes** (a 4-byte length header, then the body), and nothing gave a connection a single writer:

| Direction | Concurrent writers on one socket |
|---|---|
| app → daemon | every `DaemonConnection.send` hops onto `DispatchQueue.global()`; `AppFeature.start()` merges three at launch — `listRecentProjects`, `restoreOpenProjects`, `openGlobalGraph` |
| daemon → app | `ProjectRegistry` and `GraphStore` are **separate actors**, plus the skew reply in `graphcoded/main.swift:136` |

Overlap two and the reader consumes header A followed by body B, then reads a length belonging to someone else's message and is wrong from that byte onward — it either decodes garbage (which raises exactly this error, the only place that string exists) or blocks waiting for bytes that never arrive.

**Why a new workspace specifically:** the three launch commands wait together on `connectWithBackoff` while the freshly bootstrapped daemon comes up, then resume at the same instant — the widest possible collision window. On the next launch the daemon is already listening, the sends stagger, and it doesn't land. That is precisely "first time only, restart is fine".

## The fix

`FramedMessageIO.writeFrame` now takes a lock for the descriptor it is writing to, so a frame can never interleave with another on the same connection. One call site changed, all five writers fixed.

Per descriptor rather than one lock for the process: a write blocks while its socket buffer is full and the daemon broadcasts to every connected client, so a single lock would let one wedged client stall the writes to all the others. Locks are kept rather than reclaimed on close — descriptor numbers are small and reused, so the table stays about as big as the peak connection count, and a reused number gets the same lock back.

## Verification

`concurrentWritersDoNotInterleaveTheirFrames` — 8 writers, 64 KB bodies (larger than a socket buffer, so a single `write` cannot complete in one syscall and the interleaving is certain rather than occasional):

| | Result |
|---|---|
| **Before** | ❌ 1 of 8 frames arrived; reader then hung on a spliced header until the 30s timeout |
| **After** | ✅ passes in 0.005s |

Full suite: **989 tests passing**. `swift format lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)