### PR TITLE
feat: OpenCode as a fourth backend

### DIFF
--- a/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
+++ b/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
@@ -92,7 +92,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
                            every interval instead of the prompt carrying /loop. Needs
                            "Daemon heartbeat" enabled in the app's Settings; the prompt
                            is then the bare task, no cadence in it
-      --backend <name>     claudeCode | copilotCLI | codex — default: run from inside a
+      --backend <name>     claudeCode | copilotCLI | codex | openCode — default: run from inside a
                            loop, the creating loop's backend; otherwise claudeCode
       --model <tier>       fast | standard | capable           (default: by loop type)
       --metric <cmd>       how the loop's performance is measured — fed into its prompt

--- a/GraphcodeKit/Sources/Domain/BackendCapabilities.swift
+++ b/GraphcodeKit/Sources/Domain/BackendCapabilities.swift
@@ -58,6 +58,7 @@ extension CLISessionBackendKind {
     case .claudeCode: return "Claude Code"
     case .copilotCLI: return "Copilot CLI"
     case .codex: return "Codex"
+    case .openCode: return "OpenCode"
     }
   }
 
@@ -136,6 +137,34 @@ extension CLISessionBackendKind {
         supportsMCP: true,
         supportsMidSessionInput: true,
         supportsInSessionRecurrence: false)
+
+    case .openCode:
+      // Spiked against OpenCode 1.18.21 — every entry read off `opencode --help` and its
+      // plugin SDK, and every uncertain one left false.
+      //
+      // `opencode [project] --prompt <text>` opens the TUI already running the prompt,
+      // which is graphcode's session model (`opencode run` is the headless shape it
+      // deliberately doesn't use). `--auto` is the unattended permission mode, `-m
+      // provider/model` picks a model, and `-s <id>` resumes. MCP is first-class
+      // (`opencode mcp`). It's a TUI in a PTY, so `zmx send` can type into it.
+      //
+      // `supportsHooks` is true and is the interesting row: OpenCode has no hook *flags*
+      // but a plugin API whose events cover both edges of a turn (`session.status`,
+      // `session.idle`), tool calls (`tool.execute.before`) and permission prompts
+      // (`permission.asked`). graphcode ships a plugin through `OPENCODE_CONFIG`, which
+      // merges over the user's own config rather than replacing it — verified in the
+      // source, not assumed (`PresenceHooks.openCodePlugin`).
+      //
+      // Sub-agents exist inside the TUI (`@agent` mentions) but not as anything a
+      // composite could lean on from outside, and there is no `/loop` equivalent.
+      return BackendCapabilities(
+        supportsGoalMode: true,
+        supportsHooks: true,
+        supportsStructuredOutput: false,
+        supportsSubAgents: false,
+        supportsMCP: true,
+        supportsMidSessionInput: true,
+        supportsInSessionRecurrence: false)
     }
   }
 
@@ -149,7 +178,7 @@ extension CLISessionBackendKind {
   /// (`GhosttyTerminalView.command`), so a loop labelled Codex opened a Claude Code
   /// session. Silently running a different agent than the one the picker says is worse
   /// than refusing, so this now gates every loop type.
-  /// All three, now that Codex has an adapter and a row read off its real CLI (issue #1).
+  /// All four, now that Codex and OpenCode have adapters and rows read off their real CLIs.
   /// Kept as a property rather than deleted: the *concept* is what stopped Codex being
   /// claimed as working for months, and the next backend added will need it again.
   public var isSpiked: Bool { true }

--- a/GraphcodeKit/Sources/Domain/BackendCommand.swift
+++ b/GraphcodeKit/Sources/Domain/BackendCommand.swift
@@ -16,6 +16,7 @@ extension CLISessionBackendKind {
     case .claudeCode: return "claude"
     case .copilotCLI: return "copilot"
     case .codex: return "codex"
+    case .openCode: return "opencode"
     }
   }
 
@@ -42,6 +43,11 @@ extension CLISessionBackendKind {
       // `-m` is real, but the valid model ids are not visible from `codex --help` and a
       // wrong one fails at launch. Passing nothing lets Codex's own default apply, which
       // is honest, where a guessed id would be a confident break.
+      return []
+    case .openCode:
+      // `-m` takes `provider/model`, and which providers a user has connected is theirs
+      // to know (`opencode auth list`), not something a tier can name. Passing nothing
+      // lets whatever `opencode` is configured to use apply.
       return []
     }
   }
@@ -108,6 +114,32 @@ extension CLISessionBackendKind {
       guard let briefingPath, let briefingDirectory else { return model + access + [prompt] }
       return model + access + ["--add-dir", briefingDirectory]
         + ["\(SessionBriefing.pointer(toBriefingAt: briefingPath)) \(prompt)"]
+    case .openCode:
+      // The prompt is the value of `--prompt`, the briefing a pointer inside it. No
+      // directory grant: OpenCode's `read` permission defaults to allow, and `--auto`
+      // approves everything not explicitly denied, so the briefing is readable as is.
+      guard let briefingPath else { return model + ["--prompt", prompt] }
+      return model
+        + ["--prompt", "\(SessionBriefing.pointer(toBriefingAt: briefingPath)) \(prompt)"]
+    }
+  }
+
+  /// The flag a backend's opening prompt rides behind, or `nil` for one that takes it
+  /// positionally. The app assembles a shell string rather than an argv and needs the
+  /// same answer `launchArguments` gives.
+  public var promptFlag: String? {
+    switch self {
+    case .claudeCode, .codex: return nil
+    case .copilotCLI: return "--interactive"
+    case .openCode: return "--prompt"
+    }
+  }
+
+  /// Whether a backend that verifies paths needs `--add-dir` for the briefing's folder.
+  public var briefingNeedsDirectoryGrant: Bool {
+    switch self {
+    case .claudeCode, .openCode: return false
+    case .copilotCLI, .codex: return true
     }
   }
 
