### PR TITLE
feat: start a chain from the entry dot, and the Graph view's full loop menu

### DIFF
--- a/graphcode/Sources/Features/Canvas/CanvasEntryHandle.swift
+++ b/graphcode/Sources/Features/Canvas/CanvasEntryHandle.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// The `+` a lane's origin dot reveals when the pointer comes near it — "start another
+/// chain in this folder". The card handle's twin (`CanvasConnectorHandle`), for the one
+/// place on the canvas that isn't a card.
+///
+/// The dot itself is untouched: it stays the same marker it always was, and the handle
+/// floats below it only while the pointer is close. A hover target much larger than the
+/// 12pt dot, because "close to the entry" is what a hand aims at — hitting a dot that
+/// size exactly is a demand, not an affordance.
+struct CanvasEntryHandle: View {
+  let help: String
+  let action: () -> Void
+
+  @State private var isNear = false
+  @State private var isHandleHovered = false
+
+  /// Below rather than beside: the connectors to this lane's entry loops all leave the
+  /// dot to the right, and a handle sitting in that fan reads as a point on a line.
+  private static let dropBelow: CGFloat = 20
+
+  var body: some View {
+    ZStack {
+      Color.clear
+        .frame(width: 60, height: 56)
+        .contentShape(Rectangle())
+        .onHover { isNear = $0 }
+      if isNear || isHandleHovered {
+        CanvasConnectorHandle()
+          .offset(y: Self.dropBelow)
+          .onHover { isHandleHovered = $0 }
+          .onTapGesture(perform: action)
+          .help(help)
+      }
+    }
+  }
+}

