### PR TITLE
feat: installing an update offers to quit the other workspaces

### DIFF
--- a/graphcode/Sources/Clients/WorkspaceClient.swift
+++ b/graphcode/Sources/Clients/WorkspaceClient.swift
@@ -24,6 +24,11 @@ struct WorkspaceClient: Sendable {
   /// directory to the Trash. Throws `Workspace.DeletionRefusal` when it is not a
   /// workspace this may touch.
   var delete: @Sendable (Workspace) throws -> Void
+  /// Workspaces open in *other* instances right now. Asked before an update swaps the
+  /// bundle, since every workspace runs from the same copy in /Applications.
+  var otherOpen: @Sendable () -> [Workspace]
+  /// Asks those instances to quit, and waits — briefly — for them to actually go.
+  var quit: @Sendable ([Workspace]) async -> Void
 }
 
 extension WorkspaceClient: DependencyKey {
@@ -60,13 +65,35 @@ extension WorkspaceClient: DependencyKey {
       // copy of it. Recoverable for as long as they haven't emptied the Trash.
       var trashed: NSURL?
       try FileManager.default.trashItem(at: workspace.url, resultingItemURL: &trashed)
+    },
+    otherOpen: {
+      let current = Workspace.current
+      return Workspace.all()
+        .filter { $0.id != current.id }
+        .filter { runningInstance(of: $0) != nil }
+    },
+    quit: { workspaces in
+      let running = workspaces.compactMap(runningInstance(of:))
+      for application in running { application.terminate() }
+
+      // Waited on rather than fired and forgotten: the point is to have them gone
+      // *before* /Applications is replaced, since a running app whose bundle has been
+      // swapped underneath it is reading pages that no longer exist. Bounded, because a
+      // window that will not quit must not strand the update — the human already chose
+      // to go ahead.
+      let deadline = Date().addingTimeInterval(10)
+      while Date() < deadline, running.contains(where: { !$0.isTerminated }) {
+        try? await Task.sleep(for: .milliseconds(100))
+      }
     })
 
   static let testValue = WorkspaceClient(
     list: { [.default] },
     create: { Workspace(slug: $0, url: URL(fileURLWithPath: "/tmp/\($0)")) },
     open: { _ in },
-    delete: { _ in })
+    delete: { _ in },
+    otherOpen: { [] },
+    quit: { _ in })
 
   /// `zmx kill` per session, best effort: a name that is already gone exits non-zero and
   /// that is the healthy case, not something to abandon the deletion over.