@@ -136,6 +168,7 @@ extension CLISessionBackendKind {
     case .claudeCode: return settings.claudePermissionMode.arguments
     case .copilotCLI: return settings.copilotPermissions.arguments
     case .codex: return settings.codexApprovals.arguments
+    case .openCode: return settings.openCodePermissions.arguments
     }
   }
 
@@ -145,7 +178,32 @@ extension CLISessionBackendKind {
   /// (`GhosttyTerminalView.resumeCommand`) — so a backend gaining or losing resume
   /// support changes both paths together rather than one silently drifting.
   public var supportsResume: Bool {
-    self == .claudeCode || self == .copilotCLI
+    self == .claudeCode || self == .copilotCLI || self == .openCode
+  }
+
+  /// The argv that picks `sessionID` back up — `--resume` for Claude Code and Copilot,
+  /// `--session` for OpenCode, whose `--continue` would take the *last* session on the
+  /// machine rather than this loop's. Empty for a backend that can't resume.
+  public func resumeArguments(sessionID: String) -> [String] {
+    switch self {
+    case .claudeCode, .copilotCLI: return ["--resume", sessionID]
+    case .openCode: return ["--session", sessionID]
+    case .codex: return []
+    }
+  }
+
+  /// Environment a session needs for its reporting to reach graphcode — the fourth
+  /// shape of the `presenceArguments` problem. OpenCode takes no hook flag; its plugin
+  /// is named by a config file, and `OPENCODE_CONFIG` is the one route that *merges over*
+  /// the user's own config instead of replacing it (`OPENCODE_CONFIG_DIR` would drop
+  /// their providers and plugins on the floor — read off the config loader, not the docs).
+  public func presenceEnvironment(hooksFile: URL?) -> [String: String] {
+    switch self {
+    case .openCode:
+      return hooksFile.map { ["OPENCODE_CONFIG": $0.path] } ?? [:]
+    case .claudeCode, .copilotCLI, .codex:
+      return [:]
+    }
   }
 
   /// The argv that makes a backend's session observable — what graphcode adds so that
@@ -182,6 +240,10 @@ extension CLISessionBackendKind {
       // `zmx` path rather than a path to something graphcode wrote. Its other edge is
       // covered without asking Codex anything: see `ZmxSessionLauncher.codexPresence`.
       return zmxPath.map { ["-c", PresenceHooks.codexNotifyOverride(zmxPath: $0)] } ?? []
+    case .openCode:
+      // Reports through a plugin, which rides in the environment rather than the argv —
+      // see `presenceEnvironment`.
+      return []
     }
   }
 }

--- a/GraphcodeKit/Sources/Domain/CLISessionBackendKind.swift
+++ b/GraphcodeKit/Sources/Domain/CLISessionBackendKind.swift
@@ -1,5 +1,5 @@
 /// Which CLI coding-agent backend a `LoopNode` runs inside — see
-/// docs/04-cli-backends.md. All three are spiked and share the zmx-backed adapter
+/// docs/04-cli-backends.md. All four are spiked and share the zmx-backed adapter
 /// (`CLISessionBackend.zmxBacked`); what differs per backend is how a session can be
 /// asked what it is doing, which is why `presence` and `activity` are the two operations
 /// that switch on this and the rest are not.
@@ -11,4 +11,5 @@ public enum CLISessionBackendKind: String, Codable, CaseIterable, Sendable {
   case claudeCode
   case copilotCLI
   case codex
+  case openCode
 }

--- a/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
+++ b/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
@@ -204,6 +204,43 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
 
   public var codexApprovals: CodexApprovals
 