--- a/graphcode/Sources/Features/Overview/GraphOverview.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverview.swift
@@ -115,7 +115,7 @@ struct GraphOverview: Equatable {
 
   init() {}
 
-  init(graphs: [LoopGraph]) {
+  init(graphs: [LoopGraph], declaredEntries: [String: Set<UUID>] = [:]) {
     // The global graph's lane goes first — it's the one that dispatches into the others,
     // so reading top-to-bottom follows the direction work actually travels. Stable
     // partition rather than a sort, so the remaining folders keep sidebar order. A global
@@ -127,7 +127,8 @@ struct GraphOverview: Equatable {
 
     var laneTop = Metrics.laneTop
     for graph in lanes {
-      let lane = Self.layOutLane(graph, top: laneTop)
+      let lane = Self.layOutLane(
+        graph, top: laneTop, declaredEntries: declaredEntries[graph.project.path] ?? [])
       folders.append(lane.folder)
       loops.append(contentsOf: lane.loops)
       links.append(contentsOf: lane.links)
@@ -152,9 +153,11 @@ struct GraphOverview: Equatable {
     let links: [Link]
   }
 
-  private static func layOutLane(_ graph: LoopGraph, top: CGFloat) -> Lane {
+  private static func layOutLane(
+    _ graph: LoopGraph, top: CGFloat, declaredEntries: Set<UUID> = []
+  ) -> Lane {
     let path = graph.project.path
-    let roles = CardEntryRole.roles(in: graph)
+    let roles = CardEntryRole.roles(in: graph, declaredEntries: declaredEntries)
     var loops: [Loop] = []
     var links: [Link] = []
 

--- a/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
@@ -26,6 +26,25 @@ extension GraphOverviewView {
     }
   }
 
+  /// A `+` at each lane's origin, revealed when the pointer comes near it: a top-level
+  /// loop in *that* folder, which the origin then draws a line to like any other
+  /// beginning. The same handle the folder's own canvas puts on its origin dot.
+  ///
+  /// The one create the Graph view was missing. A card's `+` continues a chain and the
+  /// top-right New Loop lands in the global graph, so starting a *new* chain in a
+  /// particular folder meant crossing to that folder's canvas first.
+  /// Only on lanes that *have* an origin dot: `CanvasBandView` draws one exactly when a
+  /// lane has entry ports, and a `+` floating where no dot is reads as a stray control.
+  /// A lane whose loops are all in a cycle keeps the top-right New Loop.
+  func entryHandleLayer(_ overview: GraphOverview) -> some View {
+    ForEach(overview.tetheredFolders) { folder in
+      CanvasEntryHandle(help: "New loop in \(folder.name)") {
+        store.send(.projects(.element(id: folder.path, action: .addEntryLoopTapped)))
+      }
+      .position(folder.originPosition)
+    }
+  }
+
   @ViewBuilder
   func startNodeLayer(_ overview: GraphOverview) -> some View {
     if let center = overview.startNode {
@@ -171,18 +190,67 @@ extension GraphOverviewView {
     )
     .contentShape(Rectangle())
     .onTapGesture { open(loop) }
-    .contextMenu {
-      Button("Open Terminal") { open(loop) }
-      Button("Reveal in \(folderName(loop.projectPath))") {
-        store.send(.projectHeaderTapped(loop.projectPath))
-      }
-      if !node.isResolved {
-        Divider()
-        Button("Stop Loop", role: .destructive) {
-          store.send(.stopNodeTapped(projectPath: loop.projectPath, nodeID: node.id))
-        }
+    .contextMenu { loopMenu(loop) }
+  }
+
+  /// The same verbs the sidebar offers on a loop row, in the same order — a loop should
+  /// answer to the same menu wherever you right-click it, and until now this one stopped
+  /// at Open, Reveal and Stop.
+  ///
+  /// All of them work from here without switching folders first. Export and Import run
+  /// their own panels straight from the reducer; Rename and Delete present from
+  /// `AppView`, which hosts those two dialogs for the whole window; and the creation
+  /// sheet has a host per folder mounted on this view already (`nodeFormHosts`), which is
+  /// what the sidebar has to select a project to get.
+  ///
+  /// What stays out is what the overview cannot show you the consequences of: rewiring,
+  /// and drilling into a composite's sub-graph. Reveal is the answer to both.
+  @ViewBuilder
+  private func loopMenu(_ loop: GraphOverview.Loop) -> some View {
+    let node = loop.node
+    Button("Open Terminal") { open(loop) }
+    if !node.isResolved {
+      Button("New Child Loop…") { send(.newChildLoopTapped(node.id), to: loop.projectPath) }
+    }
+    if node.loopType == .composite {
+      Button("Pilot Once…") { send(.pilotCompositeTapped(node.id), to: loop.projectPath) }
+      Button("Arm Schedule") { send(.armCompositeTapped(node.id), to: loop.projectPath) }
+        .disabled(!node.pilotState.canArm)
+    }
+    Button("Rename…") { send(.renameNodeRequested(node.id), to: loop.projectPath) }
+    if !node.isResolved {
+      Button("Stop Loop") {
+        store.send(.stopNodeTapped(projectPath: loop.projectPath, nodeID: node.id))
       }
     }
+
+    Divider()
+
+    Button("Reveal in \(folderName(loop.projectPath))") {
+      store.send(.projectHeaderTapped(loop.projectPath))
+    }
+
+    Divider()
+
+    // Behind the experiments switch, exactly as on a folder's canvas and in the sidebar:
+    // a right-click verb that writes files and splices loops into graphs is one a person
+    // should choose, not find. Read inline like the folder canvas's menu does — the
+    // sidebar's outline is the one place that cannot (see `AppSidebarView.sharesLoops`).
+    if SettingsModel.shared.settings.sharesLoops {
+      Button("Export Loop…") { send(.exportNodeRequested(node.id), to: loop.projectPath) }
+      Button("Import Loops Here…") {
+        send(.importLoopsRequested(asChildOf: node.id), to: loop.projectPath)
+      }
+      Divider()
+    }
+
+    Button("Delete Loop…", role: .destructive) {
+      send(.deleteNodeRequested(node.id), to: loop.projectPath)
+    }
+  }
+
+  private func send(_ action: ProjectFeature.Action, to projectPath: String) {
+    store.send(.projects(.element(id: projectPath, action: action)))
   }
 
 }

--- a/graphcode/Sources/Features/Overview/GraphOverviewView.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverviewView.swift
@@ -75,7 +75,10 @@ struct GraphOverviewView: View {
   /// directory for it to belong to.
   var body: some View {
     let derived = Derived(
-      overview: GraphOverview(graphs: store.projects.map(\.graph)),
+      overview: GraphOverview(
+        graphs: store.projects.map(\.graph),
+        declaredEntries: Dictionary(
+          uniqueKeysWithValues: store.projects.map { ($0.id, $0.declaredEntryIDs) })),
       attentionItems: store.attentionItems)
 
     return canvas(derived)
@@ -169,6 +172,9 @@ struct GraphOverviewView: View {
         startNodeLayer(overview)
         linksLayer(overview)
         loopsLayer(overview, reasons: derived.attentionReasons, now: now)
+        // Above the cards and the links, since the handle it reveals hangs below the
+        // origin dot and must not end up under a line drawn from it.
+        entryHandleLayer(overview)
       }
       .scaleEffect(transform.scale)
       .offset(liveOffset)

--- a/graphcode/Sources/Features/Project/ProjectCanvasView.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasView.swift
@@ -205,6 +205,7 @@ struct ProjectCanvasView: View {
     return GeometryReader { proxy in
       ZStack {
         bandLayer(derived)
+        entryHandleLayer(derived)
         edgesLayer
         subGraphLinksLayer(derived.subGraph)
         nodesLayer(derived.attentionReasons, roles: derived.entryRoles, now: now)
@@ -336,6 +337,22 @@ struct ProjectCanvasView: View {
         entryPorts: entryPorts(derived),
         worktreeChip: worktreeChip,
         onWorktreeChipTapped: { store.send(.worktreeSweepTapped) })
+    }
+  }
+
+  /// The `+` on this canvas's origin dot — a second beginning in this folder, the twin
+  /// of the one the Graph view puts on every lane.
+  ///
+  /// It sits where the dot does, and only when there is one: `CanvasBandView` draws the
+  /// origin exactly when the canvas has entry ports. An empty canvas has no band at all,
+  /// and there the top-right New Loop is the way in.
+  @ViewBuilder
+  private func entryHandleLayer(_ derived: Derived) -> some View {
+    if let rect = bandRect(derived), !entryPorts(derived).isEmpty {
+      CanvasEntryHandle(help: "New loop in \(store.graph.project.name)") {
+        store.send(.addEntryLoopTapped)
+      }
+      .position(x: rect.minX + CanvasBand.originLane / 2, y: rect.midY)
     }
   }
 

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -132,6 +132,9 @@ struct ProjectFeature {
     /// to "does this start something" is its edges, and a stored flag would be a second
     /// answer free to disagree with them. See `CardEntryRole`.
     var declaredEntryIDs: Set<UUID> = []
+    /// Whether the open form was started from a lane's entry handle, so the loop it
+    /// creates joins `declaredEntryIDs` instead of reading as a loose one.
+    var draftDeclaresEntry = false
 
     /// The sidebar's display order for this project's loops, node ids first-to-last.
     /// Local UI state like `nodePositions`: the daemon's graph carries no ordering a
@@ -174,6 +177,9 @@ struct ProjectFeature {
     case binding(BindingAction<State>)
     case daemonEvent(DaemonEvent)
     case addNodeButtonTapped(parentBackend: CLISessionBackendKind?)
+    /// The lane's origin `+` on the Graph view: a top-level loop, declared an entry
+    /// because someone asked for a beginning rather than left one lying around.
+    case addEntryLoopTapped
     /// The + handle on a node card: opens the same form, and the created loop gets a
     /// hand-off edge from this node.
     case addChildNodeTapped(UUID)
@@ -315,6 +321,9 @@ struct ProjectFeature {
 
       case .addNodeButtonTapped(let parentBackend):
         return openNodeForm(&state, backend: parentBackend, parentNodeID: nil)
+
+      case .addEntryLoopTapped:
+        return openNodeForm(&state, backend: nil, parentNodeID: nil, declaresEntry: true)
 
       case .addChildNodeTapped(let parentID):
         // The child inherits its parent's backend, same rule as creating from within an
@@ -640,6 +649,11 @@ extension ProjectFeature {
     // graph never broadcasts a child floating unconnected.
     let parentNodeID = state.draftParentNodeID
     let custodial = state.draftParentIsCustodial
+    // Asked for from the entry handle, so it is a beginning on purpose — without this it
+    // would land as `.unwired`, which the canvas draws dimmed and dashed and offers to
+    // fix. See `CardEntryRole`.
+    if state.draftDeclaresEntry { state.declaredEntryIDs.insert(draft.id) }
+    state.draftDeclaresEntry = false
     state.draftParentNodeID = nil
     state.draftParentIsCustodial = false
     state.showingNewNodeForm = false
@@ -717,9 +731,10 @@ extension ProjectFeature {
 
   private func openNodeForm(
     _ state: inout State, backend: CLISessionBackendKind?, parentNodeID: UUID?,
-    custodial: Bool = false
+    custodial: Bool = false, declaresEntry: Bool = false
   ) -> Effect<Action> {
     state.draftID = UUID()
+    state.draftDeclaresEntry = declaresEntry
     state.draftLoopType = Self.rememberedLoopType
     state.draftTitle = ""
     state.draftCheck = ""

--- a/graphcode/Tests/EntryLoopCreationTests.swift
+++ b/graphcode/Tests/EntryLoopCreationTests.swift
@@ -1,0 +1,121 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// The `+` on a lane's origin dot in the Graph view: a top-level loop in that folder.
+///
+/// The gap it fills — a card's `+` continues a chain, and the top-right New Loop lands in
+/// the global graph, so starting a *new* chain in a particular folder meant crossing to
+/// that folder's own canvas first.
+@Suite
+struct EntryLoopCreationTests {
+  private func project() -> ProjectFeature.State {
+    ProjectFeature.State(
+      graph: LoopGraph(project: ProjectRef(path: "/tmp/project", name: "project")))
+  }
+
+  @Test
+  @MainActor
+  func theEntryHandleOpensTheFormWithNoParent() async {
+    // No parent means no hand-off edge: this is a beginning, not a continuation.
+    let store = TestStore(initialState: project()) {
+      ProjectFeature()
+    } withDependencies: {
+      // Opening the form lists the repository's worktrees for its branch picker.
+      $0.gitClient.listWorktrees = { _ in [] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.addEntryLoopTapped)
+    #expect(store.state.showingNewNodeForm)
+    #expect(store.state.draftParentNodeID == nil)
+    #expect(store.state.draftDeclaresEntry)
+  }
+
+  @Test
+  @MainActor
+  func aLoopMadeFromTheEntryHandleReadsAsAnEntryNotAsALooseOne() async {
+    // Without the declaration a brand-new root has no edge in either direction, which is
+    // `.unwired` — drawn dimmed and dashed, with two verbs offering to fix it. That is
+    // the right reading for a loop someone left lying around and the wrong one for a
+    // loop they just asked for.
+    // The draft is seeded up front rather than typed: a `TestStore`'s state is read-only,
+    // and what is under test here is what Create does with the declaration, not the form.
+    var state = project()
+    state.draftDeclaresEntry = true
+    state.draftLoopType = .sketch
+    state.draftTitle = "a beginning"
+    let draftID = state.draftID
+
+    let store = TestStore(initialState: state) {
+      ProjectFeature()
+    } withDependencies: {
+      $0.orchestratorClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createNodeConfirmed)
+
+    #expect(store.state.declaredEntryIDs.contains(draftID))
+    // Cleared, so the *next* form — the top-right New Loop, a card's `+` — doesn't
+    // inherit the declaration.
+    #expect(!store.state.draftDeclaresEntry)
+  }
+
+  @Test
+  @MainActor
+  func theOrdinaryNewLoopButtonDeclaresNothing() async {
+    let store = TestStore(initialState: project()) {
+      ProjectFeature()
+    } withDependencies: {
+      $0.gitClient.listWorktrees = { _ in [] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.addNodeButtonTapped(parentBackend: nil))
+    #expect(!store.state.draftDeclaresEntry)
+  }
+
+  @Test
+  func aLaneWithNoBeginningGetsNoHandle() {
+    // The handle lives where the origin dot does, and `CanvasBandView` draws that dot
+    // exactly when a lane has entry ports. A `+` floating where no dot is reads as a
+    // stray control — a cycle-only lane keeps the top-right New Loop instead.
+    let first = LoopNode(title: "first")
+    let second = LoopNode(title: "second")
+    var graph = LoopGraph(project: ProjectRef(path: "/tmp/project", name: "project"))
+    graph.nodes.append(first)
+    graph.nodes.append(second)
+    graph.edges.append(LoopEdge(from: first.id, to: second.id))
+    graph.edges.append(LoopEdge(from: second.id, to: first.id))
+
+    let overview = GraphOverview(graphs: [graph])
+    #expect(overview.folders.count == 1)
+    // Every loop is in the cycle, so nothing is a beginning and nothing is tethered.
+    #expect(overview.folders.first?.entryPorts.isEmpty == true)
+    #expect(overview.tetheredFolders.isEmpty)
+  }
+
+  @Test
+  func theOverviewShowsADeclaredEntryAsAnEntry() {
+    // The overview built its roles without declarations, so a loop the folder's canvas
+    // called an entry still read as loose on the Graph view — the two canvases
+    // disagreeing about the same loop.
+    let node = LoopNode(title: "a beginning")
+    var graph = LoopGraph(project: ProjectRef(path: "/tmp/project", name: "project"))
+    graph.nodes.append(node)
+
+    let loose = GraphOverview(graphs: [graph])
+    #expect(loose.loops.first?.entryRole == .unwired)
+
+    let declared = GraphOverview(
+      graphs: [graph], declaredEntries: ["/tmp/project": [node.id]])
+    #expect(declared.loops.first?.entryRole == .entry)
+    // Either way the origin has somewhere to land — an entry port is what the lane's
+    // dot draws its line to.
+    #expect(declared.folders.first?.entryPorts.isEmpty == false)
+  }
+}

--- a/graphcode/Tests/GraphViewLoopMenuTests.swift
+++ b/graphcode/Tests/GraphViewLoopMenuTests.swift
@@ -1,0 +1,61 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// The Graph view's loop menu offers the verbs the sidebar does, and they have to work
+/// from there — on a loop whose folder is not the one selected, without crossing to that
+/// folder's canvas first.
+///
+/// That is a claim about plumbing rather than about menus: the dialogs these verbs raise
+/// are hosted by `AppView` for the whole window, and the panels Export and Import run come
+/// straight from the reducer. These pin the half a test can reach.
+@Suite
+struct GraphViewLoopMenuTests {
+  private func app(withLoopIn path: String) -> (AppFeature.State, LoopNode) {
+    let node = LoopNode(title: "a loop")
+    var graph = LoopGraph(project: ProjectRef(path: path, name: "other"))
+    graph.nodes.append(node)
+
+    var state = AppFeature.State()
+    state.projects = [
+      ProjectFeature.State(
+        graph: LoopGraph(project: ProjectRef(path: "/tmp/selected", name: "selected"))),
+      ProjectFeature.State(graph: graph),
+    ]
+    // Looking at the *other* folder — the Graph view spans them all, so the loop being
+    // acted on routinely belongs to one that isn't selected.
+    state.detailSelection = .project("/tmp/selected")
+    return (state, node)
+  }
+
+  @Test
+  @MainActor
+  func deletingALoopFromAnUnselectedFolderRaisesTheWindowsConfirmation() async {
+    let (state, node) = app(withLoopIn: "/tmp/other")
+    let store = TestStore(initialState: state) { AppFeature() }
+    store.exhaustivity = .off
+
+    await store.send(.projects(.element(id: "/tmp/other", action: .deleteNodeRequested(node.id))))
+
+    // `AppView` hosts this dialog off `pendingLoopDeletion`, which scans every project —
+    // so the confirmation appears without the folder being selected first.
+    #expect(store.state.pendingLoopDeletion?.node.id == node.id)
+    #expect(store.state.pendingLoopDeletion?.projectPath == "/tmp/other")
+  }
+
+  @Test
+  @MainActor
+  func renamingALoopFromAnUnselectedFolderRaisesTheWindowsPrompt() async {
+    let (state, node) = app(withLoopIn: "/tmp/other")
+    let store = TestStore(initialState: state) { AppFeature() }
+    store.exhaustivity = .off
+
+    await store.send(.projects(.element(id: "/tmp/other", action: .renameNodeRequested(node.id))))
+
+    #expect(store.state.pendingLoopRename?.node.id == node.id)
+    #expect(store.state.pendingLoopRename?.projectPath == "/tmp/other")
+  }
+}


### PR DESCRIPTION
Two gaps in the Graph view, both of the "this verb exists everywhere else" kind.

## 1. A `+` on the entry dot

A card's handle continues a chain; the top-right **New Loop** lands in the global graph. So starting a *new* chain in a particular folder meant crossing to that folder's canvas first.

The lane's origin dot now reveals the same `CanvasConnectorHandle` a card does when the pointer comes near it, and creates a **top-level loop in that folder**. The folder's own canvas gets the identical handle on its identical dot.

| Decision | Why |
|---|---|
| The dot itself is unchanged | It's the marker it always was; only the handle is new |
| Handle appears **below** the dot | Every connector to that lane's entry loops leaves the dot rightward — a handle in that fan reads as a point on a line |
| Hover zone is 60×56, not 12×12 | "Near the entry" is what a hand aims at; hitting a 12pt dot exactly is a demand, not an affordance |
| No new edge kind | The origin already draws a line to every card nothing hands off to, so the new loop is tethered the moment it exists |
| Only where a dot exists | `CanvasBandView` draws the origin exactly when a lane has entry ports — a cycle-only lane keeps the top-right New Loop rather than growing a control attached to nothing |

A loop made this way is registered as a **declared entry**. Without it a brand-new root has no edge in either direction, which is `.unwired` — dimmed, dashed, with two verbs offering to fix it. That's the right reading for a loop someone left lying around and the wrong one for a loop they just asked for. The overview honours declared entries now too: it built its roles without them, so a loop the folder's canvas called an entry still read as loose over here.

## 2. The loop menu

Right-clicking a loop in the Graph view stopped at Open / Reveal / Stop. It now offers what the sidebar does, in the same order:

| | Sidebar | Folder canvas | Graph view |
|---|---|---|---|
| Open Terminal | ✓ | ✓ | ✓ |
| New Child Loop… | ✓ | ✓ | **added** |
| Pilot / Arm *(composite)* | ✓ | ✓ | **added** |
| Rename… | ✓ | ✓ | **added** |
| Stop Loop | ✓ | ✓ | ✓ |
| Reveal in *folder* | — | n/a | ✓ |
| Export / Import *(behind `sharesLoops`)* | ✓ | ✓ | **added** |
| Delete Loop… | ✓ | ✓ | **added** |

They work on a loop whose folder isn't the selected one, which is the part that could have been decorative: Export and Import run their panels straight from the reducer, Rename and Delete present from `AppView` (`pendingLoopDeletion` scans every project), and the creation sheet already has a per-folder host mounted on that view — the thing the sidebar has to select a project to get.

Still out of the overview: rewiring and drilling into a composite, since it can't show you the consequences. **Reveal** is the answer to both.

## Tests

`EntryLoopCreationTests` — the handle opens a parentless form; a loop created that way joins `declaredEntryIDs` while the ordinary New Loop declares nothing; a cycle-only lane has no entry ports and so no handle; and the overview reads a declared entry as `.entry` rather than `.unwired`.

`GraphViewLoopMenuTests` — deleting and renaming a loop in an **unselected** folder still raise the window's dialogs.

**1007 tests passing**, `swift format lint --strict` clean. Built as a Release bundle and driven on a real install before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)