### PR TITLE
fix: deliver graphcoded's shutdown signals as dispatch work items

### DIFF
--- a/graphcoded/Sources/main.swift
+++ b/graphcoded/Sources/main.swift
@@ -84,14 +84,36 @@ FileHandle.standardOutput.write(Data("graphcoded: listening on \(path)\n".utf8))
 // process just never lived long enough to run it.
 signal(SIGPIPE, SIG_IGN)
 
-signal(SIGTERM) { _ in
-  unlink(path)
-  exit(0)
+// Termination is handled on the main queue, not in signal context (#167). The handlers
+// this replaces called `exit(0)` from inside the signal handler itself, and `exit` is
+// not async-signal-safe: it runs atexit and runtime teardown after interrupting whatever
+// thread happened to be running — which can be a thread mid-`malloc` or mid-`write`,
+// holding exactly the locks teardown needs. An idle daemon died cleanly in milliseconds
+// every time; a busy one could deadlock until launchd's ExitTimeOut escalated to
+// SIGKILL, observed as `launchctl bootout` taking ~29 seconds while a workspace was
+// being deleted. A dispatch signal source delivers the signal as an ordinary work item,
+// where `exit` is just a function call.
+//
+// `SIG_IGN` first, so the default terminate-without-cleanup disposition can't win the
+// race before the sources are resumed.
+signal(SIGTERM, SIG_IGN)
+signal(SIGINT, SIG_IGN)
+
+func makeShutdownSource(for signalNumber: Int32) -> DispatchSourceSignal {
+  let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .main)
+  source.setEventHandler {
+    unlink(path)
+    exit(0)
+  }
+  source.resume()
+  return source
 }
-signal(SIGINT) { _ in
-  unlink(path)
-  exit(0)
-}
+
+// Top-level lets, so the sources outlive this file's execution — a released source
+// stops delivering, and the signal falls back to the ignored disposition above, which
+// would make the daemon *unkillable* by SIGTERM instead of slow.
+let terminateSource = makeShutdownSource(for: SIGTERM)
+let interruptSource = makeShutdownSource(for: SIGINT)
 
 let registry = ProjectRegistry(persistenceDirectory: supportDirectory)
 


### PR DESCRIPTION
Closes #167 — whose title turned out wrong in an instructive way: the SIGTERM handler wasn't missing, it was **unsafe**.

## The actual defect

```swift
signal(SIGTERM) { _ in
  unlink(path)
  exit(0)
}
```

`exit` is not async-signal-safe. Called from signal-handler context it runs atexit and runtime teardown *after interrupting whatever thread happened to be running* — which can be a thread mid-`malloc` or mid-`write`, holding exactly the locks teardown needs. So:

| Daemon state at SIGTERM | Outcome |
|---|---|
| Idle | Clean exit in 0.03 s, every time — which is why this looked fine on any bench test |
| Busy | Deadlock in teardown → launchd waits out `ExitTimeOut` (~20 s) → SIGKILL |

The busy case is what the #166 action log recorded: `launchctl bootout` of a recently-active workspace daemon taking ~29 s during a workspace deletion.

## The fix

The signals are delivered as **dispatch work items** on the main queue (which `dispatchMain()` services), where `exit` is an ordinary function call. Two details that matter:

- `SIG_IGN` is set **before** the sources resume, so the default terminate-without-cleanup disposition can't win the race in between.
- The sources are top-level `let`s: a released source stops delivering, and with the disposition ignored that would make the daemon **unkillable** by SIGTERM instead of slow.

## Verification

Rebuilt daemon, isolated `GRAPHCODE_SUPPORT_DIR`: **0.03 s idle, 0.03 s under four concurrent CLI clients churning connections**, socket file cleaned both times. Stated honestly: the deadlock was timing-dependent, so the numbers alone prove little — the point is the mechanism is gone, not that the race got rarer.

Full suite: **1029 passing**.

## Note for the release

The *first* update onto a build with this fix still pays the old cost once — the daemon being replaced during the update is the old binary with the unsafe handler. Every shutdown after that is instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)