+  /// How much an OpenCode session may do without stopping to ask.
+  ///
+  /// One flag: `--auto` approves every permission not explicitly denied in the user's
+  /// own `opencode.json`, which is exactly the bargain an unattended loop needs — their
+  /// deny rules still hold, and nothing else stops to ask. OpenCode's own default asks
+  /// per tool, which leaves an unattended loop at a dialog nobody sees.
+  public enum OpenCodePermissions: String, Codable, CaseIterable, Sendable {
+    case ask
+    case auto
+
+    public var displayName: String {
+      switch self {
+      case .ask: return "Ask every time"
+      case .auto: return "Auto-approve (recommended)"
+      }
+    }
+
+    public var explanation: String {
+      switch self {
+      case .ask:
+        return "OpenCode's own default. An unattended loop will wait at the first prompt."
+      case .auto:
+        return "OpenCode's --auto: everything your own opencode.json doesn't deny is "
+          + "approved — what an unattended loop needs to run without a human at the pane."
+      }
+    }
+
+    public var arguments: [String] {
+      switch self {
+      case .ask: return []
+      case .auto: return ["--auto"]
+      }
+    }
+  }
+
+  public var openCodePermissions: OpenCodePermissions
+
   public var defaultBackend: CLISessionBackendKind {
     didSet {
       if !defaultBackend.isSpiked { defaultBackend = oldValue.isSpiked ? oldValue : .claudeCode }
@@ -320,6 +357,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
   public init(
     defaultBackend: CLISessionBackendKind = .claudeCode,
     codexApprovals: CodexApprovals = .workspace,
+    openCodePermissions: OpenCodePermissions = .auto,
     claudePermissionMode: ClaudePermissionMode = .auto,
     copilotPermissions: CopilotPermissions = .allowEverything,
     briefsSessionsAboutTheGraph: Bool = true,
@@ -333,6 +371,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
   ) {
     self.defaultBackend = defaultBackend.isSpiked ? defaultBackend : .claudeCode
     self.codexApprovals = codexApprovals
+    self.openCodePermissions = openCodePermissions
     self.claudePermissionMode = claudePermissionMode
     self.copilotPermissions = copilotPermissions
     self.briefsSessionsAboutTheGraph = briefsSessionsAboutTheGraph
@@ -356,6 +395,9 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     defaultBackend = storedBackend.isSpiked ? storedBackend : .claudeCode
     codexApprovals =
       try container.decodeIfPresent(CodexApprovals.self, forKey: .codexApprovals) ?? .workspace
+    openCodePermissions =
+      try container.decodeIfPresent(OpenCodePermissions.self, forKey: .openCodePermissions)
+      ?? .auto
     claudePermissionMode =
       try container.decodeIfPresent(ClaudePermissionMode.self, forKey: .claudePermissionMode)
       ?? .auto

--- a/GraphcodeKit/Sources/Sessions/CLISessionBackend.swift
+++ b/GraphcodeKit/Sources/Sessions/CLISessionBackend.swift
@@ -113,6 +113,10 @@ extension CLISessionBackend {
           return await CopilotSessionLog.presence(of: node, projectPath: projectPath)
         case .codex:
           return await ZmxSessionLauncher.codexPresence(of: node, projectPath: projectPath)
+        case .openCode:
+          // Its plugin writes the same labels Claude Code's hooks do, so the same reader
+          // serves both — see `OpenCodePresencePlugin`.
+          return await ZmxSessionLauncher.presence(of: node, projectPath: projectPath)
         }
       },
       usage: { node, projectPath in
@@ -130,6 +134,8 @@ extension CLISessionBackend {
           return await CopilotSessionLog.activity(of: node, projectPath: projectPath)
         case .codex:
           return await CodexSessionLog.activity(of: node, projectPath: projectPath)
+        case .openCode:
+          return await ZmxSessionLauncher.activity(of: node, projectPath: projectPath)
         }
       },
       // Every backend narrates before it acts, and all three write that narration to disk
@@ -154,6 +160,11 @@ extension CLISessionBackend {
           reading = await CopilotSessionLog.summary(of: node, projectPath: projectPath)
         case .codex:
           reading = await CodexSessionLog.summary(of: node, projectPath: projectPath)
+        case .openCode:
+          // OpenCode keeps its transcript in SQLite rather than a file to tail; nothing
+          // narrates a beat yet, and a nil reading leaves the card without a rail rather
+          // than with one that guesses.
+          reading = nil
         }
         // The optional second pass, which is the only part of this that costs anything.
         // Off, `applied` returns what it was given untouched.

--- a/GraphcodeKit/Sources/Sessions/OpenCodePresencePlugin.swift
+++ b/GraphcodeKit/Sources/Sessions/OpenCodePresencePlugin.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// The plugin an OpenCode session runs to report what it is doing — the fourth shape of
+/// the problem `PresenceHooks` solves for the other three backends.
+///
+/// OpenCode has no hook flags and no `notify` override; it has a plugin API whose events
+/// cover every edge the graph reads: `session.status`/`session.idle` for the turn,
+/// `tool.execute.before` for what the turn is doing, `permission.asked` for the one
+/// state the other backends can only infer, and `session.created` for the id a reboot
+/// resumes from. All of it writes into the same session-owned label store Claude Code's
+/// hooks write to, so `ZmxSessionLauncher.presence(of:)` and `.activity(of:)` read an
+/// OpenCode loop with no code of their own.
+///
+/// **Why a plugin and not the terminal stream.** OpenCode redraws its TUI continuously;
+/// scanning it for prompts would be the heuristic tier of docs/04-cli-backends.md, and
+/// the plugin is the reported one.
+///
+/// **Where it lands.** Written by `PresenceHooks.write(forBackend: .openCode)` beside the
+/// config file that names it, and delivered through `OPENCODE_CONFIG` — the one route
+/// that merges over the user's own config rather than replacing it. Guarded on
+/// `$ZMX_SESSION` so a session graphcode didn't start is a no-op, and every write is
+/// best-effort: a plugin that throws would surface as an error over the human's own turn.
+///
+/// Events verified against OpenCode 1.18.21 with a probe plugin, not read off the docs:
+/// `session.status` carries `{type: "busy" | "idle" | "retry"}`, `message.updated`
+/// carries the message's `role`, `tokens` and `time.completed`, and a sub-agent's session
+/// arrives with a `parentID` — which is why every reading is filtered to the session the
+/// loop itself opened, exactly as `SubagentStop` is left out of Claude Code's hooks.
+enum OpenCodePresencePlugin {
+  /// The plugin source, with the paths only this machine can know baked in.
+  static func source(zmxPath: String, sessionsDirectory: String) -> String {
+    """
+    // Written by graphcode. Reports what this session is doing, for its card in the graph.
+    import { spawnSync } from "node:child_process"
+    import { appendFileSync, mkdirSync, writeFileSync } from "node:fs"
+    import { join } from "node:path"
+
+    const ZMX = \(jsString(zmxPath))
+    const SESSIONS = \(jsString(sessionsDirectory))
+    const PREFIX = \(jsString(SurfaceRef.zmxSessionPrefix))
+
+    export const GraphcodePresence = async ({ directory }) => {
+      const session = process.env.ZMX_SESSION
+      if (!session || !session.startsWith(PREFIX)) return {}
+      const nodeID = session.slice(PREFIX.length)
+      const set = (...labels) => {
+        try { spawnSync(ZMX, ["set", session, ...labels], { stdio: "ignore" }) } catch {}
+      }
+      const encode = (phrase) =>
+        phrase.slice(0, 64).replace(/_/g, "_5F").replace(/[^A-Za-z0-9._-]+/g, " ").trim()
+          .replace(/ /g, "_20")
+      const leaf = (path) => String(path ?? "").split("/").filter(Boolean).pop() ?? ""
+      const phrase = (tool, args) => {
+        const a = args ?? {}
+        switch (tool) {
+          case "edit": case "write": case "patch": case "multiedit":
+            return a.filePath ? "editing " + leaf(a.filePath) : "editing files"
+          case "read": return a.filePath ? "reading " + leaf(a.filePath) : "reading"
+          case "bash": return a.command ? "running " + a.command : "running a command"
+          case "grep": return a.pattern ? "searching for " + a.pattern : "searching"
+          case "glob": return a.pattern ? "looking for " + a.pattern : "looking for files"
+          case "list": return a.path ? "listing " + leaf(a.path) : "listing files"
+          case "websearch": return a.query ? "searching the web for " + a.query : "searching the web"
+          case "webfetch": return a.url ? "reading " + String(a.url).replace(/^.*?\\/\\//, "").split("/")[0] : "reading a page"
+          case "task": return a.description ? "delegating " + a.description : "delegating"
+          case "skill": return a.name ? "running the " + a.name + " skill" : "running a skill"
+          case "todowrite": case "todoread": return "planning"
+          default: return "using " + tool.replace(/^.*_/, "")
+        }
+      }
+
+      let main = null
+      let input = 0
+      let output = 0
+      const counted = new Set()
+      const owns = (id) => main === null || id === main
+      const bank = (id) => {
+        try {
+          mkdirSync(SESSIONS, { recursive: true })
+          const stamp = Math.floor(Date.now() / 1000)
+          appendFileSync(join(SESSIONS, nodeID + ".history"), `${stamp} ${id} ${directory}\\n`)
+          writeFileSync(join(SESSIONS, nodeID + ".id"), id)
+        } catch {}
+      }
+
+      set("presence=idle", "activity=")
+      return {
+        event: async ({ event }) => {
+          const p = event.properties ?? {}
+          switch (event.type) {
+            case "session.created":
+              if (p.info?.parentID) return
+              if (main === null) { main = p.info?.id ?? p.sessionID ?? null; if (main) bank(main) }
+              set("presence=busy")
+              return
+            case "session.status":
+              if (!owns(p.sessionID)) return
+              if (p.status?.type === "idle") set("presence=idle", "activity=")
+              else set("presence=busy")
+              return
+            case "session.idle":
+              if (owns(p.sessionID)) set("presence=idle", "activity=")
+              return
+            case "permission.asked":
+              if (owns(p.sessionID)) set("presence=awaitingInput")
+              return
+            case "permission.replied":
+              if (owns(p.sessionID)) set("presence=busy")
+              return
+            case "message.updated": {
+              const info = p.info ?? {}
+              if (!owns(info.sessionID ?? p.sessionID)) return
+              if (info.role === "user") { set("presence=busy"); return }
+              if (info.role !== "assistant" || !info.time?.completed || counted.has(info.id)) return
+              counted.add(info.id)
+              const t = info.tokens ?? {}
+              input += (t.input ?? 0) + (t.cache?.read ?? 0) + (t.cache?.write ?? 0)
+              output += (t.output ?? 0) + (t.reasoning ?? 0)
+              if (input + output > 0) set(`usage=input.${input}_output.${output}`)
+              return
+            }
+            default:
+              return
+          }
+        },
+        "tool.execute.before": async (input, output) => {
+          if (!owns(input.sessionID)) return
+          if (input.tool === "question") { set("presence=awaitingInput"); return }
+          set("presence=busy", "activity=" + encode(phrase(input.tool, output.args)))
+        },
+        "tool.execute.after": async (input) => {
+          if (owns(input.sessionID) && input.tool === "question") set("presence=busy")
+        },
+      }
+    }
+    """
+  }
+
+  /// The config OpenCode is pointed at through `OPENCODE_CONFIG`: nothing but the plugin,
+  /// so it adds to whatever the user configured and overrides none of it.
+  static func config(pluginPath: String) -> String {
+    "{\"plugin\": [\(jsString(pluginPath))]}"
+  }
+
+  /// A JSON string literal, which is also a JS one. A path containing a quote or a
+  /// backslash is a path, not a syntax error.
+  static func jsString(_ value: String) -> String {
+    let data =
+      (try? JSONSerialization.data(withJSONObject: [value], options: .withoutEscapingSlashes))
+      ?? Data()
+    let array = String(decoding: data, as: UTF8.self)
+    return String(array.dropFirst().dropLast())
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
+++ b/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
@@ -28,6 +28,12 @@ public enum PresenceHooks {
     directory.appendingPathComponent("\(backend.rawValue).json")
   }
 
+  /// OpenCode's reporter, a plugin rather than a hook script, kept beside the config
+  /// that names it — see `OpenCodePresencePlugin`.
+  public static var openCodePluginFile: URL {
+    directory.appendingPathComponent("opencode-presence.js")
+  }
+
   /// The `PreToolUse` reporter, kept as a file next to the settings that name it: it is a
   /// dozen lines of `case` and `sed`, and `zmx` types a launch command into a tty capped
   /// at `MAX_CANON` — the same reason the settings themselves travel by path.
@@ -63,7 +69,9 @@ public enum PresenceHooks {
         ("Stop", .idle),
         ("SessionEnd", .absent),
       ]
-    case .copilotCLI, .codex:
+    case .copilotCLI, .codex, .openCode:
+      // OpenCode reports through a plugin, not through a hooks table — see
+      // `OpenCodePresencePlugin`.
       return nil
     }
   }
@@ -298,6 +306,9 @@ public enum PresenceHooks {
     sessionsDirectory: String? = nil, activityScriptPath: String? = nil,
     usageScriptPath: String? = nil
   ) -> String? {
+    if backend == .openCode {
+      return OpenCodePresencePlugin.config(pluginPath: openCodePluginFile.path)
+    }
     guard let events = events(forBackend: backend) else { return nil }
     let sessions = sessionsDirectory ?? localSessionsExpression
     let script = activityScriptPath ?? localActivityScriptExpression
@@ -346,6 +357,13 @@ public enum PresenceHooks {
         .write(to: activityScriptFile, atomically: true, encoding: .utf8)
       try? usageScript(zmxPath: ZmxLocator.binaryURL.path)
         .write(to: usageScriptFile, atomically: true, encoding: .utf8)
+      if backend == .openCode {
+        // Not best-effort: the config names this file, and OpenCode reports a plugin it
+        // cannot load as an error in the session. No plugin means no config.
+        try OpenCodePresencePlugin.source(
+          zmxPath: ZmxLocator.binaryURL.path, sessionsDirectory: SessionIDStore.directory.path
+        ).write(to: openCodePluginFile, atomically: true, encoding: .utf8)
+      }
       try json.write(to: url, atomically: true, encoding: .utf8)
       return url
     } catch {

--- a/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
@@ -180,7 +180,7 @@ public enum RemoteGraphAccess {
       --predicate <cmd>      optional stop condition for --type goal (exit 0 = met)
       --prompt <text>        required for --type time or turn; a time loop's cadence
                              goes inside it (/loop 1h ...)
-      --backend <name>       claudeCode | copilotCLI | codex
+      --backend <name>       claudeCode | copilotCLI | codex | openCode
       --model <tier>         fast | standard | capable
       --metric <cmd>         performance measure; last stdout line must be a number
       --direction <d>        minimize | maximize (default: maximize)
@@ -409,7 +409,7 @@ public enum RemoteGraphAccess {
                 goal["metricCommand"] = flags["metric"]
             draft["goal"] = goal
         if flags.get("backend"):
-            if flags["backend"] not in ("claudeCode", "copilotCLI", "codex"):
+            if flags["backend"] not in ("claudeCode", "copilotCLI", "codex", "openCode"):
                 fail("invalid value for --backend: %s" % flags["backend"])
             draft["backend"] = flags["backend"]
         if flags.get("model"):

--- a/GraphcodeKit/Sources/Sessions/SessionTransplant.swift
+++ b/GraphcodeKit/Sources/Sessions/SessionTransplant.swift
@@ -82,6 +82,13 @@ public enum SessionTransplant {
         backend: .codex, sessionID: url.lastPathComponent,
         sourceWorkingDirectory: workingDirectory,
         files: ["rollout.jsonl": rollout])
+
+    case .openCode:
+      // OpenCode's conversations live in one SQLite database shared by every session on
+      // the machine, not in a file per session that can be lifted out. Its own
+      // `opencode export` could produce one, but nothing imports it back into a *fresh*
+      // identity, so an exported OpenCode loop starts fresh — as every Codex one does.
+      return nil
     }
   }
 
@@ -113,6 +120,7 @@ public enum SessionTransplant {
     case .claudeCode: return restoreClaude(artifact, forNodeID: nodeID, projectPath: projectPath)
     case .copilotCLI: return restoreCopilot(artifact, forNodeID: nodeID)
     case .codex: return restoreCodex(artifact, projectPath: projectPath)
+    case .openCode: return nil
     }
   }
 

--- a/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
@@ -85,6 +85,8 @@ public enum SummaryModelWriter {
       return ["copilot", "-p", prompt] + model
     case .codex:
       return ["codex", "exec", prompt] + model
+    case .openCode:
+      return ["opencode", "run", prompt] + model
     }
   }
 

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -553,7 +553,8 @@ public enum ZmxSessionLauncher {
       ]
       + Self.loginShellInvocation(
         of: executable, arguments: arguments,
-        environment: Self.environment(forBackend: node.backend, briefingPath: briefingPath),
+        environment: Self.environment(
+          forBackend: node.backend, briefingPath: briefingPath, hooksFile: hooksFile),
         scriptSuffix: remoteHooksSuffix)
 
     // `zmx` types this command into the session's shell, and a tty in canonical mode
@@ -674,12 +675,15 @@ public enum ZmxSessionLauncher {
         hooksFile: hooksFile,
         sessionName: sessionName,
         zmxPath: reportingPath)
-      + ["--resume", sessionID]
+      + node.backend.resumeArguments(sessionID: sessionID)
     return [
       "run", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName, "-d",
     ]
       + Self.loginShellInvocation(
-        of: executable, arguments: resumeArgs, scriptSuffix: remoteHooksSuffix)
+        of: executable, arguments: resumeArgs,
+        environment: Self.environment(
+          forBackend: node.backend, briefingPath: nil, hooksFile: hooksFile),
+        scriptSuffix: remoteHooksSuffix)
   }
 
   /// Stands in for a remote session ID that this machine cannot know: the ID was written
