### PR TITLE
fix: the starter applies whatever is selected when it closes

### DIFF
--- a/GraphcodeKit/Sources/WorkspaceStarter.swift
+++ b/GraphcodeKit/Sources/WorkspaceStarter.swift
@@ -19,9 +19,12 @@ import Foundation
 public enum WorkspaceStarter {
   /// What the creating workspace passes on to the new one.
   public struct Invitation: Codable, Equatable, Sendable {
-    /// Preselected in the dialog. Not applied on its own: a workspace whose starter was
-    /// never answered keeps whatever `GraphcodeSettings` defaults to, so the suggestion
-    /// can never quietly become the setting.
+    /// Preselected in the dialog, and applied when the dialog closes with it still
+    /// selected. An earlier rule — "the suggestion can never quietly become the
+    /// setting" — applied it only on a tap, which made the preselection's checkmark a
+    /// lie: Start Working over the suggested row kept the built-in default. The one
+    /// case that keeps the old rule is a workspace whose starter never opened at all
+    /// (created before this shipped): no dialog, no suggestion, no write.
     public var suggestedBackend: CLISessionBackendKind
 
     public init(suggestedBackend: CLISessionBackendKind) {

--- a/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
@@ -235,10 +235,23 @@ struct AppWorkspacesReducer: Reducer {
         return .run { [apply = workspaces.applyDefaultBackend] _ in await apply(backend) }
 
       case .workspaces(.starterDismissed):
-        // Skip counts as answered: someone who dismissed this does not want it again on
-        // the next launch. Whatever is selected has already been applied.
+        // Every exit applies whatever is on screen — Start Working, Skip, and Escape
+        // alike — so the checkmark is never decoration. The version this replaced
+        // applied only on a *tap*: someone whose suggested agent was already the one
+        // they wanted pressed Start Working over a filled checkmark and got the
+        // built-in default instead, while tapping two rows in a row worked. A selected
+        // row plus the primary button is not "quietly": it is the answer.
+        //
+        // Skip counts as answered too: someone who dismissed this does not want it
+        // again on the next launch.
+        guard state.workspaces.starter != nil else { return .none }
         state.workspaces.starter = nil
-        return .run { [finish = workspaces.finishStarter] _ in finish() }
+        let backend = state.workspaces.starterBackend
+        return .run {
+          [apply = workspaces.applyDefaultBackend, finish = workspaces.finishStarter] _ in
+          await apply(backend)
+          finish()
+        }
 
       case .workspaces(.newRequested):
         // One update, no hand-off: the single `sheet(item:)` morphs `.manage` into

--- a/graphcode/Tests/WorkspaceStarterTests.swift
+++ b/graphcode/Tests/WorkspaceStarterTests.swift
@@ -72,6 +72,41 @@ struct WorkspaceStarterTests {
     await store.send(.workspaces(.starterDismissed))
     #expect(store.state.workspaces.starter == nil)
     #expect(finished.value == 1)
+    // Dismissal re-applies what is on screen — idempotent here, load-bearing in the
+    // untapped case below.
+    #expect(applied.value == [.codex, .codex])
+  }
+
+  @Test
+  @MainActor
+  func startWorkingOverThePreselectionAppliesIt() async {
+    // The reported bug: the starter opened with Copilot preselected — a filled
+    // checkmark — and Start Working was pressed with no tap. Nothing was written, and
+    // the workspace ran on the built-in default while Settings said Claude Code.
+    // Tapping two rows in a row worked, because only taps applied. The dialog's exit
+    // applies whatever is selected now, so the checkmark is the answer.
+    let applied = LockIsolated<[CLISessionBackendKind]>([])
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.workspaceClient.starterInvitation = {
+        WorkspaceStarter.Invitation(suggestedBackend: .copilotCLI)
+      }
+      $0.workspaceClient.applyDefaultBackend = { backend in
+        applied.withValue { $0.append(backend) }
+      }
+      $0.workspaceClient.finishStarter = {}
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaces(.starterChecked))
+    await store.send(.workspaces(.starterDismissed))
+    #expect(applied.value == [.copilotCLI])
+
+    // Answered is answered: a second dismissal (a late sheet callback, say) must not
+    // write again.
+    await store.send(.workspaces(.starterDismissed))
+    #expect(applied.value == [.copilotCLI])
   }
 
   @Test


### PR DESCRIPTION
Reported: create a workspace whose starter comes up with **Copilot preselected** — a filled checkmark — press **Start Working**, and Settings says Claude Code. Tap two rows in a row instead, and everything works.

## Root cause

The choice was applied only on a **tap** (`starterBackendPicked`). The dismissal handler's comment claimed *"whatever is selected has already been applied"* — true for tapped selections, false for the preselection. And the invitation's own doc made it deliberate: *"the suggestion can never quietly become the setting."* Defensible for a suggestion nobody looked at; wrong under a primary button beside a filled checkmark. A selected row plus Start Working is not *quietly* — it is the answer.

So: zero taps → zero writes → the workspace's `settings.json` never gained a backend → built-in Claude Code, while the dialog had shown Copilot checked.

## Fix

Every exit applies the on-screen selection — Start Working, Skip, and Escape alike — so **the checkmark is never decoration**. Taps still apply live (the Settings pane behind updates as you click); the exit re-applies idempotently; and answered is final — a late sheet callback cannot write twice. The one case keeping the old restraint: a workspace whose starter never opened (created before the starter shipped) — no dialog, no suggestion, no write.

## Tests

**1030 passing.** New: `startWorkingOverThePreselectionAppliesIt` — the exact repro (preselected Copilot, zero taps, Start Working → exactly one `applyDefaultBackend(.copilotCLI)`, and a second dismissal writes nothing). The pick-then-dismiss test now asserts the idempotent re-apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)