### PR TITLE
fix: only the default workspace offers app updates

### DIFF
--- a/graphcode/Sources/Features/App/AppFeature+Updates.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Updates.swift
@@ -43,6 +43,11 @@ extension AppFeature {
         // A second click while a check is in flight would just race two alerts; the
         // menu item is disabled on this flag, and this guard is the backstop.
         guard !state.isCheckingForUpdates else { return .none }
+        // Updates belong to the default workspace — every workspace is the same bundle
+        // in /Applications, so this is not per-workspace news. See
+        // `WorkspacesState.managesUpdates`; the menu item is disabled elsewhere and this
+        // is the backstop for it.
+        guard state.workspaces.managesUpdates else { return .none }
         state.isCheckingForUpdates = true
         return .run { send in
           do {
@@ -69,6 +74,11 @@ extension AppFeature {
         // and no auto-presented alert on success — the banner is the whole surface. A
         // check already running (the menu item, another launch tick) owns the result.
         guard !state.isCheckingForUpdates else { return .none }
+        // Updates belong to the default workspace — every workspace is the same bundle
+        // in /Applications, so this is not per-workspace news. See
+        // `WorkspacesState.managesUpdates`; the menu item is disabled elsewhere and this
+        // is the backstop for it.
+        guard state.workspaces.managesUpdates else { return .none }
         state.isCheckingForUpdates = true
         return .run { send in
           let current = updateClient.currentVersion()

--- a/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
@@ -12,8 +12,9 @@ extension AppFeature {
     /// by a human every few weeks, and the alternative is a directory watcher on `$HOME`.
     var known: [Workspace] = []
     /// Read once. A running app cannot change workspace — that is what launching another
-    /// instance is for — so this is fixed for the life of the process.
-    let current: Workspace = .current
+    /// instance is for — so this is fixed for the life of the process. A `var` only so a
+    /// test can state which workspace it is asking about.
+    var current: Workspace = .current
     var isCreating = false
     var draftName = ""
     /// What is wrong with `draftName`, said while it is being typed rather than after
@@ -25,6 +26,16 @@ extension AppFeature {
     /// A refusal or a failure from the last deletion attempt, shown as an alert. Distinct
     /// from `problem`, which is about a name being typed.
     var deletionFailure: String?
+
+    /// Whether this instance is the one that offers and installs app updates.
+    ///
+    /// Only the default workspace does. Every workspace is the same bundle in
+    /// `/Applications`, so an update is not per-workspace news — with three open, the
+    /// same banner appears three times and three windows race to swap one app. Worse,
+    /// `UpdateInstallClient.relaunch` reopens the app with no `GRAPHCODE_SUPPORT_DIR`:
+    /// a named workspace that updated itself would come back as the default one, which
+    /// reads as the update having thrown its projects away.
+    var managesUpdates: Bool { current.isDefault }
 
     /// Whether to name the workspace in the UI at all. A machine with one workspace has
     /// no ambiguity to resolve, and a permanent "Default" chip would be noise on every

--- a/graphcode/Sources/Features/App/AppSidebarView.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView.swift
@@ -193,8 +193,8 @@ struct AppSidebarView: View {
     VStack(spacing: 0) {
       // Hidden while an install is mid-flight (the progress overlay speaks then) or
       // already staged (the relaunch alert does).
-      if let update = store.offeredUpdate, store.updateInstallProgress == nil,
-        !store.isUpdateReadyToRelaunch
+      if store.workspaces.managesUpdates, let update = store.offeredUpdate,
+        store.updateInstallProgress == nil, !store.isUpdateReadyToRelaunch
       {
         SidebarUpdateBanner(version: update.version) {
           store.send(.updateBannerTapped)

--- a/graphcode/Sources/GraphcodeApp.swift
+++ b/graphcode/Sources/GraphcodeApp.swift
@@ -77,7 +77,11 @@ struct GraphcodeApp: App {
         Button("Check for Updates…") {
           Self.store.send(.checkForUpdatesTapped)
         }
-        .disabled(Self.store.isCheckingForUpdates || Self.store.updateInstallProgress != nil)
+        // Disabled outside the default workspace, the only one that updates the app —
+        // see `AppFeature.WorkspacesState.managesUpdates`.
+        .disabled(
+          !Self.store.workspaces.managesUpdates || Self.store.isCheckingForUpdates
+            || Self.store.updateInstallProgress != nil)
       }
       // Replacing rather than appending: the default "GraphCode Help" item asks AppKit
       // for a help book the app doesn't bundle, so it only ever showed "Help isn't

--- a/graphcode/Tests/WorkspaceUpdateGatingTests.swift
+++ b/graphcode/Tests/WorkspaceUpdateGatingTests.swift
@@ -1,0 +1,55 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// Which workspace offers app updates.
+///
+/// Only the default one. Every workspace is the same bundle in `/Applications`, so an
+/// update is not per-workspace news: with three open, the same banner appears three
+/// times and three windows race to swap one app. And `UpdateInstallClient.relaunch`
+/// reopens the app with no `GRAPHCODE_SUPPORT_DIR`, so a named workspace that updated
+/// itself would come back as the default one — which reads as the update having thrown
+/// its projects away.
+///
+/// That the default workspace still checks is covered by `CheckForUpdatesTests`, whose
+/// stores are all in it.
+@Suite
+struct WorkspaceUpdateGatingTests {
+  private func state(inWorkspace workspace: Workspace) -> AppFeature.State {
+    var state = AppFeature.State()
+    state.workspaces.current = workspace
+    return state
+  }
+
+  private var namedWorkspace: Workspace {
+    Workspace(slug: "work", url: URL(fileURLWithPath: "/tmp/.graphcode-work"))
+  }
+
+  @Test
+  func theDefaultWorkspaceIsTheOneThatManagesUpdates() {
+    #expect(AppFeature.State().workspaces.managesUpdates)
+    #expect(!state(inWorkspace: namedWorkspace).workspaces.managesUpdates)
+  }
+
+  @Test
+  @MainActor
+  func aNamedWorkspaceNeitherChecksOnItsOwnNorWhenAsked() async {
+    // Both entry points, and the dependencies are left unimplemented on purpose: a check
+    // that reached GitHub from here would fail the test by calling one of them.
+    let store = TestStore(initialState: state(inWorkspace: namedWorkspace)) {
+      AppFeature()
+    }
+
+    await store.send(.checkForUpdatesInBackground)
+    #expect(!store.state.isCheckingForUpdates)
+
+    // The menu item is disabled in a named workspace; this is the backstop behind it.
+    await store.send(.checkForUpdatesTapped)
+    #expect(!store.state.isCheckingForUpdates)
+    #expect(store.state.offeredUpdate == nil)
+  }
+
+}


### PR DESCRIPTION
Every workspace is the same bundle in `/Applications`, so an update is not per-workspace news. With three open, the same banner appeared three times and three windows were each one click from swapping one app underneath the other two.

The sharper reason is the relaunch: `UpdateInstallClient.relaunch` reopens `/Applications/graphcode.app` with **no** `GRAPHCODE_SUPPORT_DIR`, so a named workspace that installed an update came back as the **default** one — indistinguishable, to the person watching, from the update having thrown their projects away.

| Surface | Default | Named workspace |
|---|---|---|
| Sidebar update banner | shows | hidden |
| Background check at launch | runs | skipped |
| `Check for Updates…` | enabled | disabled |
| Install progress / relaunch alerts | as before | cannot arise |

All off one property, `WorkspacesState.managesUpdates`. Both check actions guard on it as well — a disabled menu item is not a place to keep the only copy of a rule.

## Tests

- `theDefaultWorkspaceIsTheOneThatManagesUpdates`
- `aNamedWorkspaceNeitherChecksOnItsOwnNorWhenAsked` — sends both entry points with the update dependencies left *unimplemented*, so a check that reached GitHub would fail the test by calling one.
- That the default workspace still checks stays covered by `CheckForUpdatesTests`, whose stores are all in it.

**991 tests passing**, `swift format lint --strict` clean.

## Not in this PR

Installing from the default workspace while other workspace windows are open still replaces the bundle under them — they keep running the old binary until they are relaunched. Worth a follow-up (offer to quit the others, or defer), but it is the pre-existing behaviour for any second window, not something this changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)