@@ -714,14 +718,14 @@ public enum ZmxSessionLauncher {
     return paths
   }
 
-  /// Environment a session needs beyond what its shell provides. Nothing does, currently —
-  /// Copilot's briefing rides on its argv (see `CLISessionBackendKind.launchArguments`)
-  /// after the documented environment route turned out not to work. Kept because the
-  /// plumbing is the awkward part and the next backend will want it.
-  static func environment(forBackend backend: CLISessionBackendKind, briefingPath: String?)
-    -> [String: String]
-  {
-    [:]
+  /// Environment a session needs beyond what its shell provides. Copilot's briefing rides
+  /// on its argv (see `CLISessionBackendKind.launchArguments`) after the documented
+  /// environment route turned out not to work; OpenCode's presence plugin is the one
+  /// thing that genuinely has to travel this way (`presenceEnvironment`).
+  static func environment(
+    forBackend backend: CLISessionBackendKind, briefingPath: String?, hooksFile: URL? = nil
+  ) -> [String: String] {
+    backend.presenceEnvironment(hooksFile: hooksFile)
   }
 
   /// Whether the assembled command survives being typed into a terminal. Budgeted well

--- a/docs/index.html
+++ b/docs/index.html
@@ -402,7 +402,7 @@ description: Graph engineering for coding agents on macOS — loops connected on
   <div class="stats-grid">
     <div class="stat"><div class="stat-num">10+</div><div class="stat-desc">parallel live sessions, one canvas</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-desc">files written inside your project folder</div></div>
-    <div class="stat"><div class="stat-num">3</div><div class="stat-desc">backends: Claude Code, Copilot, Codex</div></div>
+    <div class="stat"><div class="stat-num">4</div><div class="stat-desc">backends: Claude Code, Copilot, Codex, OpenCode</div></div>
     <div class="stat"><div class="stat-num">∞</div><div class="stat-desc">reboots survived — sessions outlive the app</div></div>
   </div>
 </section>

--- a/graphcode/Sources/Clients/TitleSuggestionClient.swift
+++ b/graphcode/Sources/Clients/TitleSuggestionClient.swift
@@ -85,6 +85,7 @@ extension TitleSuggestionClient: DependencyKey {
     case .claudeCode: command = "exec claude -p \"$\(promptVariable)\""
     case .copilotCLI: command = "exec copilot -p \"$\(promptVariable)\""
     case .codex: command = "exec codex exec \"$\(promptVariable)\""
+    case .openCode: command = "exec opencode run \"$\(promptVariable)\""
     }
     return ["/bin/zsh", "-i", "-l", "-c", command]
   }

