### PR TITLE
feat: rename a workspace

### DIFF
--- a/GraphcodeKit/Sources/Workspace.swift
+++ b/GraphcodeKit/Sources/Workspace.swift
@@ -233,32 +233,75 @@ extension Workspace {
     return contents
   }
 
-  /// Why a workspace cannot be deleted right now.
-  public enum DeletionRefusal: Error, Equatable, LocalizedError {
-    case isDefault
-    case isCurrent
-    case isOpen(pid: Int32)
+  /// What is being asked of a workspace, so a refusal can say so in words.
+  public enum Change: Equatable, Sendable {
+    case rename
+    case delete
+
+    var verb: String {
+      switch self {
+      case .rename: return "renamed"
+      case .delete: return "deleted"
+      }
+    }
+  }
+
+  /// Why a workspace cannot be changed right now.
+  public enum Refusal: Error, Equatable, LocalizedError {
+    case isDefault(Change)
+    case isCurrent(Change)
+    case isOpen(pid: Int32, Change)
 
     public var errorDescription: String? {
       switch self {
-      case .isDefault:
-        return "The default workspace can't be deleted."
-      case .isCurrent:
-        return "This is the workspace you're in. Switch to another one first."
-      case .isOpen(let pid):
+      case .isDefault(let change):
+        return "The default workspace can't be \(change.verb)."
+      case .isCurrent(let change):
+        return
+          "This is the workspace you're in — it can't be \(change.verb) from inside. "
+          + "Switch to another one first."
+      case .isOpen(let pid, _):
         return "That workspace is open in another window (pid \(pid)). Quit it first."
       }
     }
   }
 
-  /// The three questions asked before anything is torn down. Deleting the workspace a
-  /// window is *using* would pull its graphs out from under a live app; deleting one
-  /// another instance has open is the same thing, one process away.
-  public func deletionRefusal(current: Workspace = .current) -> DeletionRefusal? {
-    if isDefault { return .isDefault }
-    if id == current.id { return .isCurrent }
-    if let pid = WorkspaceLock.holder(of: self) { return .isOpen(pid: pid) }
+  /// The three questions asked before a workspace is touched. Both changes move or
+  /// remove the directory a running app resolves every path through, so doing either to
+  /// the workspace a window is *using* pulls its graphs out from under it — and doing it
+  /// to one another instance has open is the same thing, one process away.
+  public func refusal(for change: Change, current: Workspace = .current) -> Refusal? {
+    if isDefault { return .isDefault(change) }
+    if id == current.id { return .isCurrent(change) }
+    if let pid = WorkspaceLock.holder(of: self) { return .isOpen(pid: pid, change) }
     return nil
+  }
+
+  /// Moves this workspace to a new name: its directory, and with it every graph, layout
+  /// and session id inside.
+  ///
+  /// The old launch agent goes first — its label carries the old slug, and an agent left
+  /// loaded over a directory that has moved is `KeepAlive`, so launchd restarts a daemon
+  /// pointed at a path that is no longer there. Nothing installs the new one here: the
+  /// instance that next opens the workspace writes its agent and starts its daemon, the
+  /// same first-open path a freshly created workspace takes.
+  ///
+  /// What deliberately does *not* happen is any rewriting inside the directory. Graphs
+  /// key projects by the project's own path, layouts key surfaces by node id, and the
+  /// helpers in `bin/` are copies — none of it names the workspace. The exception worth
+  /// knowing about is a `zmx` session that was already running: its environment still
+  /// carries the old `GRAPHCODE_SUPPORT_DIR`, so the `graphcode` CLI inside it cannot
+  /// reach the graph until that session is restarted. The session itself survives.
+  @discardableResult
+  public func renamed(
+    to name: String, home: URL = URL(fileURLWithPath: NSHomeDirectory()),
+    fileManager: FileManager = .default
+  ) throws -> Workspace {
+    let destination = try Workspace.validate(name: name, home: home, fileManager: fileManager)
+      .get()
+    DaemonBootstrap.removeLaunchAgent(for: self)
+    try fileManager.moveItem(at: url, to: destination.url)
+    return destination
   }
 
   /// What is wrong with a typed name, or `nil` when nothing is — the form the sheet wants

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ graphs and its own `graphcoded`. Nothing is shared between them — a loop in on
 other — and the switcher at the foot of the sidebar says which one you are in. The CLI follows the
 same variable the app sets: `GRAPHCODE_SUPPORT_DIR=~/.graphcode-work graphcode status <project>`.
 
-**⌥⌘1 … ⌥⌘9** switch between them in menu order and **⌥⌘N** makes a new one. **Delete Workspace**,
-in the same menu, ends that workspace's terminal sessions, stops its daemon, and moves its folder to
-the Trash — the default workspace and whichever one you are in are never offered.
+**⌥⌘1 … ⌥⌘9** switch between them in menu order and **⌥⌘N** makes a new one. **Rename Workspace**
+moves its folder, taking its projects and loops with it; **Delete Workspace** ends that workspace's
+terminal sessions, stops its daemon, and moves its folder to the Trash. Neither is offered for the
+default workspace or for whichever one you are in.
 
 Not to be confused with a loop's **terminal workspace**, which is the tabs and splits inside one
 loop. A workspace holds projects; a terminal workspace holds panes.

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -46,9 +46,11 @@ and splits *inside* a loop, see [Terminals](#terminals).)
 | ⌥⌘1 … ⌥⌘9 | Switch to that workspace, in the order the menu lists them (⌥⌘1 is the default one). Raises its window, or opens it if it isn't running |
 | ⌥⌘N | New workspace — name it and it opens straight away |
 
-Deleting one is in the same menu, under **Delete Workspace**. It ends that workspace's
-terminal sessions, stops its daemon, and moves its folder to the Trash — a workspace that
-is currently open somewhere can't be deleted until that window is closed.
+**Rename Workspace** and **Delete Workspace** are in the same menu. A rename moves the
+workspace's folder and everything in it; a delete ends that workspace's terminal sessions,
+stops its daemon, and moves its folder to the Trash. Neither is offered for the default
+workspace or for the one you are in, and a workspace open in another window has to be
+closed first.
 
 ## Terminals
 

--- a/graphcode/Sources/Clients/WorkspaceClient.swift
+++ b/graphcode/Sources/Clients/WorkspaceClient.swift
@@ -21,9 +21,13 @@ struct WorkspaceClient: Sendable {
   /// to prevent.
   var open: @Sendable (Workspace) -> Void
   /// Tears a workspace down: its daemon out of launchd, its `zmx` sessions ended, its
-  /// directory to the Trash. Throws `Workspace.DeletionRefusal` when it is not a
-  /// workspace this may touch.
+  /// directory to the Trash. Throws `Workspace.Refusal` when it is not a workspace this
+  /// may touch.
   var delete: @Sendable (Workspace) throws -> Void
+  /// Moves a workspace to a new name, returning it. Same three refusals as `delete`, and
+  /// for the same reason: both change the directory a running app resolves its paths
+  /// through.
+  var rename: @Sendable (Workspace, String) throws -> Workspace
   /// Workspaces open in *other* instances right now. Asked before an update swaps the
   /// bundle, since every workspace runs from the same copy in /Applications.
   var otherOpen: @Sendable () -> [Workspace]
@@ -47,7 +51,7 @@ extension WorkspaceClient: DependencyKey {
         at: Bundle.main.bundleURL, configuration: configuration, completionHandler: nil)
     },
     delete: { workspace in
-      if let refusal = workspace.deletionRefusal() { throw refusal }
+      if let refusal = workspace.refusal(for: .delete) { throw refusal }
 
       // Order matters. The agent is `KeepAlive`, so a daemon still loaded over a deleted
       // directory is restarted by launchd and recreates it — the workspace comes back
@@ -65,6 +69,10 @@ extension WorkspaceClient: DependencyKey {
       // copy of it. Recoverable for as long as they haven't emptied the Trash.
       var trashed: NSURL?
       try FileManager.default.trashItem(at: workspace.url, resultingItemURL: &trashed)
+    },
+    rename: { workspace, name in
+      if let refusal = workspace.refusal(for: .rename) { throw refusal }
+      return try workspace.renamed(to: name)
     },
     otherOpen: {
       let current = Workspace.current
@@ -92,6 +100,9 @@ extension WorkspaceClient: DependencyKey {
     create: { Workspace(slug: $0, url: URL(fileURLWithPath: "/tmp/\($0)")) },
     open: { _ in },
     delete: { _ in },
+    rename: { workspace, name in
+      Workspace(slug: name, url: workspace.url.deletingLastPathComponent())
+    },
     otherOpen: { [] },
     quit: { _ in })
 

--- a/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
@@ -23,12 +23,17 @@ extension AppFeature {
     /// The workspace a Delete confirmation is up for, with what it would take with it —
     /// counted when the dialog opens, since the numbers come off disk.
     var pendingDeletion: PendingDeletion?
+    /// The workspace being renamed, and the name being typed for it. `nil` means the
+    /// sheet is closed.
+    var renaming: Workspace?
+    var renameDraft = ""
     /// The other workspaces found open when Install was pressed, held while the app asks
     /// what to do about them. `nil` means nothing is being asked.
     var othersOpenForUpdate: [Workspace]?
-    /// A refusal or a failure from the last deletion attempt, shown as an alert. Distinct
-    /// from `problem`, which is about a name being typed.
-    var deletionFailure: String?
+    /// A refusal or a failure from the last rename or deletion, shown as an alert. One
+    /// channel for both: the refusal's own sentence already names which was refused.
+    /// Distinct from `problem`, which is about a name being typed.
+    var changeFailure: String?
 
     /// Whether this instance is the one that offers and installs app updates.
     ///
@@ -72,10 +77,14 @@ extension AppFeature {
     case createConfirmed
     /// Raise (or launch) the instance that owns this workspace.
     case switchRequested(Workspace)
+    case renameRequested(Workspace)
+    case renameDraftChanged(String)
+    case renameConfirmed
+    case renameCancelled
     case deleteRequested(Workspace)
     case deleteConfirmed
     case deleteCancelled
-    case deletionFailureDismissed
+    case changeFailureDismissed
     /// The three answers to "other workspaces are open" — see `UpdateDialogs`.
     case quitOthersForUpdate
     case updateWithoutQuittingOthers
@@ -130,9 +139,44 @@ struct AppWorkspacesReducer: Reducer {
         guard workspace.id != state.workspaces.current.id else { return .none }
         return .run { [open = workspaces.open] _ in open(workspace) }
 
+      case .workspaces(.renameRequested(let workspace)):
+        if let refusal = workspace.refusal(for: .rename, current: state.workspaces.current) {
+          state.workspaces.changeFailure = refusal.localizedDescription
+          return .none
+        }
+        state.workspaces.renaming = workspace
+        // Prefilled with the current name: renaming is usually a correction, not a
+        // fresh start, and an empty field would make you retype what you had.
+        state.workspaces.renameDraft = workspace.name
+        state.workspaces.problem = nil
+        return .none
+
+      case .workspaces(.renameDraftChanged(let name)):
+        state.workspaces.renameDraft = name
+        state.workspaces.problem =
+          name.isEmpty ? nil : Workspace.problem(name: name)?.localizedDescription
+        return .none
+
+      case .workspaces(.renameCancelled):
+        state.workspaces.renaming = nil
+        state.workspaces.problem = nil
+        return .none
+
+      case .workspaces(.renameConfirmed):
+        guard let workspace = state.workspaces.renaming else { return .none }
+        do {
+          _ = try workspaces.rename(workspace, state.workspaces.renameDraft)
+          state.workspaces.renaming = nil
+          state.workspaces.renameDraft = ""
+          state.workspaces.known = workspaces.list()
+        } catch {
+          state.workspaces.problem = error.localizedDescription
+        }
+        return .none
+
       case .workspaces(.deleteRequested(let workspace)):
-        if let refusal = workspace.deletionRefusal(current: state.workspaces.current) {
-          state.workspaces.deletionFailure = refusal.localizedDescription
+        if let refusal = workspace.refusal(for: .delete, current: state.workspaces.current) {
+          state.workspaces.changeFailure = refusal.localizedDescription
           return .none
         }
         state.workspaces.pendingDeletion = AppFeature.PendingDeletion(
@@ -145,7 +189,7 @@ struct AppWorkspacesReducer: Reducer {
         do {
           try workspaces.delete(pending.workspace)
         } catch {
-          state.workspaces.deletionFailure = error.localizedDescription
+          state.workspaces.changeFailure = error.localizedDescription
         }
         state.workspaces.known = workspaces.list()
         return .none
@@ -154,8 +198,8 @@ struct AppWorkspacesReducer: Reducer {
         state.workspaces.pendingDeletion = nil
         return .none
 
-      case .workspaces(.deletionFailureDismissed):
-        state.workspaces.deletionFailure = nil
+      case .workspaces(.changeFailureDismissed):
+        state.workspaces.changeFailure = nil
         return .none
 
       case .workspaces(.quitOthersForUpdate):

--- a/graphcode/Sources/Features/App/AppView.swift
+++ b/graphcode/Sources/Features/App/AppView.swift
@@ -162,6 +162,13 @@ struct AppView: View {
     ) {
       NewWorkspaceFormView(store: store)
     }
+    .sheet(
+      isPresented: Binding(
+        get: { store.workspaces.renaming != nil },
+        set: { if !$0 { store.send(.workspaces(.renameCancelled)) } })
+    ) {
+      RenameWorkspaceFormView(store: store)
+    }
     // Another instance may have created or deleted one since this window last looked,
     // and the File menu is built from this list — so it is refreshed whenever the window
     // comes forward rather than only at launch.
@@ -188,15 +195,15 @@ struct AppView: View {
           + "the folder moves to the Trash, where it stays recoverable.")
     }
     .alert(
-      "That workspace can't be deleted",
+      "That workspace can't be changed",
       isPresented: Binding(
-        get: { store.workspaces.deletionFailure != nil },
-        set: { if !$0 { store.send(.workspaces(.deletionFailureDismissed)) } }
+        get: { store.workspaces.changeFailure != nil },
+        set: { if !$0 { store.send(.workspaces(.changeFailureDismissed)) } }
       )
     ) {
-      Button("OK", role: .cancel) { store.send(.workspaces(.deletionFailureDismissed)) }
+      Button("OK", role: .cancel) { store.send(.workspaces(.changeFailureDismissed)) }
     } message: {
-      Text(store.workspaces.deletionFailure ?? "")
+      Text(store.workspaces.changeFailure ?? "")
     }
     .confirmationDialog(
       // Naming the loop matters here in a way it didn't on the canvas: from the sidebar

--- a/graphcode/Sources/Features/Workspaces/RenameWorkspaceFormView.swift
+++ b/graphcode/Sources/Features/Workspaces/RenameWorkspaceFormView.swift
@@ -1,0 +1,80 @@
+import ComposableArchitecture
+import GraphcodeKit
+import SwiftUI
+
+/// Renaming a workspace — which means moving its directory, since that directory *is* the
+/// workspace. The sheet shows where it lands for the same reason the New Workspace sheet
+/// does: that path is what a `GRAPHCODE_SUPPORT_DIR` on the CLI points at.
+struct RenameWorkspaceFormView: View {
+  @Bindable var store: StoreOf<AppFeature>
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Text("Rename Workspace").font(.headline)
+
+      Text(
+        """
+        Its projects, loops and terminal layouts move with it. A session already running \
+        in this workspace keeps running, but can't reach the graph again until it is \
+        restarted — it still holds the old directory.
+        """
+      )
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .fixedSize(horizontal: false, vertical: true)
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      Form {
+        TextField("Name", text: name, prompt: Text(store.workspaces.renaming?.name ?? ""))
+          .autocorrectionDisabled()
+          .onSubmit { if canRename { store.send(.workspaces(.renameConfirmed)) } }
+      }
+      .formStyle(.columns)
+      .fixedSize(horizontal: false, vertical: true)
+
+      Group {
+        if let problem = store.workspaces.problem {
+          Text(problem).foregroundStyle(.red)
+        } else if !directoryPath.isEmpty {
+          Text(directoryPath).foregroundStyle(.secondary)
+        }
+      }
+      .font(.caption)
+      .lineLimit(1)
+      .truncationMode(.middle)
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      HStack {
+        Button("Cancel") { store.send(.workspaces(.renameCancelled)) }
+          .keyboardShortcut(.cancelAction)
+        Spacer()
+        Button("Rename") { store.send(.workspaces(.renameConfirmed)) }
+          .keyboardShortcut(.defaultAction)
+          .disabled(!canRename)
+      }
+    }
+    .padding(24)
+    .frame(width: 420)
+  }
+
+  private var name: Binding<String> {
+    Binding(
+      get: { store.workspaces.renameDraft },
+      set: { store.send(.workspaces(.renameDraftChanged($0))) })
+  }
+
+  /// The unchanged name is not a rename — and it would fail validation as "already
+  /// exists", which reads as a bug rather than as nothing to do.
+  private var canRename: Bool {
+    guard let renaming = store.workspaces.renaming else { return false }
+    let draft = store.workspaces.renameDraft
+    return store.workspaces.problem == nil && !draft.isEmpty
+      && Workspace.slug(from: draft) != renaming.slug
+  }
+
+  private var directoryPath: String {
+    guard case .success(let workspace) = Workspace.validate(name: store.workspaces.renameDraft)
+    else { return "" }
+    return (workspace.url.path as NSString).abbreviatingWithTildeInPath
+  }
+}

--- a/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
@@ -34,9 +34,14 @@ struct WorkspaceMenuItems: View {
     Divider()
     Button("New Workspace…") { store.send(.workspaces(.newRequested)) }
       .modifier(NewWorkspaceShortcut(isEnabled: showsShortcuts))
-    if !deletable.isEmpty {
+    if !changeable.isEmpty {
+      Menu("Rename Workspace") {
+        ForEach(changeable) { workspace in
+          Button("\(workspace.name)…") { store.send(.workspaces(.renameRequested(workspace))) }
+        }
+      }
       Menu("Delete Workspace") {
-        ForEach(deletable) { workspace in
+        ForEach(changeable) { workspace in
           Button("\(workspace.name)…") { store.send(.workspaces(.deleteRequested(workspace))) }
         }
       }
@@ -45,7 +50,7 @@ struct WorkspaceMenuItems: View {
 
   /// Never the default, and never the one this window is using — the two `Workspace`
   /// refuses anyway. Offering them and then explaining why not is worse than not offering.
-  private var deletable: [Workspace] {
+  private var changeable: [Workspace] {
     store.workspaces.known.filter { !$0.isDefault && $0.id != store.workspaces.current.id }
   }
 }

--- a/graphcode/Tests/WorkspaceTests.swift
+++ b/graphcode/Tests/WorkspaceTests.swift
@@ -154,6 +154,69 @@ struct WorkspaceTests {
   }
 
   @Test
+  func renamingMovesTheDirectoryAndRetiresTheOldAgent() throws {
+    // The directory *is* the workspace, so a rename is a move — the graphs, layouts and
+    // session ids inside go with it untouched, because none of them names the workspace.
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    let workspace = try Workspace.create(name: "work", home: home)
+    let projects = workspace.url.appendingPathComponent("projects", isDirectory: true)
+    try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+    try Data("{}".utf8).write(to: projects.appendingPathComponent("_tmp_project.json"))
+
+    let renamed = try workspace.renamed(to: "Client Work", home: home)
+
+    #expect(renamed.slug == "client-work")
+    #expect(renamed.daemonLabel == "dev.graphcode.graphcoded.client-work")
+    #expect(!FileManager.default.fileExists(atPath: workspace.url.path))
+    #expect(
+      FileManager.default.fileExists(
+        atPath: renamed.url.appendingPathComponent("projects/_tmp_project.json").path))
+  }
+
+  @Test
+  func aRenameIsRefusedByTheSameNameRulesAsACreate() throws {
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    let work = try Workspace.create(name: "work", home: home)
+    _ = try Workspace.create(name: "oss", home: home)
+
+    // Onto a name already in use — which would otherwise be a move onto a live directory.
+    #expect(throws: Workspace.NameProblem.taken("oss")) {
+      try work.renamed(to: "OSS", home: home)
+    }
+    #expect(throws: Workspace.NameProblem.empty) {
+      try work.renamed(to: "///", home: home)
+    }
+    // Still where it was, under its own name.
+    #expect(FileManager.default.fileExists(atPath: work.url.path))
+  }
+
+  @Test
+  func bothChangesAreRefusedForTheDefaultTheCurrentAndAnOpenWorkspace() {
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let work = Workspace(slug: "work", url: Workspace.url(forSlug: "work", home: home))
+    let other = Workspace(slug: "oss", url: Workspace.url(forSlug: "oss", home: home))
+
+    // The refusal names what was asked, so one alert serves both.
+    #expect(
+      Workspace.default.refusal(for: .rename, current: work) == .isDefault(.rename))
+    #expect(
+      Workspace.default.refusal(for: .rename, current: work)?.errorDescription
+        == "The default workspace can't be renamed.")
+    #expect(
+      Workspace.default.refusal(for: .delete, current: work)?.errorDescription
+        == "The default workspace can't be deleted.")
+    // Renaming the workspace this window is using would move the directory it resolves
+    // every path through, out from under itself.
+    #expect(work.refusal(for: .rename, current: work) == .isCurrent(.rename))
+    #expect(work.refusal(for: .rename, current: other) == nil)
+  }
+
+  @Test
   func deletionIsRefusedForTheDefaultTheCurrentAndAnOpenWorkspace() {
     let home = makeHome()
     defer { try? FileManager.default.removeItem(at: home) }
@@ -162,17 +225,17 @@ struct WorkspaceTests {
     try? FileManager.default.createDirectory(at: work.url, withIntermediateDirectories: true)
 
     // The default workspace is every existing install's whole state.
-    #expect(Workspace.default.deletionRefusal(current: work) == .isDefault)
+    #expect(Workspace.default.refusal(for: .delete, current: work) == .isDefault(.delete))
     // Deleting the workspace this window is using would pull its graphs out from under a
     // live app.
-    #expect(work.deletionRefusal(current: work) == .isCurrent)
-    #expect(work.deletionRefusal(current: other) == nil)
+    #expect(work.refusal(for: .delete, current: work) == .isCurrent(.delete))
+    #expect(work.refusal(for: .delete, current: other) == nil)
 
     // And the same thing one process away: another instance has it open.
     WorkspaceLock.claim(work, pid: getpid())
-    #expect(work.deletionRefusal(current: other) == .isOpen(pid: getpid()))
+    #expect(work.refusal(for: .delete, current: other) == .isOpen(pid: getpid(), .delete))
     WorkspaceLock.release(work, pid: getpid())
-    #expect(work.deletionRefusal(current: other) == nil)
+    #expect(work.refusal(for: .delete, current: other) == nil)
   }
 
   @Test


### PR DESCRIPTION
**File ▸ Workspace ▸ Rename Workspace ▸ *name*…** (also in the sidebar chip menu) opens a sheet prefilled with the current name, showing the directory the new name resolves to.

## What a rename actually is

A workspace *is* its directory, so this is a move:

1. Retire the old launch agent — its label carries the old slug, and an agent left loaded over a directory that has moved is `KeepAlive`, so launchd would restart a daemon pointed at a path that no longer exists.
2. Move the directory.
3. The instance that next opens the workspace writes the new agent and starts its daemon — the same first-open path a freshly created workspace takes.

Nothing inside is rewritten, because nothing in there names the workspace: graphs key projects by the project's own path, layouts key surfaces by node id, `bin/` holds copies.

⚠️ Stated in the sheet itself: a `zmx` session that was already running keeps running, but still carries the old `GRAPHCODE_SUPPORT_DIR`, so the `graphcode` CLI inside it can't reach the graph until that session restarts.

## Rules

| Case | Behaviour |
|---|---|
| **Default workspace** | Never offered — it *is* `~/.graphcode` |
| The workspace you're in | Refused: renaming moves the directory it resolves every path through, out from under itself |
| Open in another window | Refused, naming the pid |
| Name taken / invalid / socket path too long | Same validator as create, shown while typing |
| Unchanged name | Rename stays disabled — nothing to do, and letting it through would fail as "already exists", which reads as a bug |

`DeletionRefusal` becomes `Refusal` carrying *what was asked*, so one alert serves both verbs instead of telling someone who tried to rename that it "can't be deleted".

## Tests

`renamingMovesTheDirectoryAndRetiresTheOldAgent` (a file written inside survives the move), `aRenameIsRefusedByTheSameNameRulesAsACreate` (taken and empty names, directory untouched afterwards), and `bothChangesAreRefusedForTheDefaultTheCurrentAndAnOpenWorkspace` (including that the two refusals produce the right sentence for each verb).

**1000 tests passing**, `swift format lint --strict` clean. README and the shortcuts page updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)