### PR TITLE
fix: three reported workspace bugs — footer, backend, sheet hand-off

### DIFF
--- a/GraphcodeKit/Sources/GraphcodeSettingsStore.swift
+++ b/GraphcodeKit/Sources/GraphcodeSettingsStore.swift
@@ -25,6 +25,23 @@ public enum GraphcodeSettingsStore {
     return settings
   }
 
+  /// Changes one setting on disk, reading and writing in one step.
+  ///
+  /// Exists because the app's live `SettingsModel` is a singleton whose first touch in a
+  /// freshly launched instance may be the very effect trying to write through it — the
+  /// new-workspace starter's, which asks which agent runs this workspace's loops before
+  /// anything else has read a setting. Going straight to the file removes that ordering
+  /// from the answer: the pick lands whether or not anything has looked at settings yet,
+  /// and the caller syncs the live model afterwards.
+  @discardableResult
+  public static func setDefaultBackend(
+    _ backend: CLISessionBackendKind, to url: URL = GraphcodeSettingsStore.url
+  ) -> Bool {
+    var settings = load(from: url)
+    settings.defaultBackend = backend
+    return save(settings, to: url)
+  }
+
   @discardableResult
   public static func save(
     _ settings: GraphcodeSettings, to url: URL = GraphcodeSettingsStore.url

--- a/graphcode/Sources/Clients/WorkspaceClient.swift
+++ b/graphcode/Sources/Clients/WorkspaceClient.swift
@@ -96,7 +96,15 @@ extension WorkspaceClient: DependencyKey {
     },
     starterInvitation: { WorkspaceStarter.pending() },
     applyDefaultBackend: { backend in
-      await MainActor.run { SettingsModel.shared.settings.defaultBackend = backend }
+      // The file first, and unconditionally: this runs moments after a new workspace's
+      // window opens, when nothing has necessarily read a setting yet, and routing the
+      // write through the live model made the pick depend on that model already
+      // existing. Six workspaces were created with the starter answered and not one
+      // settings.json was written.
+      GraphcodeSettingsStore.setDefaultBackend(backend)
+      // Then the live model, so the Settings pane shows the choice and its next save
+      // does not write back over it — the lesson `OnboardingView` records.
+      await MainActor.run { SettingsModel.shared.settings = GraphcodeSettingsStore.load() }
     },
     finishStarter: { WorkspaceStarter.clear() },
     otherOpen: {

--- a/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
@@ -103,6 +103,11 @@ extension AppFeature {
     case starterBackendPicked(CLISessionBackendKind)
     case starterDismissed
     case renameRequested(Workspace)
+    /// The half that actually raises each sheet, sent once Manage has closed — see
+    /// `handOff`. Separate cases rather than a flag, so the order is visible in a test.
+    case newPresented
+    case renamePresented(Workspace)
+    case deletePresented(PendingDeletion)
     case renameDraftChanged(String)
     case renameConfirmed
     case renameCancelled
@@ -125,6 +130,27 @@ struct AppWorkspacesReducer: Reducer {
   @Dependency(\.workspaceClient) var workspaces
   @Dependency(\.updateClient) var updateClient
   @Dependency(\.openURL) var openURL
+  @Dependency(\.continuousClock) var clock
+
+  /// Closes Manage Workspaces, then raises the sheet the row asked for.
+  ///
+  /// A view presents one sheet at a time. Rename and Delete are rows *inside* Manage, so
+  /// flipping Manage off and the next sheet on in the same update left neither on screen:
+  /// Manage stayed put and nothing came up — the same trap `GraphOverviewView`'s form
+  /// hosts record, where a binding and its host changing together miss the transition.
+  ///
+  /// The wait is only paid when Manage is actually open, so the File menu and the
+  /// switcher still raise their sheets immediately.
+  private func handOff(
+    _ state: inout AppFeature.State, to action: AppFeature.Action
+  ) -> Effect<AppFeature.Action> {
+    let wasManaging = state.workspaces.isManaging
+    state.workspaces.isManaging = false
+    return .run { send in
+      if wasManaging { try? await clock.sleep(for: .milliseconds(280)) }
+      await send(action)
+    }
+  }
 
   var body: some Reducer<AppFeature.State, AppFeature.Action> {
     Reduce { state, action in
@@ -189,6 +215,9 @@ struct AppWorkspacesReducer: Reducer {
         return .run { [finish = workspaces.finishStarter] _ in finish() }
 
       case .workspaces(.newRequested):
+        return handOff(&state, to: .workspaces(.newPresented))
+
+      case .workspaces(.newPresented):
         state.workspaces.draftName = ""
         state.workspaces.problem = nil
         state.workspaces.isCreating = true
@@ -226,6 +255,9 @@ struct AppWorkspacesReducer: Reducer {
           state.workspaces.changeFailure = refusal.localizedDescription
           return .none
         }
+        return handOff(&state, to: .workspaces(.renamePresented(workspace)))
+
+      case .workspaces(.renamePresented(let workspace)):
         state.workspaces.renaming = workspace
         // Prefilled with the current name: renaming is usually a correction, not a
         // fresh start, and an empty field would make you retype what you had.
@@ -261,8 +293,15 @@ struct AppWorkspacesReducer: Reducer {
           state.workspaces.changeFailure = refusal.localizedDescription
           return .none
         }
-        state.workspaces.pendingDeletion = AppFeature.PendingDeletion(
-          workspace: workspace, contents: workspace.contents())
+        return handOff(
+          &state,
+          to: .workspaces(
+            .deletePresented(
+              AppFeature.PendingDeletion(
+                workspace: workspace, contents: workspace.contents()))))
+
+      case .workspaces(.deletePresented(let pending)):
+        state.workspaces.pendingDeletion = pending
         return .none
 
       case .workspaces(.deleteConfirmed):

--- a/graphcode/Sources/Features/Workspaces/ManageWorkspacesView.swift
+++ b/graphcode/Sources/Features/Workspaces/ManageWorkspacesView.swift
@@ -33,10 +33,9 @@ struct ManageWorkspacesView: View {
       }
 
       HStack {
-        Button("New Workspace…") {
-          store.send(.workspaces(.manageDismissed))
-          store.send(.workspaces(.newRequested))
-        }
+        // No manual dismiss: `newRequested` closes Manage and raises the sheet after
+        // it has gone, the same hand-off Rename and Delete use.
+        Button("New Workspace…") { store.send(.workspaces(.newRequested)) }
         Spacer()
         Button("Done") { store.send(.workspaces(.manageDismissed)) }
           .keyboardShortcut(.defaultAction)

--- a/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
@@ -92,10 +92,24 @@ struct WorkspaceFooter: View {
 
   var body: some View {
     if store.workspaces.isWorthShowing {
-      // The rule above it, full width: without one the row reads as one more project at
-      // the end of the list rather than as the thing the whole list belongs to.
-      Divider().overlay(.white.opacity(0.09))
+      VStack(spacing: 0) {
+        // The rule above it, full width: without one the row reads as one more project
+        // at the end of the list rather than as the thing the whole list belongs to.
+        Divider().overlay(.white.opacity(0.09))
 
+        row
+      }
+      // Opaque, and this is the whole bug it fixes: a `safeAreaInset` reserves space but
+      // paints nothing, so with more loops than fit, rows scrolled *under* the footer and
+      // straight through it — the workspace name and its icon sitting on top of moving
+      // text, both illegible. The bar material rather than a flat colour, so it belongs
+      // to the same glass the sidebar is made of.
+      .background(.bar)
+    }
+  }
+
+  private var row: some View {
+    Group {
       Button {
         store.send(.workspaces(.switcherPresented(true)))
       } label: {

--- a/graphcode/Tests/ManageWorkspacesHandOffTests.swift
+++ b/graphcode/Tests/ManageWorkspacesHandOffTests.swift
@@ -1,0 +1,106 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// Rename and Delete are rows inside Manage Workspaces, and a view presents one sheet at
+/// a time. Flipping Manage off and the next sheet on in the same update left neither on
+/// screen — Manage stayed put and nothing came up. Manage closes first now, and the sheet
+/// it hands to comes up once it has gone.
+@Suite
+struct ManageWorkspacesHandOffTests {
+  private func workspace(_ slug: String) -> Workspace {
+    Workspace(slug: slug, url: URL(fileURLWithPath: "/tmp/.graphcode-\(slug)"))
+  }
+
+  private func managing(_ workspaces: [Workspace]) -> AppFeature.State {
+    var state = AppFeature.State()
+    state.workspaces.known = [.default] + workspaces
+    state.workspaces.isManaging = true
+    return state
+  }
+
+  @Test
+  @MainActor
+  func renameClosesManageBeforeItsOwnSheetComesUp() async {
+    let work = workspace("work")
+    let clock = TestClock()
+    let store = TestStore(initialState: managing([work])) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaces(.renameRequested(work)))
+    // Manage is gone immediately; the rename sheet is not up yet — that is the whole
+    // point, and doing both at once is what broke it.
+    #expect(!store.state.workspaces.isManaging)
+    #expect(store.state.workspaces.renaming == nil)
+
+    await clock.advance(by: .milliseconds(280))
+    await store.receive(\.workspaces.renamePresented)
+    #expect(store.state.workspaces.renaming == work)
+    #expect(store.state.workspaces.renameDraft == "work")
+  }
+
+  @Test
+  @MainActor
+  func deleteClosesManageBeforeItsConfirmation() async {
+    let work = workspace("work")
+    let clock = TestClock()
+    let store = TestStore(initialState: managing([work])) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaces(.deleteRequested(work)))
+    #expect(!store.state.workspaces.isManaging)
+    #expect(store.state.workspaces.pendingDeletion == nil)
+
+    await clock.advance(by: .milliseconds(280))
+    await store.receive(\.workspaces.deletePresented)
+    #expect(store.state.workspaces.pendingDeletion?.workspace == work)
+  }
+
+  @Test
+  @MainActor
+  func aRefusedRowLeavesManageOpen() async {
+    // The reason is shown on the row, so there is nothing to hand off to — closing Manage
+    // would throw away the list someone is working through.
+    let clock = TestClock()
+    let store = TestStore(initialState: managing([])) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaces(.renameRequested(.default)))
+    #expect(store.state.workspaces.isManaging)
+    #expect(store.state.workspaces.changeFailure != nil)
+    #expect(store.state.workspaces.renaming == nil)
+  }
+
+  @Test
+  @MainActor
+  func withoutManageOpenTheSheetComesUpWithoutWaiting() async {
+    // The File menu and the switcher raise their sheets directly, and must not pay for a
+    // dismissal that is not happening.
+    let clock = TestClock()
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaces(.newRequested))
+    await store.receive(\.workspaces.newPresented)
+    #expect(store.state.workspaces.isCreating)
+  }
+}

--- a/graphcode/Tests/SettingsBackendWriteTests.swift
+++ b/graphcode/Tests/SettingsBackendWriteTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// Writing the default backend straight to a workspace's settings file.
+///
+/// The new-workspace starter asks which agent runs this workspace's loops moments after
+/// its window opens, and the write used to go through the app's live `SettingsModel` — a
+/// singleton whose first touch in a fresh instance was that very effect. Six workspaces
+/// were created with the starter answered and not one `settings.json` was written, so the
+/// write goes to the file directly now and the live model is synced from it afterwards.
+@Suite
+struct SettingsBackendWriteTests {
+  private func makeSettingsURL() -> URL {
+    let directory = URL(fileURLWithPath: "/tmp")
+      .appendingPathComponent("gcset-\(UUID().uuidString.prefix(8))", isDirectory: true)
+    try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory.appendingPathComponent("settings.json")
+  }
+
+  @Test
+  func thePickLandsOnAWorkspaceThatHasNoSettingsFileYet() throws {
+    // Which is every new workspace: it is made by `createDirectory` and nothing else.
+    let url = makeSettingsURL()
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+    #expect(!FileManager.default.fileExists(atPath: url.path))
+    #expect(GraphcodeSettingsStore.setDefaultBackend(.codex, to: url))
+    #expect(FileManager.default.fileExists(atPath: url.path))
+    #expect(GraphcodeSettingsStore.load(from: url).defaultBackend == .codex)
+  }
+
+  @Test
+  func everyBackendSurvivesTheRoundTrip() throws {
+    // Copilot and Codex are the two that were reported as not sticking; claudeCode is
+    // here so a coercion that quietly forced the default could not pass.
+    for backend in CLISessionBackendKind.allCases {
+      let url = makeSettingsURL()
+      defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+      GraphcodeSettingsStore.setDefaultBackend(backend, to: url)
+      #expect(GraphcodeSettingsStore.load(from: url).defaultBackend == backend)
+    }
+  }
+
+  @Test
+  func changingTheBackendLeavesEverySettingBesideItAlone() throws {
+    // It reads, changes one field and writes the whole file back, so anything already in
+    // there — a permission mode, a worktree policy — has to come through untouched.
+    let url = makeSettingsURL()
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+    var settings = GraphcodeSettings()
+    settings.sharesLoops = true
+    settings.showsActivityStrip = false
+    GraphcodeSettingsStore.save(settings, to: url)
+
+    GraphcodeSettingsStore.setDefaultBackend(.copilotCLI, to: url)
+
+    let reloaded = GraphcodeSettingsStore.load(from: url)
+    #expect(reloaded.defaultBackend == .copilotCLI)
+    #expect(reloaded.sharesLoops)
+    #expect(!reloaded.showsActivityStrip)
+  }
+
+  @Test
+  func aSecondPickReplacesTheFirst() throws {
+    // The starter applies on every tap, not on the button, so someone trying all three
+    // rows must end on the one they left selected.
+    let url = makeSettingsURL()
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+    GraphcodeSettingsStore.setDefaultBackend(.codex, to: url)
+    GraphcodeSettingsStore.setDefaultBackend(.copilotCLI, to: url)
+    #expect(GraphcodeSettingsStore.load(from: url).defaultBackend == .copilotCLI)
+  }
+}


### PR DESCRIPTION
Three bugs reported against beta6/beta7, all in the workspace surfaces.

## The footer was transparent

A `safeAreaInset` reserves space and paints nothing. Past the fold, project rows scrolled **under** the workspace row and straight through it — the name and its icon sitting on moving text, both illegible.

It carries the `.bar` material now: a material rather than a flat colour, so it stays part of the sidebar's glass instead of becoming a painted patch on it.

## The starter's pick never reached disk

Six workspaces were created with the starter answered (`starter.json` cleared in every one) and **not one `settings.json` was written** — so a new workspace went on using Claude Code however its creator had answered, both in Settings and for its first loop.

The write went through the app's live `SettingsModel`, a singleton whose *first touch* in a freshly launched instance was that very effect: the starter runs seconds after the window opens, before anything else has read a setting. It now writes to the file directly through `GraphcodeSettingsStore.setDefaultBackend`, then syncs the live model **from the file** — so the Settings pane shows the choice and its next save cannot write back over it, which is the lesson `OnboardingView` already records.

## Rename and Delete did nothing from Manage Workspaces

They are rows *inside* that sheet, and a view presents one sheet at a time. Flipping Manage off and the next sheet on in the same update left neither on screen: Manage stayed put, nothing came up.

Manage closes first now, and the sheet it hands to comes up once it has gone. Two details:

- The wait is paid **only when Manage is open** — the File menu and the switcher still raise their sheets immediately.
- A **refused row leaves Manage open**: the reason is already printed on the row, so closing the list someone is working through to show nothing would be worse than doing nothing.

Manage's own New Workspace… button was dismissing by hand and hitting the identical trap; it goes through the same hand-off.

## Tests

**1027 passing**, lint clean. 8 new:

- The backend write lands on a workspace with **no settings file yet** (which is every new workspace), all three backends survive a round trip, neighbouring settings are preserved, and a second pick replaces the first.
- The hand-off, on a `TestClock` so the ordering is asserted rather than slept through: Manage is gone **and** the sheet is not yet up, then the sheet arrives; a refused row leaves Manage open; and without Manage open nothing waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)