--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -75,6 +75,16 @@ struct SettingsView: View {
           .font(.caption2)
           .foregroundStyle(.secondary)
           .fixedSize(horizontal: false, vertical: true)
+
+        Picker("OpenCode", selection: $model.settings.openCodePermissions) {
+          ForEach(GraphcodeSettings.OpenCodePermissions.allCases, id: \.self) { mode in
+            Text(mode.displayName).tag(mode)
+          }
+        }
+        Text(model.settings.openCodePermissions.explanation)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
       } header: {
         Text("Permissions")
       } footer: {

--- a/graphcode/Sources/Features/Welcome/OnboardingPages.swift
+++ b/graphcode/Sources/Features/Welcome/OnboardingPages.swift
@@ -348,6 +348,7 @@ struct OnboardingBackendPage: View {
     case .claudeCode: return "Anthropic's agent — the reference backend, fully wired."
     case .copilotCLI: return "GitHub's agent CLI."
     case .codex: return "OpenAI's agent CLI."
+    case .openCode: return "The open-source agent CLI — any model provider."
     }
   }
 

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
@@ -252,7 +252,8 @@ extension GhosttyTerminalView {
     .joined(separator: " ")
     if !presence.isEmpty { parts.append(presence) }
     if let remoteSettingsPath { parts.append("--settings \"\(remoteSettingsPath)\"") }
-    parts.append("--resume \"$\(ZmxSessionLauncher.remoteResumeIDVariable)\"")
+    parts += backend.resumeArguments(
+      sessionID: "\"$\(ZmxSessionLauncher.remoteResumeIDVariable)\"")
     return Self.interactiveLoginShell(parts)
   }
 

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -91,7 +91,8 @@ struct GhosttyTerminalView: NSViewRepresentable {
       return GhosttyTerminalNSView(
         command: command(briefingPath: briefingPath),
         workingDirectory: effectiveWorkingDirectory,
-        environment: sessionEnvironment(briefingPath: briefingPath))
+        environment: sessionEnvironment(
+          briefingPath: briefingPath, hooksFile: presenceHooksFile()))
     }
     apply(to: view)
     host.adopt(view)
