### PR TITLE
feat: the workspace surfaces, reworked from a design review

### DIFF
--- a/GraphcodeKit/Sources/Workspace.swift
+++ b/GraphcodeKit/Sources/Workspace.swift
@@ -246,6 +246,31 @@ extension Workspace {
     }
   }
 
+  /// What a switcher row needs to say about a workspace it is not inside: how much is in
+  /// it, and whether a window has it open.
+  ///
+  /// Read from disk every time rather than cached. These are small JSON files, the list
+  /// is opened by a human gesture, and the alternative — a cache — would be wrong in the
+  /// one case that matters, which is another instance working while you look at the row.
+  public struct Summary: Equatable, Sendable {
+    public var projects = 0
+    public var loops = 0
+    public var isOpen = false
+
+    public init(projects: Int = 0, loops: Int = 0, isOpen: Bool = false) {
+      self.projects = projects
+      self.loops = loops
+      self.isOpen = isOpen
+    }
+  }
+
+  public func summary(fileManager: FileManager = .default) -> Summary {
+    let contents = contents(fileManager: fileManager)
+    return Summary(
+      projects: contents.projects, loops: contents.loops,
+      isOpen: WorkspaceLock.holder(of: self) != nil)
+  }
+
   /// Why a workspace cannot be changed right now.
   public enum Refusal: Error, Equatable, LocalizedError {
     case isDefault(Change)

--- a/GraphcodeKit/Sources/WorkspaceStarter.swift
+++ b/GraphcodeKit/Sources/WorkspaceStarter.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// The one question a new workspace has to ask before it is any use: which agent runs
+/// its loops.
+///
+/// It is genuinely per-workspace and easy to miss. `settings.json` lives *inside* the
+/// support directory, so a workspace created by someone running Codex everywhere still
+/// starts on the built-in default — silently, and not discovered until the first loop
+/// opens the wrong CLI.
+///
+/// The invitation is a file rather than a flag in `UserDefaults`, for the reason the
+/// tour's own `hasSeenOnboarding` cannot be reused: defaults are per *app*, and every
+/// workspace on the machine is the same app. A file in the workspace's own directory is
+/// the only thing that can say "this workspace has not been started yet".
+///
+/// Written by the instance that *creates* the workspace, because that is the one that
+/// knows what to suggest — the agent the human is already using. Read, and removed, by
+/// the instance that opens it.
+public enum WorkspaceStarter {
+  /// What the creating workspace passes on to the new one.
+  public struct Invitation: Codable, Equatable, Sendable {
+    /// Preselected in the dialog. Not applied on its own: a workspace whose starter was
+    /// never answered keeps whatever `GraphcodeSettings` defaults to, so the suggestion
+    /// can never quietly become the setting.
+    public var suggestedBackend: CLISessionBackendKind
+
+    public init(suggestedBackend: CLISessionBackendKind) {
+      self.suggestedBackend = suggestedBackend
+    }
+  }
+
+  static func url(for workspace: Workspace) -> URL {
+    workspace.url.appendingPathComponent("starter.json")
+  }
+
+  /// Leaves the invitation for a workspace that is about to be opened for the first time.
+  ///
+  /// Never for the default workspace: that one is configured by the tour, and an install
+  /// upgrading into this feature must not be asked again about a workspace it has been
+  /// using for months.
+  public static func invite(_ workspace: Workspace, suggesting backend: CLISessionBackendKind) {
+    guard !workspace.isDefault else { return }
+    guard let data = try? JSONEncoder().encode(Invitation(suggestedBackend: backend)) else {
+      return
+    }
+    try? data.write(to: url(for: workspace), options: .atomic)
+  }
+
+  /// The invitation this workspace was opened with, or `nil` — already answered, or a
+  /// workspace made before this shipped, which is treated as answered rather than
+  /// interrogated about a decision it has been living with.
+  public static func pending(_ workspace: Workspace = .current) -> Invitation? {
+    guard !workspace.isDefault,
+      let data = try? Data(contentsOf: url(for: workspace))
+    else { return nil }
+    return try? JSONDecoder().decode(Invitation.self, from: data)
+  }
+
+  /// Answered — by choosing or by skipping. Both count: the dialog asks once, and a
+  /// person who dismissed it does not want it again on the next launch.
+  public static func clear(_ workspace: Workspace = .current) {
+    try? FileManager.default.removeItem(at: url(for: workspace))
+  }
+}

--- a/graphcode/Sources/Clients/WorkspaceClient.swift
+++ b/graphcode/Sources/Clients/WorkspaceClient.swift
@@ -30,6 +30,17 @@ struct WorkspaceClient: Sendable {
   var rename: @Sendable (Workspace, String) throws -> Workspace
   /// Workspaces open in *other* instances right now. Asked before an update swaps the
   /// bundle, since every workspace runs from the same copy in /Applications.
+  /// What each workspace holds and whether a window has it — for the switcher's rows,
+  /// keyed by workspace id.
+  var summarize: @Sendable ([Workspace]) -> [String: Workspace.Summary]
+  /// The invitation this workspace was opened with, if it has not been answered yet —
+  /// what raises the starter dialog. See `WorkspaceStarter`.
+  var starterInvitation: @Sendable () -> WorkspaceStarter.Invitation?
+  /// Applied the moment it is picked, like the tour's page: through `SettingsModel`, not
+  /// the store underneath it, or the Settings pane would keep showing the old value.
+  var applyDefaultBackend: @Sendable (CLISessionBackendKind) async -> Void
+  /// Answered — by choosing or by skipping. Either way the dialog does not come back.
+  var finishStarter: @Sendable () -> Void
   var otherOpen: @Sendable () -> [Workspace]
   /// Asks those instances to quit, and waits — briefly — for them to actually go.
   var quit: @Sendable ([Workspace]) async -> Void
@@ -38,7 +49,13 @@ struct WorkspaceClient: Sendable {
 extension WorkspaceClient: DependencyKey {
   static let liveValue = WorkspaceClient(
     list: { Workspace.all() },
-    create: { try Workspace.create(name: $0) },
+    create: { name in
+      let created = try Workspace.create(name: name)
+      // The creating workspace is the one that knows what to suggest: the agent this
+      // person is already using, read from *this* workspace's settings.
+      WorkspaceStarter.invite(created, suggesting: GraphcodeSettingsStore.load().defaultBackend)
+      return created
+    },
     open: { workspace in
       if let existing = runningInstance(of: workspace) {
         existing.activate()
@@ -74,6 +91,14 @@ extension WorkspaceClient: DependencyKey {
       if let refusal = workspace.refusal(for: .rename) { throw refusal }
       return try workspace.renamed(to: name)
     },
+    summarize: { workspaces in
+      Dictionary(uniqueKeysWithValues: workspaces.map { ($0.id, $0.summary()) })
+    },
+    starterInvitation: { WorkspaceStarter.pending() },
+    applyDefaultBackend: { backend in
+      await MainActor.run { SettingsModel.shared.settings.defaultBackend = backend }
+    },
+    finishStarter: { WorkspaceStarter.clear() },
     otherOpen: {
       let current = Workspace.current
       return Workspace.all()
@@ -103,6 +128,10 @@ extension WorkspaceClient: DependencyKey {
     rename: { workspace, name in
       Workspace(slug: name, url: workspace.url.deletingLastPathComponent())
     },
+    summarize: { _ in [:] },
+    starterInvitation: { nil },
+    applyDefaultBackend: { _ in },
+    finishStarter: {},
     otherOpen: { [] },
     quit: { _ in })
 

--- a/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
@@ -23,6 +23,19 @@ extension AppFeature {
     /// The workspace a Delete confirmation is up for, with what it would take with it —
     /// counted when the dialog opens, since the numbers come off disk.
     var pendingDeletion: PendingDeletion?
+    /// What each known workspace holds, keyed by id — the switcher's second line.
+    /// Refreshed with `known`, since both are read by the same gesture.
+    var summaries: [String: Workspace.Summary] = [:]
+    var isSwitcherPresented = false
+    /// Up when this launch owes someone the news that workspaces exist — see
+    /// `WorkspaceNews` for who that is. Carries the version so the badge can name it.
+    var news: String?
+    var isManaging = false
+    /// The invitation this workspace was opened with; `nil` once answered, and on every
+    /// workspace that predates the starter. See `WorkspaceStarter`.
+    var starter: WorkspaceStarter.Invitation?
+    /// The row selected in the starter — seeded from the invitation, applied on pick.
+    var starterBackend: CLISessionBackendKind = .claudeCode
     /// The workspace being renamed, and the name being typed for it. `nil` means the
     /// sheet is closed.
     var renaming: Workspace?
@@ -77,6 +90,18 @@ extension AppFeature {
     case createConfirmed
     /// Raise (or launch) the instance that owns this workspace.
     case switchRequested(Workspace)
+    case switcherPresented(Bool)
+    case manageRequested
+    case manageDismissed
+    /// Raises the starter if this workspace was opened with an unanswered invitation.
+    case starterChecked
+    /// Asked once per launch, alongside the starter — the two are mutually exclusive by
+    /// construction: the news is for the default workspace, the starter never is.
+    case newsChecked
+    case newsNotesTapped
+    case newsDismissed
+    case starterBackendPicked(CLISessionBackendKind)
+    case starterDismissed
     case renameRequested(Workspace)
     case renameDraftChanged(String)
     case renameConfirmed
@@ -98,13 +123,70 @@ struct AppWorkspacesReducer: Reducer {
   typealias Action = AppFeature.Action
 
   @Dependency(\.workspaceClient) var workspaces
+  @Dependency(\.updateClient) var updateClient
+  @Dependency(\.openURL) var openURL
 
   var body: some Reducer<AppFeature.State, AppFeature.Action> {
     Reduce { state, action in
       switch action {
       case .workspaces(.listRequested):
         state.workspaces.known = workspaces.list()
+        state.workspaces.summaries = workspaces.summarize(state.workspaces.known)
         return .none
+
+      case .workspaces(.switcherPresented(let isPresented)):
+        state.workspaces.isSwitcherPresented = isPresented
+        // Read on open, not on a timer: another instance may have created, deleted or
+        // started using a workspace since this window last looked.
+        guard isPresented else { return .none }
+        return .send(.workspaces(.listRequested))
+
+      case .workspaces(.manageRequested):
+        state.workspaces.isManaging = true
+        return .send(.workspaces(.listRequested))
+
+      case .workspaces(.manageDismissed):
+        state.workspaces.isManaging = false
+        return .none
+
+      case .workspaces(.starterChecked):
+        guard let invitation = workspaces.starterInvitation() else { return .none }
+        state.workspaces.starter = invitation
+        state.workspaces.starterBackend = invitation.suggestedBackend
+        return .none
+
+      case .workspaces(.newsChecked):
+        // Only in the default workspace. A workspace created since the upgrade has never
+        // known a GraphCode without them, and `UserDefaults` is per app — so without this
+        // every window on the machine would announce the same news.
+        guard state.workspaces.current.isDefault else { return .none }
+        let version = updateClient.currentVersion()
+        guard WorkspaceNews.announceIfNeeded(currentVersion: version) else { return .none }
+        state.workspaces.news = version
+        return .none
+
+      case .workspaces(.newsNotesTapped):
+        state.workspaces.news = nil
+        return .run { [openURL] _ in
+          await openURL(WorkspaceNews.releasesURL)
+        }
+
+      case .workspaces(.newsDismissed):
+        state.workspaces.news = nil
+        return .none
+
+      case .workspaces(.starterBackendPicked(let backend)):
+        // Applied on the pick rather than on the button, the same as the tour's page:
+        // there is no Save here, and a choice that only lands if you press the right
+        // button afterwards is a choice that gets lost.
+        state.workspaces.starterBackend = backend
+        return .run { [apply = workspaces.applyDefaultBackend] _ in await apply(backend) }
+
+      case .workspaces(.starterDismissed):
+        // Skip counts as answered: someone who dismissed this does not want it again on
+        // the next launch. Whatever is selected has already been applied.
+        state.workspaces.starter = nil
+        return .run { [finish = workspaces.finishStarter] _ in finish() }
 
       case .workspaces(.newRequested):
         state.workspaces.draftName = ""

--- a/graphcode/Sources/Features/App/AppView.swift
+++ b/graphcode/Sources/Features/App/AppView.swift
@@ -152,59 +152,7 @@ struct AppView: View {
       JumpPaletteView(store: store)
     }
     .task { await store.send(.task).finish() }
-    // Which workspaces exist decides whether the sidebar names this one at all, so the
-    // list is wanted before anything is drawn rather than when the switcher opens.
-    .task { store.send(.workspaces(.listRequested)) }
-    .sheet(
-      isPresented: Binding(
-        get: { store.workspaces.isCreating },
-        set: { if !$0 { store.send(.workspaces(.createCancelled)) } })
-    ) {
-      NewWorkspaceFormView(store: store)
-    }
-    .sheet(
-      isPresented: Binding(
-        get: { store.workspaces.renaming != nil },
-        set: { if !$0 { store.send(.workspaces(.renameCancelled)) } })
-    ) {
-      RenameWorkspaceFormView(store: store)
-    }
-    // Another instance may have created or deleted one since this window last looked,
-    // and the File menu is built from this list — so it is refreshed whenever the window
-    // comes forward rather than only at launch.
-    .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
-    { _ in
-      store.send(.workspaces(.listRequested))
-    }
-    .confirmationDialog(
-      "Delete the “\(store.workspaces.pendingDeletion?.workspace.name ?? "")” workspace?",
-      isPresented: Binding(
-        get: { store.workspaces.pendingDeletion != nil },
-        set: { if !$0 { store.send(.workspaces(.deleteCancelled)) } }
-      ),
-      titleVisibility: .visible,
-      presenting: store.workspaces.pendingDeletion
-    ) { _ in
-      Button("Delete Workspace", role: .destructive) {
-        store.send(.workspaces(.deleteConfirmed))
-      }
-      Button("Cancel", role: .cancel) { store.send(.workspaces(.deleteCancelled)) }
-    } message: { pending in
-      Text(
-        "\(pending.summary). Its terminal sessions are ended and its daemon stopped; "
-          + "the folder moves to the Trash, where it stays recoverable.")
-    }
-    .alert(
-      "That workspace can't be changed",
-      isPresented: Binding(
-        get: { store.workspaces.changeFailure != nil },
-        set: { if !$0 { store.send(.workspaces(.changeFailureDismissed)) } }
-      )
-    ) {
-      Button("OK", role: .cancel) { store.send(.workspaces(.changeFailureDismissed)) }
-    } message: {
-      Text(store.workspaces.changeFailure ?? "")
-    }
+    .modifier(WorkspaceDialogs(store: store))
     .confirmationDialog(
       // Naming the loop matters here in a way it didn't on the canvas: from the sidebar
       // you may be several projects away from the thing you right-clicked.

--- a/graphcode/Sources/Features/Welcome/OnboardingPages.swift
+++ b/graphcode/Sources/Features/Welcome/OnboardingPages.swift
@@ -293,7 +293,7 @@ struct OnboardingBackendPage: View {
         VStack(alignment: .leading, spacing: 2) {
           HStack(spacing: 7) {
             Text(backend.displayName).font(.system(size: 13, weight: .semibold))
-            capabilityBadge(backend)
+            Self.capabilityBadge(backend)
           }
           Text(OnboardingBackendPage.blurb(backend))
             .font(.system(size: 11.5))
@@ -324,7 +324,7 @@ struct OnboardingBackendPage: View {
   /// dialog, said here before anyone runs into it. Derived rather than written out, so
   /// it can't come to claim something the capability table disagrees with.
   @ViewBuilder
-  private func capabilityBadge(_ backend: CLISessionBackendKind) -> some View {
+  static func capabilityBadge(_ backend: CLISessionBackendKind) -> some View {
     let missing = LoopType.allCases.filter { !backend.canHost($0) }
     let hostsEverything = missing.isEmpty
     Text(
@@ -353,4 +353,128 @@ struct OnboardingBackendPage: View {
 
   private static let hostsInk = Color(red: 0.494, green: 0.894, blue: 0.608)
   private static let limitedInk = Color(red: 1.0, green: 0.804, blue: 0.478)
+}
+
+/// Page 4 — one window per line of work.
+///
+/// Placed before the agent page rather than after it, so the tour still ends on the one
+/// choice that configures something.
+///
+/// The closing line is the page's real content. On day one a fresh install has no
+/// crowding problem, and a tour that pushes a second workspace at someone with zero loops
+/// has taught them to make a mess — so this page says when a workspace is worth having
+/// and explicitly says "not yet".
+struct OnboardingWorkspacesPage: View {
+  var body: some View {
+    VStack(spacing: 14) {
+      Text("One window per line of work")
+        .font(.system(size: 25, weight: .bold))
+        .tracking(-0.25)
+      Text(
+        "A workspace has its own projects, loops and daemon. Start one when a second "
+          + "kind of work would otherwise crowd the first."
+      )
+      .font(.system(size: 14))
+      .foregroundStyle(.white.opacity(0.65))
+      .multilineTextAlignment(.center)
+      .frame(maxWidth: 470)
+
+      HStack(spacing: 14) {
+        miniWindow(name: "Default", tint: Theme.paneFocusTint, widths: [1, 0.76, 0.88, 0.6])
+        divider
+        miniWindow(
+          name: "Client Work", tint: Color(red: 0.847, green: 0.651, blue: 0.341),
+          widths: [0.82, 1, 0.54])
+      }
+      .padding(.top, 8)
+
+      VStack(alignment: .leading, spacing: 7) {
+        fact("Separate", "projects, loops, terminal layouts, agent default")
+        fact("Shared", "the app itself, and nothing else")
+        fact("Make one", "File ▸ Workspace ▸ New Workspace…   ⌥⌘N")
+      }
+      .frame(width: 440, alignment: .leading)
+      .padding(.top, 12)
+
+      Text("You do not need one yet — one workspace is the right number until it isn't.")
+        .font(.system(size: 11))
+        .foregroundStyle(.white.opacity(0.4))
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 440)
+    }
+  }
+
+  private var divider: some View {
+    VStack(spacing: 4) {
+      ZStack {
+        Rectangle()
+          .fill(.white.opacity(0.18))
+          .frame(width: 52, height: 1)
+        Image(systemName: "xmark")
+          .font(.system(size: 9, weight: .medium))
+          .foregroundStyle(.white.opacity(0.28))
+          .padding(3)
+          .background(Theme.windowTone, in: Circle())
+      }
+      Text("nothing\ncrosses")
+        .font(.system(size: 9.5))
+        .foregroundStyle(.white.opacity(0.38))
+        .multilineTextAlignment(.center)
+    }
+    .frame(width: 74)
+  }
+
+  /// Not a screenshot and not to scale — two windows, each with its own loops, and the
+  /// gap between them is the whole point.
+  private func miniWindow(name: String, tint: Color, widths: [CGFloat]) -> some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 6) {
+        Circle().fill(tint).frame(width: 6, height: 6)
+        Text(name).font(.system(size: 9)).foregroundStyle(.white.opacity(0.7))
+        Spacer(minLength: 0)
+      }
+      .padding(.horizontal, 7)
+      .frame(height: 18)
+      .background(.white.opacity(0.05))
+
+      Divider().overlay(.white.opacity(0.08))
+
+      VStack(alignment: .leading, spacing: 5) {
+        ForEach(Array(widths.enumerated()), id: \.offset) { index, width in
+          RoundedRectangle(cornerRadius: 2)
+            .fill(OnboardingWorkspacesPage.loopTint(index))
+            .frame(width: 154 * width, height: 4)
+        }
+      }
+      .padding(9)
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .frame(width: 172)
+    .background(Color(white: 0.137), in: RoundedRectangle(cornerRadius: 7))
+    .overlay {
+      RoundedRectangle(cornerRadius: 7).stroke(.white.opacity(0.12), lineWidth: 1)
+    }
+  }
+
+  private func fact(_ label: String, _ value: String) -> some View {
+    HStack(alignment: .firstTextBaseline, spacing: 9) {
+      Text(label)
+        .font(.system(size: 11))
+        .foregroundStyle(.white.opacity(0.45))
+        .frame(width: 96, alignment: .trailing)
+      Text(value)
+        .font(.system(size: 11.5))
+        .foregroundStyle(.white.opacity(0.7))
+    }
+  }
+
+  /// A couple of the bars carry a loop-state colour so the windows read as holding work
+  /// rather than as empty frames.
+  static func loopTint(_ index: Int) -> Color {
+    switch index {
+    case 0: return Color(red: 0.494, green: 0.894, blue: 0.608).opacity(0.55)
+    case 2: return Color(red: 1.0, green: 0.804, blue: 0.478).opacity(0.5)
+    default: return .white.opacity(0.16)
+    }
+  }
 }

--- a/graphcode/Sources/Features/Welcome/OnboardingView.swift
+++ b/graphcode/Sources/Features/Welcome/OnboardingView.swift
@@ -19,10 +19,10 @@ struct OnboardingView: View {
 
   @State private var page = 0
   @State private var selectedBackend = SettingsModel.shared.settings.defaultBackend
-  /// Four, and the count is checked: the edge lesson folded into the types page to make
+  /// Five, and the count is checked: the edge lesson folded into the types page to make
   /// room for "How to read a loop", and a page silently lost in that merge would be a
   /// tour that stops teaching something without anyone noticing.
-  static let pageCount = 4
+  static let pageCount = 5
 
   var body: some View {
     VStack(spacing: 0) {
@@ -41,6 +41,10 @@ struct OnboardingView: View {
         case 0: OnboardingWelcomePage()
         case 1: OnboardingReadingPage()
         case 2: OnboardingLoopTypesPage()
+        // Before the agent page, not after it: the tour ends on the one choice that
+        // configures something, and "where work lives" reads better just ahead of
+        // "what runs it".
+        case 3: OnboardingWorkspacesPage()
         default: OnboardingBackendPage(selection: $selectedBackend)
         }
       }

--- a/graphcode/Sources/Features/Workspaces/ManageWorkspacesView.swift
+++ b/graphcode/Sources/Features/Workspaces/ManageWorkspacesView.swift
@@ -1,0 +1,91 @@
+import ComposableArchitecture
+import GraphcodeKit
+import SwiftUI
+
+/// Rename and Delete, one click from the workspace they act on.
+///
+/// These were two submenus hanging off `File ▸ Workspace`, which put deleting a workspace
+/// four levels down a menu and made the two verbs impossible to compare — you could not
+/// see what you were about to delete while deciding to delete it. Here each workspace is
+/// a row that says how much is in it, with both verbs on the row.
+///
+/// The rules are unchanged and still enforced by `Workspace.refusal`: the default
+/// workspace and the one this window is using are shown but not actionable, and one open
+/// in another window refuses with its reason when tried.
+struct ManageWorkspacesView: View {
+  @Bindable var store: StoreOf<AppFeature>
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Workspaces").font(.headline)
+
+      VStack(spacing: 0) {
+        ForEach(store.workspaces.known) { workspace in
+          row(workspace)
+          if workspace.id != store.workspaces.known.last?.id {
+            Divider().overlay(.white.opacity(0.06))
+          }
+        }
+      }
+      .background(.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 8))
+      .overlay {
+        RoundedRectangle(cornerRadius: 8).stroke(.white.opacity(0.08), lineWidth: 1)
+      }
+
+      HStack {
+        Button("New Workspace…") {
+          store.send(.workspaces(.manageDismissed))
+          store.send(.workspaces(.newRequested))
+        }
+        Spacer()
+        Button("Done") { store.send(.workspaces(.manageDismissed)) }
+          .keyboardShortcut(.defaultAction)
+      }
+    }
+    .padding(24)
+    .frame(width: 480)
+  }
+
+  private func row(_ workspace: Workspace) -> some View {
+    let isCurrent = workspace.id == store.workspaces.current.id
+    let refusal = workspace.refusal(for: .delete, current: store.workspaces.current)
+    let summary = store.workspaces.summaries[workspace.id]
+    return HStack(spacing: 10) {
+      Circle()
+        .fill(WorkspaceSwitcherPanel.tint(for: workspace))
+        .frame(width: 7, height: 7)
+
+      VStack(alignment: .leading, spacing: 1) {
+        Text(workspace.name).font(.system(size: 13))
+        Text(WorkspaceSwitcherPanel.subtitle(summary, isCurrent: isCurrent))
+          .font(.system(size: 10, design: .monospaced))
+          .foregroundStyle(.white.opacity(0.42))
+      }
+
+      Spacer(minLength: 12)
+
+      // Said once, on the row, rather than as an alert after the click: the default
+      // workspace and the one you are in are never actionable, and the reason is short
+      // enough to print.
+      if let refusal {
+        Text(ManageWorkspacesView.reason(refusal))
+          .font(.system(size: 10))
+          .foregroundStyle(.white.opacity(0.35))
+      } else {
+        Button("Rename…") { store.send(.workspaces(.renameRequested(workspace))) }
+        Button("Delete…") { store.send(.workspaces(.deleteRequested(workspace))) }
+      }
+    }
+    .padding(.vertical, 9)
+    .padding(.horizontal, 12)
+  }
+
+  /// The refusal in three words for a row, where the alert's full sentence would wrap.
+  static func reason(_ refusal: Workspace.Refusal) -> String {
+    switch refusal {
+    case .isDefault: return "the default"
+    case .isCurrent: return "this window"
+    case .isOpen: return "open elsewhere"
+    }
+  }
+}

--- a/graphcode/Sources/Features/Workspaces/NewWorkspaceFormView.swift
+++ b/graphcode/Sources/Features/Workspaces/NewWorkspaceFormView.swift
@@ -7,59 +7,82 @@ import SwiftUI
 /// The sheet shows the directory the name resolves to, because that directory *is* the
 /// workspace — it is where its graphs live, what a `GRAPHCODE_SUPPORT_DIR` on the CLI
 /// would point at, and what someone deleting a workspace later has to remove.
+///
+/// **Why a picture rather than a paragraph.** The explainer this replaced was three lines
+/// of caption above a single text field — the largest thing in the dialog, read once, in
+/// the way forever. What someone actually needs to know before pressing Create is what
+/// they are about to get: another window, its own daemon, an empty sidebar. The diagram
+/// says all three at a glance and stops being read the moment it stops being news.
 struct NewWorkspaceFormView: View {
   @Bindable var store: StoreOf<AppFeature>
 
   var body: some View {
-    VStack(spacing: 12) {
+    VStack(alignment: .leading, spacing: 14) {
       Text("New Workspace").font(.headline)
 
-      Text(
-        """
-        A workspace keeps its own projects, loops and terminal sessions. Nothing is \
-        shared with this one — it opens in a separate window you can put on another \
-        screen.
-        """
-      )
-      .font(.caption)
-      .foregroundStyle(.secondary)
-      .fixedSize(horizontal: false, vertical: true)
-      .frame(maxWidth: .infinity, alignment: .leading)
+      HStack(alignment: .top, spacing: 16) {
+        VStack(alignment: .leading, spacing: 6) {
+          TextField("", text: name, prompt: Text("Client Work"))
+            .textFieldStyle(.roundedBorder)
+            .font(.system(size: 15))
+            .autocorrectionDisabled()
+            .onSubmit { if canCreate { store.send(.workspaces(.createConfirmed)) } }
 
-      Form {
-        TextField(
-          "Name", text: name,
-          prompt: Text("client work")
-        )
-        .autocorrectionDisabled()
-        .onSubmit { if canCreate { store.send(.workspaces(.createConfirmed)) } }
-      }
-      .formStyle(.columns)
-      .fixedSize(horizontal: false, vertical: true)
+          detail
 
-      Group {
-        if let problem = store.workspaces.problem {
-          Text(problem).foregroundStyle(.red)
-        } else if !directoryPath.isEmpty {
-          Text(directoryPath).foregroundStyle(.secondary)
+          VStack(alignment: .leading, spacing: 5) {
+            bullet("Its own projects and loops", isPresent: true)
+            bullet("Its own background daemon", isPresent: true)
+            bullet("Nothing shared with \(store.workspaces.current.name)", isPresent: false)
+          }
+          .padding(.top, 6)
         }
+
+        WorkspacePreview(name: previewName)
       }
-      .font(.caption)
-      .lineLimit(1)
-      .truncationMode(.middle)
-      .frame(maxWidth: .infinity, alignment: .leading)
 
       HStack {
+        Spacer()
         Button("Cancel") { store.send(.workspaces(.createCancelled)) }
           .keyboardShortcut(.cancelAction)
-        Spacer()
         Button("Create & Open") { store.send(.workspaces(.createConfirmed)) }
           .keyboardShortcut(.defaultAction)
           .disabled(!canCreate)
       }
     }
     .padding(24)
-    .frame(width: 420)
+    .frame(width: 460)
+  }
+
+  /// One line, and it is the *path* whenever there is one to show: a name that is still
+  /// being typed is not yet a mistake, so an empty field says nothing at all rather than
+  /// scolding.
+  @ViewBuilder
+  private var detail: some View {
+    Group {
+      if let problem = store.workspaces.problem {
+        Text(problem).foregroundStyle(.red)
+      } else if !directoryPath.isEmpty {
+        Text(directoryPath).foregroundStyle(.secondary)
+      } else {
+        Text(" ")
+      }
+    }
+    .font(.caption)
+    .lineLimit(1)
+    .truncationMode(.middle)
+  }
+
+  private func bullet(_ text: String, isPresent: Bool) -> some View {
+    HStack(spacing: 7) {
+      Image(systemName: isPresent ? "plus" : "minus")
+        .font(.system(size: 9, weight: .bold))
+        .foregroundStyle(.white.opacity(isPresent ? 0.5 : 0.35))
+        .frame(width: 12)
+      Text(text)
+        .font(.system(size: 11))
+        .foregroundStyle(.white.opacity(isPresent ? 0.6 : 0.45))
+    }
   }
 
   private var name: Binding<String> {
@@ -72,10 +95,89 @@ struct NewWorkspaceFormView: View {
     store.workspaces.problem == nil && !store.workspaces.draftName.isEmpty
   }
 
-  /// Where the typed name lands, abbreviated the way a human writes it.
+  /// The typed name until it resolves, so the window in the diagram is titled with what
+  /// is being typed rather than blinking between states.
+  private var previewName: String {
+    let typed = store.workspaces.draftName.trimmingCharacters(in: .whitespaces)
+    return typed.isEmpty ? "Client Work" : typed
+  }
+
   private var directoryPath: String {
     guard case .success(let workspace) = Workspace.validate(name: store.workspaces.draftName)
     else { return "" }
     return (workspace.url.path as NSString).abbreviatingWithTildeInPath
+  }
+}
+
+/// The second window, drawn small: title bar, sidebar, and the empty canvas it opens on.
+///
+/// Deliberately not a screenshot and deliberately not accurate — it is a diagram of "one
+/// more window, starting empty", and the one detail that has to be right is the name in
+/// its title bar, because that is the thing being decided.
+private struct WorkspacePreview: View {
+  let name: String
+
+  var body: some View {
+    VStack(spacing: 7) {
+      ZStack(alignment: .topLeading) {
+        RoundedRectangle(cornerRadius: 5)
+          .fill(.white.opacity(0.03))
+          .strokeBorder(.white.opacity(0.1), lineWidth: 1)
+          .frame(width: 108, height: 74)
+          .offset(x: 0, y: 10)
+
+        VStack(spacing: 0) {
+          HStack(spacing: 3) {
+            ForEach(0..<3, id: \.self) { _ in
+              Circle().fill(.white.opacity(0.22)).frame(width: 5, height: 5)
+            }
+            Spacer(minLength: 4)
+            Text(name)
+              .font(.system(size: 7))
+              .foregroundStyle(.white.opacity(0.55))
+              .lineLimit(1)
+              .truncationMode(.tail)
+          }
+          .padding(.horizontal, 5)
+          .frame(height: 15)
+          .background(.white.opacity(0.05))
+
+          Divider().overlay(.white.opacity(0.09))
+
+          HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 3) {
+              RoundedRectangle(cornerRadius: 1).fill(.white.opacity(0.13)).frame(height: 3)
+              RoundedRectangle(cornerRadius: 1).fill(.white.opacity(0.1))
+                .frame(width: 16, height: 3)
+              Spacer(minLength: 0)
+            }
+            .padding(5)
+            .frame(width: 32)
+
+            Divider().overlay(.white.opacity(0.07))
+
+            Text("empty")
+              .font(.system(size: 7))
+              .foregroundStyle(.white.opacity(0.3))
+              .frame(maxWidth: .infinity, maxHeight: .infinity)
+          }
+        }
+        .frame(width: 118, height: 84)
+        .background(Color(white: 0.165), in: RoundedRectangle(cornerRadius: 5))
+        .overlay {
+          RoundedRectangle(cornerRadius: 5).stroke(.white.opacity(0.22), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.5), radius: 9, x: -6, y: 5)
+        .offset(x: 26, y: 0)
+      }
+      .frame(width: 150, height: 96)
+
+      Text("A second window, starting empty")
+        .font(.system(size: 10))
+        .foregroundStyle(.white.opacity(0.4))
+        .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .frame(width: 150)
   }
 }

--- a/graphcode/Sources/Features/Workspaces/WorkspaceDialogs.swift
+++ b/graphcode/Sources/Features/Workspaces/WorkspaceDialogs.swift
@@ -1,0 +1,109 @@
+import ComposableArchitecture
+import GraphcodeKit
+import SwiftUI
+
+/// Every dialog the workspace surfaces raise, applied to `AppView`'s dialog host — the
+/// same arrangement `UpdateDialogs` uses, and here it is load-bearing rather than tidy:
+/// inlined in `AppView.body`, four sheets, a confirmation and an alert pushed the
+/// expression past what the SwiftUI type-checker will resolve, and the build failed with
+/// "unable to type-check this expression in reasonable time".
+///
+/// They are hosted at window level, not on the surface that raises them, because that is
+/// what lets a workspace be renamed from the sidebar's switcher and deleted from the File
+/// menu and have both present the same dialog.
+struct WorkspaceDialogs: ViewModifier {
+  @Bindable var store: StoreOf<AppFeature>
+
+  func body(content: Content) -> some View {
+    content
+      // Which workspaces exist decides whether the sidebar names this one at all, so the
+      // list is wanted before anything is drawn rather than when the switcher opens.
+      .task { store.send(.workspaces(.listRequested)) }
+      // A workspace opened for the first time asks its one question here — see
+      // `WorkspaceStarter`. Never in the window that created it: the choice belongs to the
+      // window it configures.
+      .task { store.send(.workspaces(.starterChecked)) }
+      // The other half of the same question — whoever was already here when workspaces
+      // landed. Mutually exclusive with the starter by construction: this is default-only
+      // and the starter never is.
+      .task { store.send(.workspaces(.newsChecked)) }
+      .sheet(
+        isPresented: Binding(
+          get: { store.workspaces.news != nil },
+          set: { if !$0 { store.send(.workspaces(.newsDismissed)) } })
+      ) {
+        if let version = store.workspaces.news {
+          WorkspaceNewsView(store: store, version: version)
+        }
+      }
+      .sheet(
+        isPresented: Binding(
+          get: { store.workspaces.starter != nil },
+          set: { if !$0 { store.send(.workspaces(.starterDismissed)) } })
+      ) {
+        if let starter = store.workspaces.starter {
+          WorkspaceStarterView(
+            store: store, workspace: store.workspaces.current,
+            suggested: starter.suggestedBackend)
+        }
+      }
+      .sheet(
+        isPresented: Binding(
+          get: { store.workspaces.isManaging },
+          set: { if !$0 { store.send(.workspaces(.manageDismissed)) } })
+      ) {
+        ManageWorkspacesView(store: store)
+      }
+      .sheet(
+        isPresented: Binding(
+          get: { store.workspaces.isCreating },
+          set: { if !$0 { store.send(.workspaces(.createCancelled)) } })
+      ) {
+        NewWorkspaceFormView(store: store)
+      }
+      .sheet(
+        isPresented: Binding(
+          get: { store.workspaces.renaming != nil },
+          set: { if !$0 { store.send(.workspaces(.renameCancelled)) } })
+      ) {
+        RenameWorkspaceFormView(store: store)
+      }
+      // Another instance may have created or deleted one since this window last looked,
+      // and the File menu is built from this list — so it is refreshed whenever the window
+      // comes forward rather than only at launch.
+      .onReceive(
+        NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+      ) { _ in
+        store.send(.workspaces(.listRequested))
+      }
+      .confirmationDialog(
+        "Delete the “\(store.workspaces.pendingDeletion?.workspace.name ?? "")” workspace?",
+        isPresented: Binding(
+          get: { store.workspaces.pendingDeletion != nil },
+          set: { if !$0 { store.send(.workspaces(.deleteCancelled)) } }
+        ),
+        titleVisibility: .visible,
+        presenting: store.workspaces.pendingDeletion
+      ) { _ in
+        Button("Delete Workspace", role: .destructive) {
+          store.send(.workspaces(.deleteConfirmed))
+        }
+        Button("Cancel", role: .cancel) { store.send(.workspaces(.deleteCancelled)) }
+      } message: { pending in
+        Text(
+          "\(pending.summary). Its terminal sessions are ended and its daemon stopped; "
+            + "the folder moves to the Trash, where it stays recoverable.")
+      }
+      .alert(
+        "That workspace can't be changed",
+        isPresented: Binding(
+          get: { store.workspaces.changeFailure != nil },
+          set: { if !$0 { store.send(.workspaces(.changeFailureDismissed)) } }
+        )
+      ) {
+        Button("OK", role: .cancel) { store.send(.workspaces(.changeFailureDismissed)) }
+      } message: {
+        Text(store.workspaces.changeFailure ?? "")
+      }
+  }
+}

--- a/graphcode/Sources/Features/Workspaces/WorkspaceNews.swift
+++ b/graphcode/Sources/Features/Workspaces/WorkspaceNews.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Whether this launch should tell someone that workspaces exist.
+///
+/// The tour teaches a fresh install (`OnboardingWorkspacesPage`). Everyone else was
+/// already using GraphCode when workspaces landed, and re-running four pages of tour to
+/// deliver one piece of news would be worse than the news — so they get a dialog, once.
+///
+/// **The rule, and the trap in it.** Nothing before this release recorded a version, so
+/// the *absence* of one cannot mean "new install" — it means "old install". What tells
+/// them apart is the tour's own flag: someone who has seen the tour has used the app
+/// before, whatever the version file says.
+///
+///     tour not seen                 → the tour, which now covers workspaces
+///     tour seen, last run < 0.1.46  → this dialog, once
+///     tour seen, no version at all  → this dialog, once (an older install)
+///
+/// `UserDefaults` and not the support directory: this is news about the *app*, and it
+/// should not be repeated by every workspace on the machine. Which is also why the
+/// caller gates it on being in the default workspace — a workspace created after the
+/// upgrade has never known a GraphCode without them.
+enum WorkspaceNews {
+  static let lastRunVersionKey = "lastRunVersion"
+  static let hasSeenOnboardingKey = "hasSeenOnboarding"
+
+  /// The releases page, not a constructed tag URL: beta tags carry no `v` prefix and
+  /// stable ones do, so assembling one by hand is a 404 waiting to happen.
+  static let releasesURL = URL(string: "https://github.com/scgopi/GraphCode/releases")!
+
+  /// The release that introduced workspaces. Compared on the release triple *alone*:
+  /// they shipped in 0.1.46-beta1, and `AppVersion` sorts every prerelease before its
+  /// release — so asking whether a version is `< 0.1.46` calls each of that release's
+  /// own betas "before workspaces" and announces the news to someone who has been using
+  /// them for a week.
+  static let introducedIn = "0.1.46"
+
+  /// `0.1.46` as its triple. `AppVersion` parses from a string and has no memberwise
+  /// initializer, so the comparison below works on the numbers rather than rebuilding a
+  /// version with its prerelease stripped.
+  static let introducedRelease = [0, 1, 46]
+
+  /// Whether a release triple comes before another, padding the shorter with zeros so
+  /// `0.1` and `0.1.0` compare equal.
+  static func precedes(_ release: [Int], _ other: [Int]) -> Bool {
+    for index in 0..<max(release.count, other.count) {
+      let left = index < release.count ? release[index] : 0
+      let right = index < other.count ? other[index] : 0
+      if left != right { return left < right }
+    }
+    return false
+  }
+
+  static func shouldAnnounce(
+    currentVersion: String,
+    lastRunVersion: String?,
+    hasSeenOnboarding: Bool
+  ) -> Bool {
+    // A fresh install learns it from the tour; announcing as well would be the same
+    // lesson twice in one sitting.
+    guard hasSeenOnboarding else { return false }
+    guard let current = AppVersion(currentVersion),
+      !precedes(current.release, introducedRelease)
+    else { return false }
+    // No recorded version means an install from before this key existed — which is
+    // exactly the audience for the news.
+    guard let lastRunVersion, let last = AppVersion(lastRunVersion) else { return true }
+    return precedes(last.release, introducedRelease)
+  }
+
+  /// Reads the two defaults, answers, and records this version either way — so the
+  /// question is asked once per machine however it is answered.
+  static func announceIfNeeded(
+    currentVersion: String, defaults: UserDefaults = .standard
+  ) -> Bool {
+    let announce = shouldAnnounce(
+      currentVersion: currentVersion,
+      lastRunVersion: defaults.string(forKey: lastRunVersionKey),
+      hasSeenOnboarding: defaults.bool(forKey: hasSeenOnboardingKey))
+    defaults.set(currentVersion, forKey: lastRunVersionKey)
+    return announce
+  }
+}

--- a/graphcode/Sources/Features/Workspaces/WorkspaceNewsView.swift
+++ b/graphcode/Sources/Features/Workspaces/WorkspaceNewsView.swift
@@ -1,0 +1,103 @@
+import ComposableArchitecture
+import GraphcodeKit
+import SwiftUI
+
+/// Workspaces exist now — said once, to people who were already using GraphCode when they
+/// landed. See `WorkspaceNews` for who that is.
+///
+/// A dialog rather than a tour page, because its audience has already done the tour. Three
+/// lines, and the third one is the reason this dialog exists at all: the first question on
+/// finding a "Default" label at the foot of a sidebar that never had one is whether your
+/// loops are still there.
+struct WorkspaceNewsView: View {
+  @Bindable var store: StoreOf<AppFeature>
+  let version: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      VStack(alignment: .leading, spacing: 10) {
+        Text("NEW IN \(version)")
+          .font(.system(size: 9, weight: .bold))
+          .tracking(0.5)
+          .foregroundStyle(Self.newInk)
+          .padding(.vertical, 2)
+          .padding(.horizontal, 6)
+          .background(Self.newInk.opacity(0.14), in: RoundedRectangle(cornerRadius: 4))
+
+        Text("Workspaces")
+          .font(.system(size: 19, weight: .bold))
+          .tracking(-0.2)
+
+        Text(
+          "A second GraphCode with its own projects, loops and daemon — for keeping "
+            + "unrelated work apart, or putting one window on each screen."
+        )
+        .font(.system(size: 13))
+        .foregroundStyle(.white.opacity(0.65))
+        .fixedSize(horizontal: false, vertical: true)
+      }
+
+      VStack(alignment: .leading, spacing: 11) {
+        item(
+          "rectangle.split.2x1", "Make one from File ▸ Workspace",
+          "It opens in its own window, with its own Dock tile.")
+        item(
+          "list.bullet", "Switch with ⌥⌘1 … ⌥⌘9",
+          "Or from the workspace name at the foot of the sidebar.")
+        item(
+          "arrow.up.to.line", "Nothing moved",
+          "Everything you have is in the workspace called Default, exactly where it was.")
+      }
+      .padding(.top, 18)
+
+      Text(
+        "Also in this release: a new workspace opens cleanly the first time, updates are "
+          + "handled from Default only, and updating offers to close your other workspace "
+          + "windows first."
+      )
+      .font(.system(size: 11))
+      .foregroundStyle(.white.opacity(0.45))
+      .fixedSize(horizontal: false, vertical: true)
+      .padding(11)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 8))
+      .overlay {
+        RoundedRectangle(cornerRadius: 8).stroke(.white.opacity(0.07), lineWidth: 1)
+      }
+      .padding(.top, 20)
+
+      HStack {
+        Text("Shown once")
+          .font(.system(size: 11))
+          .foregroundStyle(.white.opacity(0.35))
+        Spacer()
+        Button("Release Notes") { store.send(.workspaces(.newsNotesTapped)) }
+        Button("Got It") { store.send(.workspaces(.newsDismissed)) }
+          .keyboardShortcut(.defaultAction)
+          .buttonStyle(.borderedProminent)
+      }
+      .padding(.top, 20)
+    }
+    .padding(26)
+    .frame(width: 460)
+  }
+
+  private func item(_ symbol: String, _ title: String, _ detail: String) -> some View {
+    HStack(alignment: .top, spacing: 11) {
+      Image(systemName: symbol)
+        .font(.system(size: 12))
+        .foregroundStyle(.white.opacity(0.45))
+        .frame(width: 15)
+        .padding(.top, 1)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title).font(.system(size: 12.5)).foregroundStyle(.white.opacity(0.92))
+        Text(detail)
+          .font(.system(size: 11))
+          .foregroundStyle(.white.opacity(0.5))
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+  }
+
+  private static let newInk = Color(red: 0.494, green: 0.894, blue: 0.608)
+}

--- a/graphcode/Sources/Features/Workspaces/WorkspaceStarterView.swift
+++ b/graphcode/Sources/Features/Workspaces/WorkspaceStarterView.swift
@@ -1,0 +1,150 @@
+import ComposableArchitecture
+import GraphcodeKit
+import SwiftUI
+
+/// The one question a new workspace has to ask: which agent runs its loops.
+///
+/// Page 4 of the tour, alone, in the new window. The other three pages taught what a loop
+/// is and what the graph does — learned once, in whichever workspace came first. This one
+/// is different because the *answer* is per-workspace: `settings.json` lives inside the
+/// support directory, so a new workspace starts on the built-in default however the
+/// person has configured every other one (see `WorkspaceStarter`).
+///
+/// Three deliberate departures from the tour's version of this page:
+///
+/// - **It names the workspace.** A workspace opens in its own window, often on another
+///   screen, so a dialog that doesn't say which window is asking is a dialog you have to
+///   go and identify.
+/// - **It preselects what the creating workspace uses**, not the built-in default. The
+///   common case is "the same as I already use", and that should be one button, not a
+///   re-decision.
+/// - **No dots, no Back.** A one-step wizard is a dialog.
+struct WorkspaceStarterView: View {
+  @Bindable var store: StoreOf<AppFeature>
+  let workspace: Workspace
+  let suggested: CLISessionBackendKind
+
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack {
+        HStack(spacing: 7) {
+          Circle()
+            .fill(WorkspaceSwitcherPanel.tint(for: workspace))
+            .frame(width: 7, height: 7)
+          Text(workspace.name)
+            .font(.system(size: 11))
+            .foregroundStyle(.white.opacity(0.5))
+        }
+        Spacer()
+        Button("Skip") { store.send(.workspaces(.starterDismissed)) }
+          .buttonStyle(.plain)
+          .foregroundStyle(.white.opacity(0.6))
+      }
+      .padding(.horizontal, 20)
+      .padding(.top, 14)
+
+      VStack(spacing: 14) {
+        Text("Which agent runs them here")
+          .font(.system(size: 25, weight: .bold))
+          .tracking(-0.25)
+        Text(
+          "This workspace keeps its own default. Starting from what \(store.workspaces.current.name) "
+            + "uses — change it any time in Settings, or per loop."
+        )
+        .font(.system(size: 14))
+        .foregroundStyle(.white.opacity(0.65))
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 470)
+
+        VStack(spacing: 8) {
+          ForEach(CLISessionBackendKind.allCases, id: \.self) { backend in
+            row(backend)
+          }
+        }
+        .frame(maxWidth: 440)
+
+        // Same words as the tour's page, and for the same reason: nothing here probes
+        // the PATH, so promising that the CLI is present would be the dialog making it
+        // up.
+        Text(
+          "The CLI must be installed and on your PATH — GraphCode launches it, it doesn't "
+            + "bundle it."
+        )
+        .font(.system(size: 11))
+        .foregroundStyle(.white.opacity(0.45))
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 440)
+      }
+      .padding(.top, 22)
+      .padding(.horizontal, 32)
+
+      Spacer(minLength: 20)
+
+      HStack {
+        Text("Only asked once per workspace")
+          .font(.system(size: 11))
+          .foregroundStyle(.white.opacity(0.35))
+        Spacer()
+        Button("Start Working") { store.send(.workspaces(.starterDismissed)) }
+          .keyboardShortcut(.defaultAction)
+          .buttonStyle(.borderedProminent)
+      }
+      .padding(20)
+    }
+    .frame(width: 560, height: 560)
+  }
+
+  /// `OnboardingBackendPage`'s row, verbatim in its metrics — this is the same decision
+  /// in the same words, and it should be the same object. The one addition is the
+  /// "same as …" badge, which is what makes the preselection legible as a suggestion
+  /// rather than an arbitrary starting point.
+  private func row(_ backend: CLISessionBackendKind) -> some View {
+    let isSelected = store.workspaces.starterBackend == backend
+    return Button {
+      store.send(.workspaces(.starterBackendPicked(backend)))
+    } label: {
+      HStack(spacing: 13) {
+        Text(">_")
+          .font(.system(size: 13, weight: .medium, design: .monospaced))
+          .foregroundStyle(.white.opacity(0.6))
+          .frame(width: 30, height: 30)
+          .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 8))
+        VStack(alignment: .leading, spacing: 2) {
+          HStack(spacing: 7) {
+            Text(backend.displayName).font(.system(size: 13, weight: .semibold))
+            OnboardingBackendPage.capabilityBadge(backend)
+            if backend == suggested {
+              Text("SAME AS \(store.workspaces.current.name.uppercased())")
+                .font(.system(size: 9, weight: .bold))
+                .tracking(0.4)
+                .foregroundStyle(.white.opacity(0.6))
+                .padding(.vertical, 1)
+                .padding(.horizontal, 5)
+                .background(.white.opacity(0.09), in: RoundedRectangle(cornerRadius: 4))
+            }
+          }
+          Text(OnboardingBackendPage.blurb(backend))
+            .font(.system(size: 11.5))
+            .foregroundStyle(.white.opacity(0.55))
+        }
+        Spacer(minLength: 0)
+        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+          .foregroundStyle(isSelected ? Theme.paneFocusTint : .white.opacity(0.25))
+      }
+      .padding(.vertical, 13)
+      .padding(.horizontal, 15)
+      .background(
+        isSelected ? Theme.paneFocusTint.opacity(0.1) : Color.white.opacity(0.03),
+        in: RoundedRectangle(cornerRadius: 11)
+      )
+      .overlay {
+        RoundedRectangle(cornerRadius: 11)
+          .stroke(
+            isSelected ? Theme.paneFocusTint : .white.opacity(0.08),
+            lineWidth: isSelected ? 1.5 : 1)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+}

--- a/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
@@ -2,12 +2,15 @@ import ComposableArchitecture
 import GraphcodeKit
 import SwiftUI
 
-/// The list of workspaces, as menu items — the same contents whether it is reached from
-/// the sidebar's foot or from the File menu.
+/// The list of workspaces as menu items — what `File ▸ Workspace` shows.
 ///
 /// Picking one raises the instance that has it open, or launches one. Picking the current
 /// workspace does nothing, so the row stays selectable-looking rather than dimmed: a
 /// checkmark says which one you are in.
+///
+/// Rename and Delete are *not* here. They were two submenus of this submenu, which put
+/// deleting a workspace four levels down a menu; they live in Manage Workspaces… now,
+/// where both verbs are one click from the workspace they act on.
 struct WorkspaceMenuItems: View {
   @Bindable var store: StoreOf<AppFeature>
   /// Only the menu bar's copy carries them. The same items also render in the sidebar's
@@ -34,24 +37,8 @@ struct WorkspaceMenuItems: View {
     Divider()
     Button("New Workspace…") { store.send(.workspaces(.newRequested)) }
       .modifier(NewWorkspaceShortcut(isEnabled: showsShortcuts))
-    if !changeable.isEmpty {
-      Menu("Rename Workspace") {
-        ForEach(changeable) { workspace in
-          Button("\(workspace.name)…") { store.send(.workspaces(.renameRequested(workspace))) }
-        }
-      }
-      Menu("Delete Workspace") {
-        ForEach(changeable) { workspace in
-          Button("\(workspace.name)…") { store.send(.workspaces(.deleteRequested(workspace))) }
-        }
-      }
-    }
-  }
-
-  /// Never the default, and never the one this window is using — the two `Workspace`
-  /// refuses anyway. Offering them and then explaining why not is worse than not offering.
-  private var changeable: [Workspace] {
-    store.workspaces.known.filter { !$0.isDefault && $0.id != store.workspaces.current.id }
+    Button("Manage Workspaces…") { store.send(.workspaces(.manageRequested)) }
+      .disabled(store.workspaces.known.count < 2)
   }
 }
 
@@ -105,8 +92,8 @@ struct WorkspaceFooter: View {
 
   var body: some View {
     if store.workspaces.isWorthShowing {
-      Menu {
-        WorkspaceMenuItems(store: store)
+      Button {
+        store.send(.workspaces(.switcherPresented(true)))
       } label: {
         HStack(spacing: 6) {
           Image(systemName: "square.stack.3d.up")
@@ -118,12 +105,129 @@ struct WorkspaceFooter: View {
         }
         .contentShape(.rect)
       }
-      .menuStyle(.borderlessButton)
-      .menuIndicator(.hidden)
+      .buttonStyle(.plain)
       .font(.caption)
       .foregroundStyle(.secondary)
       .padding(.horizontal, 12)
       .padding(.vertical, 6)
+      .popover(
+        isPresented: Binding(
+          get: { store.workspaces.isSwitcherPresented },
+          set: { store.send(.workspaces(.switcherPresented($0))) }),
+        arrowEdge: .top
+      ) {
+        WorkspaceSwitcherPanel(store: store)
+      }
     }
+  }
+}
+
+/// The switcher itself — a panel rather than a menu, because a menu row cannot say what
+/// is *in* a workspace.
+///
+/// Which is the whole point of it: switching workspaces from a bare list of names is a
+/// guess, and the two facts that make it a decision — how much is in there, and whether a
+/// window already has it — are both cheap to read from outside (`Workspace.summary`).
+struct WorkspaceSwitcherPanel: View {
+  @Bindable var store: StoreOf<AppFeature>
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 1) {
+      ForEach(Array(store.workspaces.known.enumerated()), id: \.element.id) { index, workspace in
+        row(workspace, index: index)
+      }
+
+      Divider().padding(.vertical, 5).padding(.horizontal, 8)
+
+      action("New Workspace…", systemImage: "plus") {
+        store.send(.workspaces(.switcherPresented(false)))
+        store.send(.workspaces(.newRequested))
+      }
+      action("Manage Workspaces…", systemImage: "pencil") {
+        store.send(.workspaces(.switcherPresented(false)))
+        store.send(.workspaces(.manageRequested))
+      }
+      .disabled(store.workspaces.known.count < 2)
+    }
+    .padding(6)
+    .frame(width: 300)
+  }
+
+  private func row(_ workspace: Workspace, index: Int) -> some View {
+    let isCurrent = workspace.id == store.workspaces.current.id
+    let summary = store.workspaces.summaries[workspace.id]
+    return Button {
+      store.send(.workspaces(.switcherPresented(false)))
+      store.send(.workspaces(.switchRequested(workspace)))
+    } label: {
+      HStack(spacing: 9) {
+        Circle()
+          .fill(WorkspaceSwitcherPanel.tint(for: workspace))
+          .frame(width: 7, height: 7)
+        VStack(alignment: .leading, spacing: 1) {
+          Text(workspace.name).font(.system(size: 13))
+          Text(WorkspaceSwitcherPanel.subtitle(summary, isCurrent: isCurrent))
+            .font(.system(size: 10, design: .monospaced))
+            .foregroundStyle(.white.opacity(0.42))
+        }
+        Spacer(minLength: 8)
+        if index < 9 {
+          Text("⌥⌘\(index + 1)")
+            .font(.system(size: 10, design: .monospaced))
+            .foregroundStyle(.white.opacity(0.35))
+        }
+      }
+      .padding(.vertical, 6)
+      .padding(.horizontal, 8)
+      .background(
+        isCurrent ? Color.white.opacity(0.08) : .clear,
+        in: RoundedRectangle(cornerRadius: 6)
+      )
+      .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+  }
+
+  private func action(
+    _ title: String, systemImage: String, perform: @escaping () -> Void
+  ) -> some View {
+    Button(action: perform) {
+      HStack(spacing: 9) {
+        Image(systemName: systemImage)
+          .font(.system(size: 11))
+          .frame(width: 7)
+        Text(title).font(.system(size: 13))
+        Spacer(minLength: 0)
+      }
+      .padding(.vertical, 6)
+      .padding(.horizontal, 8)
+      .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+  }
+
+  /// A stable colour per workspace, so the dot is worth glancing at: the same workspace
+  /// keeps the same one across launches and across windows. Hashed from the slug rather
+  /// than assigned by position — a list that reorders must not repaint every dot.
+  static func tint(for workspace: Workspace) -> Color {
+    guard !workspace.isDefault else { return Theme.paneFocusTint }
+    let palette: [Color] = [
+      Color(red: 0.847, green: 0.651, blue: 0.341),
+      Color(red: 0.616, green: 0.545, blue: 0.847),
+      Color(red: 0.435, green: 0.827, blue: 0.671),
+      Color(red: 0.898, green: 0.541, blue: 0.494),
+      Color(red: 0.435, green: 0.702, blue: 0.898),
+    ]
+    let hash = workspace.slug.unicodeScalars.reduce(0) { ($0 &* 31 &+ Int($1.value)) & 0xffff }
+    return palette[hash % palette.count]
+  }
+
+  /// What the row says under the name. "not running" is the one worth naming outright:
+  /// switching to it means launching an instance, which takes a moment and a Dock tile.
+  static func subtitle(_ summary: Workspace.Summary?, isCurrent: Bool) -> String {
+    guard let summary else { return isCurrent ? "this window" : "—" }
+    let loops = "\(summary.loops) loop\(summary.loops == 1 ? "" : "s")"
+    if isCurrent { return "\(loops) · this window" }
+    return summary.isOpen ? "\(loops) · open" : "\(loops) · not running"
   }
 }

--- a/graphcode/Tests/OnboardingViewTests.swift
+++ b/graphcode/Tests/OnboardingViewTests.swift
@@ -13,10 +13,11 @@ import Testing
 @Suite
 struct OnboardingViewTests {
   @Test
-  func thereAreStillFourPages() {
-    // The edge lesson folded into the types page to make room for "How to read a loop".
-    // A fifth page is a different tour; a third is a page silently lost in a merge.
-    #expect(OnboardingView.pageCount == 4)
+  func thereAreStillFivePages() {
+    // Four until workspaces landed, which added "One window per line of work" ahead of
+    // the agent page. A sixth is a different tour; a fourth is a page silently lost in
+    // a merge.
+    #expect(OnboardingView.pageCount == 5)
   }
 
   @Test

--- a/graphcode/Tests/WorkspaceNewsTests.swift
+++ b/graphcode/Tests/WorkspaceNewsTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+
+@testable import graphcode
+
+/// Who gets told that workspaces exist.
+///
+/// The trap this pins: nothing before 0.1.46 recorded a version, so the *absence* of one
+/// means an old install, not a new one. Reading it the other way would show the news to
+/// every fresh install — on top of the tour page that already teaches it — and show it to
+/// nobody who actually needed it.
+@Suite
+struct WorkspaceNewsTests {
+  private func announces(
+    current: String = "0.1.46", lastRun: String?, hasSeenOnboarding: Bool
+  ) -> Bool {
+    WorkspaceNews.shouldAnnounce(
+      currentVersion: current, lastRunVersion: lastRun, hasSeenOnboarding: hasSeenOnboarding)
+  }
+
+  @Test
+  func someoneUpgradingFromBeforeWorkspacesIsTold() {
+    #expect(announces(lastRun: "0.1.45", hasSeenOnboarding: true))
+    #expect(announces(lastRun: "0.1.30-beta2", hasSeenOnboarding: true))
+    // The version key did not exist before this release, so an install with no record of
+    // its last run is an old one — which is exactly the audience.
+    #expect(announces(lastRun: nil, hasSeenOnboarding: true))
+    // Unparsable is treated the same way rather than swallowed.
+    #expect(announces(lastRun: "not-a-version", hasSeenOnboarding: true))
+  }
+
+  @Test
+  func aFreshInstallIsNotToldTwice() {
+    // It learns this from the tour's own page; the dialog as well would be the same
+    // lesson twice in one sitting.
+    #expect(!announces(lastRun: nil, hasSeenOnboarding: false))
+    #expect(!announces(lastRun: "0.1.45", hasSeenOnboarding: false))
+  }
+
+  @Test
+  func nobodyIsToldTwiceOnLaterLaunches() {
+    // Once this release has run, its version is recorded — every later launch is quiet.
+    #expect(!announces(lastRun: "0.1.46", hasSeenOnboarding: true))
+    #expect(!announces(lastRun: "0.1.46-beta5", hasSeenOnboarding: true))
+    #expect(!announces(current: "0.1.47", lastRun: "0.1.46", hasSeenOnboarding: true))
+  }
+
+  @Test
+  func abetaOfTheIntroducingReleaseCounts() {
+    // 0.1.46-beta1 sorts before 0.1.46 and is where workspaces actually shipped, so
+    // someone coming from 0.1.45 to a beta must still be told.
+    #expect(announces(current: "0.1.46-beta1", lastRun: "0.1.45", hasSeenOnboarding: true))
+    // …and someone already on a beta of it must not be told again on the stable.
+    #expect(!announces(current: "0.1.46", lastRun: "0.1.46-beta1", hasSeenOnboarding: true))
+  }
+
+  @Test
+  func theVersionIsRecordedWhicheverWayItIsAnswered() {
+    let defaults = UserDefaults(suiteName: "news-\(UUID().uuidString)")!
+    defaults.set(true, forKey: WorkspaceNews.hasSeenOnboardingKey)
+    defaults.set("0.1.45", forKey: WorkspaceNews.lastRunVersionKey)
+
+    #expect(WorkspaceNews.announceIfNeeded(currentVersion: "0.1.46", defaults: defaults))
+    #expect(defaults.string(forKey: WorkspaceNews.lastRunVersionKey) == "0.1.46")
+    // Asked once per machine however it was answered — including by ignoring it.
+    #expect(!WorkspaceNews.announceIfNeeded(currentVersion: "0.1.46", defaults: defaults))
+  }
+}

--- a/graphcode/Tests/WorkspaceStarterTests.swift
+++ b/graphcode/Tests/WorkspaceStarterTests.swift
@@ -1,0 +1,120 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// The one question a new workspace asks, and the switcher rows that say what is in each.
+@Suite
+struct WorkspaceStarterTests {
+  private func makeHome() -> URL {
+    let home = URL(fileURLWithPath: "/tmp")
+      .appendingPathComponent("gcs-\(UUID().uuidString.prefix(8))", isDirectory: true)
+    try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    return home
+  }
+
+  @Test
+  func aNewWorkspaceCarriesTheSuggestionOfTheOneThatMadeIt() throws {
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let workspace = try Workspace.create(name: "work", home: home)
+
+    #expect(WorkspaceStarter.pending(workspace) == nil)
+
+    WorkspaceStarter.invite(workspace, suggesting: .codex)
+    #expect(WorkspaceStarter.pending(workspace)?.suggestedBackend == .codex)
+
+    // Answered — by choosing or by skipping — and it does not come back.
+    WorkspaceStarter.clear(workspace)
+    #expect(WorkspaceStarter.pending(workspace) == nil)
+  }
+
+  @Test
+  func theDefaultWorkspaceIsNeverInvited() {
+    // It is configured by the tour, and an install upgrading into this feature must not
+    // be interrogated about a workspace it has been using for months.
+    WorkspaceStarter.invite(.default, suggesting: .codex)
+    #expect(WorkspaceStarter.pending(.default) == nil)
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: Workspace.default.url.appendingPathComponent("starter.json").path))
+  }
+
+  @Test
+  @MainActor
+  func pickingAnAgentAppliesItImmediatelyAndSkippingStillAnswers() async {
+    let applied = LockIsolated<[CLISessionBackendKind]>([])
+    let finished = LockIsolated(0)
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.workspaceClient.starterInvitation = {
+        WorkspaceStarter.Invitation(suggestedBackend: .copilotCLI)
+      }
+      $0.workspaceClient.applyDefaultBackend = { backend in
+        applied.withValue { $0.append(backend) }
+      }
+      $0.workspaceClient.finishStarter = { finished.withValue { $0 += 1 } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaces(.starterChecked))
+    // Preselected from the invitation, not from the built-in default.
+    #expect(store.state.workspaces.starterBackend == .copilotCLI)
+    #expect(store.state.workspaces.starter != nil)
+
+    await store.send(.workspaces(.starterBackendPicked(.codex)))
+    // Applied on the pick, like the tour's page — there is no Save on this dialog.
+    #expect(applied.value == [.codex])
+
+    await store.send(.workspaces(.starterDismissed))
+    #expect(store.state.workspaces.starter == nil)
+    #expect(finished.value == 1)
+  }
+
+  @Test
+  @MainActor
+  func aWorkspaceWithNoInvitationRaisesNothing() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.workspaceClient.starterInvitation = { nil }
+    }
+
+    // No state change at all: every workspace made before this shipped is treated as
+    // already answered.
+    await store.send(.workspaces(.starterChecked))
+  }
+
+  @Test
+  func aSwitcherRowSaysWhatIsInTheWorkspaceAndWhetherAWindowHasIt() {
+    let open = Workspace.Summary(projects: 2, loops: 7, isOpen: true)
+    let closed = Workspace.Summary(projects: 1, loops: 1, isOpen: false)
+
+    #expect(WorkspaceSwitcherPanel.subtitle(open, isCurrent: false) == "7 loops · open")
+    #expect(WorkspaceSwitcherPanel.subtitle(open, isCurrent: true) == "7 loops · this window")
+    // "not running" is worth naming: switching there launches an instance.
+    #expect(WorkspaceSwitcherPanel.subtitle(closed, isCurrent: false) == "1 loop · not running")
+    #expect(WorkspaceSwitcherPanel.subtitle(nil, isCurrent: true) == "this window")
+  }
+
+  @Test
+  func aWorkspacesDotKeepsItsColourWhenTheListReorders() {
+    // Hashed from the slug rather than assigned by position — a list that gains a
+    // workspace must not repaint every dot.
+    let work = Workspace(slug: "work", url: URL(fileURLWithPath: "/tmp/.graphcode-work"))
+    let same = Workspace(slug: "work", url: URL(fileURLWithPath: "/tmp/.graphcode-work"))
+    #expect(WorkspaceSwitcherPanel.tint(for: work) == WorkspaceSwitcherPanel.tint(for: same))
+    #expect(WorkspaceSwitcherPanel.tint(for: .default) == Theme.paneFocusTint)
+  }
+
+  @Test
+  func aRowThatCannotBeActedOnSaysWhyInThreeWords() {
+    // On the row, rather than as an alert after the click.
+    #expect(ManageWorkspacesView.reason(.isDefault(.delete)) == "the default")
+    #expect(ManageWorkspacesView.reason(.isCurrent(.rename)) == "this window")
+    #expect(ManageWorkspacesView.reason(.isOpen(pid: 42, .delete)) == "open elsewhere")
+  }
+}


### PR DESCRIPTION
Six changes, from reviewing what shipped beside the code that draws it. Designs: [Workspace Surfaces Review](https://claude.ai/code/artifact/6f2039d4-c881-4a82-8a40-f692038854fa).

## B · The New Workspace sheet

Three lines of caption above one text field — the largest thing in the dialog, read once, in the way forever. What someone needs before pressing Create is what they are about to get, so the explainer becomes a **diagram**: the second window, its title bar carrying **what is being typed**, beside three lines naming what is separate and what is shared. The path line stays, and no longer scolds a field you have not finished typing.

## C · The switcher, and where Rename/Delete live

A **panel, not a menu** — a menu row cannot say what is *in* a workspace. Each row carries its loop count and whether a window has it open (`Workspace.summary`, read from outside it), so switching is a decision rather than a guess, plus a colour dot hashed from the slug so it survives the list reordering.

**Rename and Delete** were two submenus of a submenu: four levels down to delete a workspace, and no way to see what you were deleting while deciding to. They collapse into **Manage Workspaces…**, where each row shows what it holds and both verbs sit on it. Rows that cannot be acted on say why in three words — *the default*, *this window*, *open elsewhere* — instead of raising an alert after the click.

## D · A new workspace asks which agent runs its loops

`settings.json` lives **inside** the support directory, so a new workspace starts on the built-in default however its creator has configured every other one — silently, until the first loop opens the wrong CLI.

The creating instance leaves an invitation naming the agent **it** uses; the new window asks once, preselected to that and badged `SAME AS DEFAULT`. Not `UserDefaults` — those are per *app*, and every workspace on the machine is the same app, so only a file in the workspace's own directory can say "this one has not been started yet". Skip counts as answered.

## E · The tour gains a page

*"One window per line of work"*, placed **before** the agent page so the tour still ends on a choice that configures something. Its closing line is deliberate: **"You do not need one yet — one workspace is the right number until it isn't."** On day one nobody has a crowding problem, and a tour that pushes a second workspace at someone with zero loops has taught them to make a mess.

## F · Everyone else gets told once

They finished the tour long ago; re-running it to deliver one piece of news would be worse than the news. Three lines, and the third is why the dialog exists: **"Nothing moved — everything you have is in the workspace called Default, exactly where it was."**

The gate has a trap in it, and the tests are mostly about that:

| Signal | Who | Shows |
|---|---|---|
| Tour not seen | Fresh install | The tour, including E |
| Tour seen, last run < 0.1.46 | Updating | F, once |
| Tour seen, **no** recorded version | An older install | F, once |

Nothing before this release recorded a version, so the absence of one means **old**, not new — read the other way it announces to every fresh install (on top of E) and to none of the people who needed it. Compared on the **release triple alone**: `AppVersion` sorts prereleases before their release, and workspaces shipped in `0.1.46-beta1`, so `0.1.46-betaN` must count as having them.

## One structural change

`AppView.body` could not hold the sheets — four of them plus a confirmation and an alert pushed it past what the SwiftUI type-checker will resolve, and the build failed outright with "unable to type-check this expression in reasonable time". They live in a `WorkspaceDialogs` modifier now, the same arrangement `UpdateDialogs` uses.

## Tests

**1019 passing**, `swift format lint --strict` clean. 11 new, over: the invitation round-trip and the default workspace never being invited; pick-applies-immediately and skip-still-answers; the switcher subtitles; the stable dot colour; the three-word refusals; and six on F's gate, including that a beta of the introducing release counts as already-told.

Two bugs the new tests caught before this shipped, both in F's gate — the part with no UI to notice it going wrong: the prerelease ordering above, and `AppVersion` having no memberwise initializer for my first attempt at the fix.

Also verified live during this work: a workspace is addressable from outside it — a message sent from Default reached a loop in `personal3` through that workspace's own daemon, with no window open there, and the loop replied back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)