--- a/graphcode/Sources/Features/App/AppFeature+Updates.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Updates.swift
@@ -152,6 +152,21 @@ extension AppFeature {
         return .none
 
       case .updateInstallTapped:
+        guard state.offeredUpdate != nil, state.updateInstallProgress == nil
+        else { return .none }
+        // Every workspace runs from the same copy in /Applications, so installing swaps
+        // the bundle out from under any other open window — which then keeps running an
+        // old binary whose pages are no longer on disk. Ask first; `UpdateDialogs` offers
+        // to quit them, and either answer comes back as `.updateInstallConfirmed`.
+        let others = workspaceClient.otherOpen()
+        guard others.isEmpty else {
+          state.workspaces.othersOpenForUpdate = others
+          state.availableUpdate = nil
+          return .none
+        }
+        return .send(.updateInstallConfirmed)
+
+      case .updateInstallConfirmed:
         guard let update = state.offeredUpdate, state.updateInstallProgress == nil
         else { return .none }
         state.availableUpdate = nil

--- a/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
@@ -23,6 +23,9 @@ extension AppFeature {
     /// The workspace a Delete confirmation is up for, with what it would take with it —
     /// counted when the dialog opens, since the numbers come off disk.
     var pendingDeletion: PendingDeletion?
+    /// The other workspaces found open when Install was pressed, held while the app asks
+    /// what to do about them. `nil` means nothing is being asked.
+    var othersOpenForUpdate: [Workspace]?
     /// A refusal or a failure from the last deletion attempt, shown as an alert. Distinct
     /// from `problem`, which is about a name being typed.
     var deletionFailure: String?
@@ -73,6 +76,10 @@ extension AppFeature {
     case deleteConfirmed
     case deleteCancelled
     case deletionFailureDismissed
+    /// The three answers to "other workspaces are open" — see `UpdateDialogs`.
+    case quitOthersForUpdate
+    case updateWithoutQuittingOthers
+    case othersForUpdateDismissed
   }
 }
 
@@ -149,6 +156,24 @@ struct AppWorkspacesReducer: Reducer {
 
       case .workspaces(.deletionFailureDismissed):
         state.workspaces.deletionFailure = nil
+        return .none
+
+      case .workspaces(.quitOthersForUpdate):
+        guard let others = state.workspaces.othersOpenForUpdate else { return .none }
+        state.workspaces.othersOpenForUpdate = nil
+        // The install waits for them: `quit` returns once they have gone (or once it
+        // gives up on one), so the swap never lands under a live window.
+        return .run { [quit = workspaces.quit] send in
+          await quit(others)
+          await send(.updateInstallConfirmed)
+        }
+
+      case .workspaces(.updateWithoutQuittingOthers):
+        state.workspaces.othersOpenForUpdate = nil
+        return .send(.updateInstallConfirmed)
+
+      case .workspaces(.othersForUpdateDismissed):
+        state.workspaces.othersOpenForUpdate = nil
         return .none
 
       default:

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -232,6 +232,8 @@ struct AppFeature {
     case updateAlertDismissed
     case updateNoticeDismissed
     case updateInstallTapped
+    /// Install, past the other-workspaces question — see `AppFeature+Workspaces`.
+    case updateInstallConfirmed
     /// Install re-checked the channel at the moment of consent and found a newer
     /// release than the one the alert offered — the state follows what is actually
     /// being installed, so the relaunch prompt names the right version.
@@ -269,6 +271,7 @@ struct AppFeature {
   @Dependency(\.quickChatStore) var quickChatStore
   @Dependency(\.updateClient) var updateClient
   @Dependency(\.updateInstallClient) var updateInstallClient
+  @Dependency(\.workspaceClient) var workspaceClient
   @Dependency(\.openURL) var openURL
   /// Only for the cases where a workspace goes away because the *loop* did. Merely
   /// switching to another loop leaves its surfaces alive on purpose — see
@@ -484,7 +487,8 @@ struct AppFeature {
       case .checkForUpdatesTapped, .checkForUpdatesInBackground, .updateFoundInBackground,
         .updateBannerTapped, .updateCheckCompleted, .updateDownloadTapped,
         .updateReleaseNotesTapped, .updateAlertDismissed, .updateNoticeDismissed,
-        .updateInstallTapped, .updateInstallResolved, .updateInstallProgressed,
+        .updateInstallTapped, .updateInstallConfirmed, .updateInstallResolved,
+        .updateInstallProgressed,
         .updateInstallFinished, .updateInstallFailureDismissed, .updateRelaunchTapped,
         .updateRelaunchDismissed:
         return .none

--- a/graphcode/Sources/Features/App/UpdateDialogs.swift
+++ b/graphcode/Sources/Features/App/UpdateDialogs.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import GraphcodeKit
 import SwiftUI
 
 /// Check for Updates' dialogs and the install-progress indicator, applied to `AppView`'s
@@ -7,6 +8,15 @@ import SwiftUI
 /// button's action, which is how the shipped Download button managed to do nothing (#35).
 struct UpdateDialogs: ViewModifier {
   let store: StoreOf<AppFeature>
+
+  /// "work", "work and oss", "work, oss and side" — named rather than counted, because
+  /// the answer someone needs is *which* windows are about to be quit.
+  static func list(_ workspaces: [Workspace]) -> String {
+    let names = workspaces.map(\.name)
+    guard let last = names.last else { return "" }
+    guard names.count > 1 else { return last }
+    return names.dropLast().joined(separator: ", ") + " and " + last
+  }
 
   func body(content: Content) -> some View {
     content
@@ -51,6 +61,33 @@ struct UpdateDialogs: ViewModifier {
           "GraphCode \(store.offeredUpdate?.version ?? "") is in Applications and "
             + "takes over on the next launch. Sessions keep running through a relaunch "
             + "— the daemon holds them, not the window.")
+      }
+      // Asked before the swap, not after: every workspace runs from the same copy in
+      // /Applications, so installing replaces the bundle underneath any other open
+      // window — which is then executing pages that are no longer on disk.
+      .confirmationDialog(
+        "Other workspaces are open",
+        isPresented: Binding(
+          get: { store.workspaces.othersOpenForUpdate != nil },
+          set: { if !$0 { store.send(.workspaces(.othersForUpdateDismissed)) } }
+        ),
+        titleVisibility: .visible,
+        presenting: store.workspaces.othersOpenForUpdate
+      ) { others in
+        Button("Quit \(others.count == 1 ? "It" : "Them") & Install") {
+          store.send(.workspaces(.quitOthersForUpdate))
+        }
+        Button("Install Anyway") { store.send(.workspaces(.updateWithoutQuittingOthers)) }
+        Button("Cancel", role: .cancel) {
+          store.send(.workspaces(.othersForUpdateDismissed))
+        }
+      } message: { others in
+        Text(
+          "\(UpdateDialogs.list(others)) \(others.count == 1 ? "is" : "are") open in "
+            + "\(others.count == 1 ? "another window" : "other windows"). Every workspace "
+            + "runs the same app, so installing replaces it for all of them. Quitting "
+            + "them first is the clean way — their loops keep running either way, since "
+            + "the daemon holds the sessions, not the window.")
       }
       .alert(
         "Couldn't install the update",

--- a/graphcode/Tests/UpdateInstallTests.swift
+++ b/graphcode/Tests/UpdateInstallTests.swift
@@ -83,6 +83,9 @@ struct UpdateInstallTests {
 
     await store.send(.updateAlertDismissed)
     await store.send(.updateInstallTapped)
+    // Install asks about other open workspaces first (there are none here), so the work
+    // starts on the action both answers arrive as.
+    await store.receive(\.updateInstallConfirmed)
     #expect(store.state.updateInstallProgress == 0)
     await store.receive(\.updateInstallFinished)
 

--- a/graphcode/Tests/UpdateQuitsOtherWorkspacesTests.swift
+++ b/graphcode/Tests/UpdateQuitsOtherWorkspacesTests.swift
@@ -1,0 +1,131 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// Installing an update while other workspaces are open.
+///
+/// Every workspace runs from the same copy in `/Applications`, so the install swaps the
+/// bundle out from under any other open window — which is then executing pages that are
+/// no longer on disk. So Install asks first, and both answers arrive as
+/// `.updateInstallConfirmed`.
+@Suite
+struct UpdateQuitsOtherWorkspacesTests {
+  private func workspace(_ slug: String) -> Workspace {
+    Workspace(slug: slug, url: URL(fileURLWithPath: "/tmp/.graphcode-\(slug)"))
+  }
+
+  private func offeredState() -> AppFeature.State {
+    var state = AppFeature.State()
+    state.offeredUpdate = AvailableUpdate(
+      version: "0.1.99", currentVersion: "0.1.46",
+      downloadURL: URL(string: "https://example.invalid/graphcode.dmg")!,
+      releaseNotesURL: URL(string: "https://example.invalid/notes")!)
+    return state
+  }
+
+  @Test
+  @MainActor
+  func installAsksAboutOtherOpenWorkspacesBeforeSwappingTheBundle() async {
+    let others = [workspace("work"), workspace("oss")]
+    let store = TestStore(initialState: offeredState()) {
+      AppFeature()
+    } withDependencies: {
+      $0.workspaceClient.otherOpen = { others }
+    }
+
+    // No install starts: `updateInstallClient` is left unimplemented, so a download that
+    // began here would fail the test by calling it.
+    await store.send(.updateInstallTapped) {
+      $0.workspaces.othersOpenForUpdate = others
+      $0.availableUpdate = nil
+    }
+    #expect(store.state.updateInstallProgress == nil)
+  }
+
+  @Test
+  @MainActor
+  func nothingIsAskedWhenThisIsTheOnlyWindow() async {
+    let store = TestStore(initialState: offeredState()) {
+      AppFeature()
+    } withDependencies: {
+      $0.workspaceClient.otherOpen = { [] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.updateInstallTapped)
+    await store.receive(\.updateInstallConfirmed)
+    #expect(store.state.workspaces.othersOpenForUpdate == nil)
+  }
+
+  @Test
+  @MainActor
+  func quittingThemWaitsForThemToGoBeforeTheInstallRuns() async {
+    let others = [workspace("work")]
+    let quit = LockIsolated<[Workspace]>([])
+    let store = TestStore(initialState: offeredState()) {
+      AppFeature()
+    } withDependencies: {
+      $0.workspaceClient.otherOpen = { others }
+      $0.workspaceClient.quit = { asked in quit.withValue { $0 = asked } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.updateInstallTapped)
+    await store.send(.workspaces(.quitOthersForUpdate))
+    // The install only starts once `quit` has returned — that ordering is the whole
+    // point, since the swap must not land under a live window.
+    await store.receive(\.updateInstallConfirmed)
+    #expect(quit.value == others)
+    #expect(store.state.workspaces.othersOpenForUpdate == nil)
+  }
+
+  @Test
+  @MainActor
+  func installAnywayProceedsWithoutQuittingAnything() async {
+    let others = [workspace("work")]
+    let store = TestStore(initialState: offeredState()) {
+      AppFeature()
+    } withDependencies: {
+      $0.workspaceClient.otherOpen = { others }
+      $0.workspaceClient.quit = { _ in Issue.record("nothing should be asked to quit") }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.updateInstallTapped)
+    await store.send(.workspaces(.updateWithoutQuittingOthers))
+    await store.receive(\.updateInstallConfirmed)
+    #expect(store.state.workspaces.othersOpenForUpdate == nil)
+  }
+
+  @Test
+  @MainActor
+  func cancellingLeavesEverythingAsItWas() async {
+    let store = TestStore(initialState: offeredState()) {
+      AppFeature()
+    } withDependencies: {
+      $0.workspaceClient.otherOpen = { [self.workspace("work")] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.updateInstallTapped)
+    await store.send(.workspaces(.othersForUpdateDismissed))
+    #expect(store.state.workspaces.othersOpenForUpdate == nil)
+    #expect(store.state.updateInstallProgress == nil)
+    // The offer survives a cancel — the update is still there to install later.
+    #expect(store.state.offeredUpdate != nil)
+  }
+
+  @Test
+  func theWindowsAreNamedRatherThanCounted() {
+    // "2 other workspaces" does not answer the question someone actually has, which is
+    // *which* windows are about to be quit.
+    #expect(UpdateDialogs.list([workspace("work")]) == "work")
+    #expect(UpdateDialogs.list([workspace("work"), workspace("oss")]) == "work and oss")
+    #expect(
+      UpdateDialogs.list([workspace("work"), workspace("oss"), workspace("side")])
+        == "work, oss and side")
+  }
+}


### PR DESCRIPTION
Follow-up to #159. Every workspace runs from the same copy in `/Applications`, so installing an update replaces the bundle underneath every other open window — which is then executing pages that are no longer on disk. Until now the install just did it.

## What Install does now

> **Other workspaces are open**
> *work and oss are open in other windows. Every workspace runs the same app, so installing replaces it for all of them. Quitting them first is the clean way — their loops keep running either way, since the daemon holds the sessions, not the window.*
> **[ Quit Them & Install ]  [ Install Anyway ]  [ Cancel ]**

| Decision | Why |
|---|---|
| Asked **before** the swap, not at relaunch | The hazard is a live process whose bundle has been replaced, not staleness |
| `quit` **waits** for them to terminate, capped at 10s | The swap must not land under a live window; but one window refusing to quit cannot strand an update the human already consented to |
| Windows are **named**, not counted | "2 other workspaces" doesn't answer the question you have, which is *which* ones close |
| Both answers arrive as `.updateInstallConfirmed` | One install path instead of two copies of it |

Loops are unaffected by any of the three answers — `zmx` holds the sessions, not the window.

## Tests

Six new, covering: the ask happens and no install starts; nothing is asked when this is the only window; Quit Them waits for `quit` to return before the install runs; Install Anyway never calls `quit`; Cancel leaves the offer intact; and the names are listed rather than counted.

`UpdateInstallTests.installDownloadsWithProgressAndOffersTheRelaunch` now receives `.updateInstallConfirmed` before checking progress — the install starting on the tap was precisely the invariant this changes, so the test documents the hop rather than hiding it.

**997 tests passing**, `swift format lint --strict` clean.

## Note

`AppFeature`'s body sits at 346 of swiftlint's 350-line ceiling, so the new state lives in `WorkspacesState` and the three dialog answers in the nested `Workspaces` action enum. Only `updateInstallConfirmed` and the `workspaceClient` dependency were added to the type itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)