@@ -186,15 +187,14 @@ struct GhosttyTerminalView: NSViewRepresentable {
     // here: this whole string is the remote zsh's `-c` script, and that shell's own
     // tilde expansion is the only thing that knows the remote home directory.
     if let briefingPath {
-      switch backend {
-      case .claudeCode:
+      if backend == .claudeCode {
         parts.append("--append-system-prompt-file \(briefingPath)")
-      case .copilotCLI, .codex:
+      } else if backend.briefingNeedsDirectoryGrant {
         parts.append("--add-dir \((briefingPath as NSString).deletingLastPathComponent)")
       }
     }
     if !prompt.isEmpty {
-      if backend == .copilotCLI { parts.append("--interactive") }
+      if let flag = backend.promptFlag { parts.append(flag) }
       parts.append(prompt)
     }
     return Self.interactiveLoginShell(parts)
@@ -265,12 +265,14 @@ struct GhosttyTerminalView: NSViewRepresentable {
   /// than on the command line because the pointer is prose — inside `"$VAR"` it needs no
   /// quoting and cannot break the shell string the command is joined into. Claude's
   /// prompt stays untouched: its briefing arrives via `--append-system-prompt-file`.
-  func sessionEnvironment(briefingPath: String?) -> [String: String] {
-    guard var prompt = initialPrompt else { return [:] }
+  func sessionEnvironment(briefingPath: String?, hooksFile: URL? = nil) -> [String: String] {
+    var environment = backend.presenceEnvironment(hooksFile: hooksFile)
+    guard var prompt = initialPrompt else { return environment }
     if backend != .claudeCode, let briefingPath {
       prompt = "\(SessionBriefing.pointer(toBriefingAt: briefingPath)) \(prompt)"
     }
-    return [Self.promptVariable: prompt]
+    environment[Self.promptVariable] = prompt
+    return environment
   }
 
   private func command(briefingPath: String?) -> [String] {

--- a/graphcode/Tests/GraphcodeSettingsTests.swift
+++ b/graphcode/Tests/GraphcodeSettingsTests.swift
@@ -105,7 +105,7 @@ struct GraphcodeSettingsTests {
     // Codex was withheld while it had no adapter — making it the default would have set
     // every new loop to something that never starts. It has one now (issue #1).
     #expect(
-      CLISessionBackendKind.offerableAsDefault == [.claudeCode, .copilotCLI, .codex])
+      CLISessionBackendKind.offerableAsDefault == [.claudeCode, .copilotCLI, .codex, .openCode])
     #expect(GraphcodeSettings(defaultBackend: .codex).defaultBackend == .codex)
   }
 

--- a/graphcode/Tests/NodeDraftTests.swift
+++ b/graphcode/Tests/NodeDraftTests.swift
@@ -219,13 +219,16 @@ struct NodeDraftTests {
 
   @Test
   func theHostingMatrixMatchesTheSpikedCapabilities() {
-    // All three can host the two types that need nothing of the agent beyond a session:
+    // All four can host the two types that need nothing of the agent beyond a session:
     // a turn-based loop is judged by a human, and a goal's predicate is polled by the
     // daemon from outside.
-    #expect(CLISessionBackendKind.hosting(.turnBased) == [.claudeCode, .copilotCLI, .codex])
-    #expect(CLISessionBackendKind.hosting(.goalBased) == [.claudeCode, .copilotCLI, .codex])
+    #expect(
+      CLISessionBackendKind.hosting(.turnBased) == [.claudeCode, .copilotCLI, .codex, .openCode])
+    #expect(
+      CLISessionBackendKind.hosting(.goalBased) == [.claudeCode, .copilotCLI, .codex, .openCode])
     // Time-based needs the session to re-trigger itself, since graphcode holds no timer.
-    // Copilot gained that; Codex has no `/loop` equivalent in its CLI surface.
+    // Copilot gained that; Codex and OpenCode have no `/loop` equivalent in their CLI
+    // surfaces.
     #expect(CLISessionBackendKind.hosting(.timeBased) == [.claudeCode, .copilotCLI])
     // A composite still needs sub-agent fan-out, which only Claude Code has been shown
     // to do.

--- a/graphcode/Tests/OpenCodeBackendTests.swift
+++ b/graphcode/Tests/OpenCodeBackendTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// OpenCode as a real backend, spiked against 1.18.21.
+///
+/// Every flag asserted here was read off the installed `opencode --help`, and every
+/// plugin event off a probe plugin run against the real binary, not off the docs. The
+/// shape that matters: `opencode` takes its prompt as the value of `--prompt`, resumes
+/// with `--session`, and reports through a plugin that arrives in the *environment*
+/// (`OPENCODE_CONFIG`) rather than on the argv — the fourth answer to the question
+/// `presenceArguments` asks.
+@Suite
+struct OpenCodeBackendTests {
+  private func node(_ loopType: LoopType = .goalBased, tier: ModelTier? = nil) -> LoopNode {
+    LoopNode(
+      title: "Ship it",
+      loopType: loopType,
+      goal: GoalSpec(summary: "Tests pass"),
+      backend: .openCode,
+      modelTier: tier)
+  }
+
+  @Test
+  func theSessionRunsOpenCodeNotClaude() {
+    let arguments = ZmxSessionLauncher.arguments(forNode: node()) ?? []
+
+    // With a plugin to hand over the line is `exec env OPENCODE_CONFIG=… opencode "$@"`,
+    // and without one it is bare; either way it ends in the agent.
+    #expect(arguments.contains(where: { $0.hasSuffix(#"opencode "$@""#) }))
+    #expect(!arguments.contains(where: { $0.contains("claude ") }))
+  }
+
+  @Test
+  func thePromptRidesBehindItsOwnFlag() {
+    // `--prompt <text>` opens the TUI already running the prompt — an attachable
+    // session, unlike `opencode run`, which exits when the work is done.
+    let arguments = ZmxSessionLauncher.arguments(forNode: node()) ?? []
+
+    let flagIndex = try? #require(arguments.firstIndex(of: "--prompt"))
+    #expect(flagIndex != nil)
+    if let flagIndex {
+      #expect(arguments[flagIndex + 1].contains("Tests pass"))
+      #expect(arguments.index(after: flagIndex) == arguments.index(before: arguments.endIndex))
+    }
+    #expect(!arguments.contains("--interactive"))
+  }
+
+  @Test
+  func theUnattendedDefaultIsAuto() {
+    // `--auto` approves everything the user's own `opencode.json` doesn't deny. Without
+    // it OpenCode asks per tool, and an unattended loop sits at that dialog reported as
+    // running.
+    let arguments = CLISessionBackendKind.openCode.launchArguments(
+      prompt: "go", tier: .standard, settings: GraphcodeSettings())
+    #expect(arguments.contains("--auto"))
+
+    let asking = CLISessionBackendKind.openCode.launchArguments(
+      prompt: "go", tier: .standard, settings: GraphcodeSettings(openCodePermissions: .ask))
+    #expect(!asking.contains("--auto"))
+  }
+
+  @Test
+  func noTierNamesAModelBecauseTheProviderIsTheUsers() {
+    // `-m` takes `provider/model`, and which providers are connected is a fact about the
+    // user's `opencode auth`, not about a tier. A guessed one fails at launch.
+    for tier in ModelTier.allCases {
+      #expect(CLISessionBackendKind.openCode.modelArguments(for: tier).isEmpty)
+    }
+  }
+
+  @Test
+  func theBriefingIsAPointerInThePromptAndNeedsNoDirectoryGrant() {
+    let arguments = CLISessionBackendKind.openCode.launchArguments(
+      prompt: "go", tier: .standard, briefingPath: "/Users/x/.graphcode/briefings/b.md",
+      workspacePaths: ["/work"])
+
+    #expect(!arguments.contains("--add-dir"))
+    let flagIndex = try? #require(arguments.firstIndex(of: "--prompt"))
+    if let flagIndex {
+      #expect(arguments[flagIndex + 1].contains("/Users/x/.graphcode/briefings/b.md"))
+      #expect(arguments[flagIndex + 1].hasSuffix(" go"))
+    }
+    #expect(CLISessionBackendKind.openCode.promptFlag == "--prompt")
+    #expect(!CLISessionBackendKind.openCode.briefingNeedsDirectoryGrant)
+  }
+
+  @Test
+  func thePluginArrivesThroughTheEnvironmentNotTheArgv() {
+    let hooks = URL(fileURLWithPath: "/Users/x/.graphcode/hooks/openCode.json")
+
+    #expect(
+      CLISessionBackendKind.openCode.presenceArguments(hooksFile: hooks, sessionName: "s").isEmpty)
+    #expect(
+      CLISessionBackendKind.openCode.presenceEnvironment(hooksFile: hooks)
+        == ["OPENCODE_CONFIG": hooks.path])
+    #expect(CLISessionBackendKind.openCode.presenceEnvironment(hooksFile: nil).isEmpty)
+    // Nobody else uses the environment for this.
+    #expect(CLISessionBackendKind.claudeCode.presenceEnvironment(hooksFile: hooks).isEmpty)
+  }
+
+  @Test
+  func resumeUsesSessionNotContinue() {
+    // `--continue` would take the *last* session on the machine, which with several
+    // loops running is somebody else's conversation.
+    #expect(
+      CLISessionBackendKind.openCode.resumeArguments(sessionID: "ses_1") == ["--session", "ses_1"])
+    #expect(CLISessionBackendKind.openCode.supportsResume)
+    #expect(
+      CLISessionBackendKind.claudeCode.resumeArguments(sessionID: "abc") == ["--resume", "abc"])
+    #expect(CLISessionBackendKind.codex.resumeArguments(sessionID: "abc").isEmpty)
+  }
+
+  @Test
+  func theConfigNamesOnlyThePlugin() {
+    // `OPENCODE_CONFIG` merges over the user's own config, and this must add exactly one
+    // thing to it. A config carrying anything else would silently override theirs.
+    let json = PresenceHooks.json(forBackend: .openCode, zmxPath: "/usr/local/bin/zmx") ?? ""
+    let object = try? JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+
+    #expect(object?.keys.sorted() == ["plugin"])
+    #expect((object?["plugin"] as? [String])?.first?.hasSuffix("opencode-presence.js") == true)
+  }
+
+  @Test
+  func thePluginReportsEveryEdgeTheGraphReads() {
+    let source = OpenCodePresencePlugin.source(
+      zmxPath: "/Users/o'brien/bin/zmx", sessionsDirectory: "/Users/o'brien/.graphcode/sessions")
+
+    // The paths land as JS string literals, quote and all.
+    #expect(source.contains(#"const ZMX = "/Users/o'brien/bin/zmx""#))
+    // The same guard every Claude Code hook carries: not a graphcode session, do nothing.
+    #expect(source.contains("process.env.ZMX_SESSION"))
+    // Both edges of a turn, the tool inside it, and the one state only a plugin can see.
+    for event in [
+      "session.created", "session.status", "session.idle", "permission.asked",
+      "tool.execute.before", "message.updated",
+    ] {
+      #expect(source.contains(event), "\(event) is not reported")
+    }
+    for label in ["presence=busy", "presence=idle", "presence=awaitingInput", "usage=input."] {
+      #expect(source.contains(label), "\(label) is never written")
+    }
+    // A sub-agent's session must not blank the loop's card — the `SubagentStop` lesson.
+    #expect(source.contains("parentID"))
+  }
+
+  @Test
+  func itHostsEveryLoopTypeButRecurringAndComposite() {
+    #expect(CLISessionBackendKind.openCode.canHost(.goalBased))
+    #expect(CLISessionBackendKind.openCode.canHost(.turnBased))
+    #expect(CLISessionBackendKind.openCode.canHost(.sketch))
+    // No `/loop` equivalent, and no sub-agent fan-out reachable from outside the TUI.
+    #expect(!CLISessionBackendKind.openCode.canHost(.timeBased))
+    #expect(!CLISessionBackendKind.openCode.canHost(.composite))
+    #expect(CLISessionBackendKind.offerableAsDefault.contains(.openCode))
+  }
+
+  @Test
+  func settingsRoundTripAndDefaultToAuto() throws {
+    let decoded = try JSONDecoder().decode(GraphcodeSettings.self, from: Data("{}".utf8))
+    #expect(decoded.openCodePermissions == .auto)
+
+    var settings = GraphcodeSettings()
+    settings.openCodePermissions = .ask
+    let data = try JSONEncoder().encode(settings)
+    let back = try JSONDecoder().decode(GraphcodeSettings.self, from: data)
+    #expect(back.openCodePermissions == .ask)
+  }
+
+  @Test
+  func theHeadlessInvocationIsRun() {
+    #expect(
+      SummaryModelWriter.invocation(forBackend: .openCode, prompt: "say hi")
+        == ["opencode", "run", "say hi"])
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `openCode` to `CLISessionBackendKind`: `opencode --prompt <p> --auto` opens the TUI already running the prompt, `--session <id>` resumes, `-m` is left to the user's own provider config.
- Presence, activity, token usage and the resume id all come from one plugin (`OpenCodePresencePlugin`) handed over via `OPENCODE_CONFIG` — the route that merges over the user's config instead of replacing it. It writes the same zmx labels Claude Code's hooks do, so the existing readers serve OpenCode unchanged; sub-agent sessions are filtered out.
- New `OpenCodePermissions` setting (`auto` default) in Settings → Permissions; CLI `--backend openCode`.
- Spiked against OpenCode 1.18.21 — flags from `opencode --help`, events from a probe plugin run against the real binary and the plugin SDK types.

Not in this PR: summary rail (transcript is SQLite), export/import, remote-host presence.

## Test plan
- [x] 1042 tests pass (`OpenCodeBackendTests` added; hosting-matrix and default-list expectations updated)
- [x] graphcoded and graphcode-cli build; swiftlint + swift-format clean on touched files
- [x] Plugin driven under node with a fake `zmx`: busy/idle/awaitingInput edges, tool phrases, usage dedup, id banking, child-session filtering
- [x] Live `zmx run` in the daemon's launch shape starts the TUI with the plugin loaded (no working model provider on this Mac, so tool calls could not be exercised end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sjga3GZVA7nCD4ve1qXbek