### PR TITLE
Rename the Sketch loop type to Main, and give it the palette slot to match

### DIFF
--- a/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
+++ b/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
@@ -52,14 +52,14 @@ public enum GraphcodeCommand: Equatable, Sendable {
     USAGE
       graphcode projects
       graphcode status <project-path>
-      graphcode node create <project-path> --title <t> --type <sketch|turn|goal|time|composite> [options]
+      graphcode node create <project-path> --title <t> --type <main|turn|goal|time|composite> [options]
       graphcode node stop <project-path> <node-id>
       graphcode node delete <project-path> <node-id>   removes it, its edges, session
                            and memory — irreversible; stop is the reversible verb
       graphcode node send <project-path> <node-id> [--follow-up] <message…>
       graphcode node update <project-path> <node-id> [options]
       graphcode node promote <project-path> <node-id> --type <goal|turn|time> [options]
-                           give a sketch a shape, keeping its session, edges and memory
+                           give a main loop a shape, keeping its session, edges and memory
       graphcode node memo <project-path> <node-id> <note…>
       graphcode node refine <project-path> <node-id> <playbook…|--file f|--rollback>
       graphcode node pilot <project-path> <node-id>     dry-run a composite
@@ -87,7 +87,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
       --goal <text>        required for --type goal
       --predicate <cmd>    optional stop condition for --type goal (exit 0 = met)
       --prompt <text>      required for --type time; put the cadence in it (/loop 1h …).
-                           For --type sketch it is the optional starting note
+                           For --type main it is the optional starting note
       --heartbeat <secs>   for --type time, experimental: the daemon delivers the prompt
                            every interval instead of the prompt carrying /loop. Needs
                            "Daemon heartbeat" enabled in the app's Settings; the prompt
@@ -129,8 +129,8 @@ public enum GraphcodeCommand: Equatable, Sendable {
                            --predicate through promotion, the same rule update holds.
       --type turn          with --pause <every-turn|before-writes>  (default: every-turn)
       --type time          with --prompt <text> (required); put the cadence in it
-      Promotion is one-way: a sketch gains a shape, never the reverse, and only a
-      sketch can be promoted.
+      Promotion is one-way: a main loop gains a shape, never the reverse, and only a
+      main loop can be promoted.
 
     node memo appends a note to the loop's own memory log — what the next pass reads
     before starting. Record dead ends and decisions, not a transcript.
@@ -308,7 +308,9 @@ public enum GraphcodeCommand: Equatable, Sendable {
 
     let loopType: LoopType
     switch rawType {
-    case "sketch": loopType = .sketch
+    // `sketch` too, because that is the word every graph on disk still serialises and
+    // what any script written before the rename still passes.
+    case "main", "sketch": loopType = .sketch
     case "turn", "turnBased": loopType = .turnBased
     case "goal", "goalBased": loopType = .goalBased
     case "time", "timeBased": loopType = .timeBased
@@ -530,7 +532,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
       guard let prompt = flags["prompt"] else { throw ParseError.missingArgument("--prompt") }
       return .timed(triggerPrompt: prompt)
 
-    // `sketch` and `composite` are refused by shape, not by the daemon: demotion is
+    // `main` and `composite` are refused by shape, not by the daemon: demotion is
     // unrepresentable and a composite is not one decision (see `SketchPromotion`).
     default:
       throw ParseError.invalidValue(argument: "--type", value: rawType)

--- a/GraphcodeKit/Sources/Domain/LoopType.swift
+++ b/GraphcodeKit/Sources/Domain/LoopType.swift
@@ -17,6 +17,11 @@
 public enum LoopType: String, Codable, CaseIterable, Sendable {
   /// The zero-commitment type: no goal, no cadence, no checkpoint. A bare session that
   /// works with you until you promote it or close it.
+  ///
+  /// Shown as "Main" everywhere a human reads it. The identifier and the raw value keep
+  /// the older word for the same reason `composite` serialises as `proactive`: every
+  /// graph on disk carries `sketch`, and a daemon or CLI in `~/.graphcode/bin` can be a
+  /// version behind the app that wrote it.
   case sketch
   case goalBased
   case timeBased

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -837,7 +837,7 @@ public actor GraphStore {
       // instead of leaving the caller to discover promotion exists.
       announceError(
         node.loopType == .sketch
-          ? "update refused: nothing in it applies to a sketch loop — give it a shape "
+          ? "update refused: nothing in it applies to a main loop — give it a shape "
             + "first with `graphcode node promote`"
           : "update refused: nothing in it applies to a \(node.loopType) loop")
       return
@@ -886,7 +886,7 @@ public actor GraphStore {
     }
     guard node.loopType == .sketch else {
       announceError(
-        "promotion refused: \(node.title) already has a shape — only a sketch can be promoted")
+        "promotion refused: \(node.title) already has a shape — only a main loop can be promoted")
       return
     }
 
@@ -943,7 +943,7 @@ public actor GraphStore {
       promotedBy == nodeID
       ? "itself" : promotedBy.flatMap { graph.nodes[id: $0]?.title } ?? "a human"
     recordMemory(
-      nodeID, "promoted from sketch to \(promotion.targetType.rawValue) by \(promoter) — \(nudge)")
+      nodeID, "promoted from main to \(promotion.targetType.rawValue) by \(promoter) — \(nudge)")
     pendingNudges.append((nodeID, "[graphcode] \(nudge)"))
 
     // What creation does for the type, promotion does too: an unattended loop's session

--- a/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteGraphAccess.swift
@@ -373,7 +373,7 @@ public enum RemoteGraphAccess {
             fail("missing --title")
         if not flags.get("type"):
             fail("missing --type")
-        types = {"sketch": "sketch",
+        types = {"main": "sketch", "sketch": "sketch",
                  "turn": "turnBased", "turnBased": "turnBased",
                  "goal": "goalBased", "goalBased": "goalBased",
                  "time": "timeBased", "timeBased": "timeBased",

--- a/graphcode/Sources/Features/App/LoopTypeAppearance.swift
+++ b/graphcode/Sources/Features/App/LoopTypeAppearance.swift
@@ -50,7 +50,7 @@ extension LoopType {
   /// app admitting it had two vocabularies.
   var displayName: String {
     switch self {
-    case .sketch: "Sketch"
+    case .sketch: "Main"
     case .goalBased: "Goal"
     case .timeBased: "Timed"
     case .turnBased: "Turn"

--- a/graphcode/Sources/Features/App/LoopTypeAppearance.swift
+++ b/graphcode/Sources/Features/App/LoopTypeAppearance.swift
@@ -7,30 +7,40 @@ import SwiftUI
 /// `LoopState.presenceColor` does: `GraphcodeKit` is linked into the plain `graphcoded`
 /// daemon and stays free of SwiftUI.
 ///
-/// **Colour is never the only signal.** Every card already spells the type out, and the
-/// glyph below is a second non-colour channel. That matters here: four hues that stay
-/// mutually distinguishable under *every* kind of colour blindness don't exist within one
-/// lightness band — validated, not assumed, and the run is recorded below — so the
-/// palette is only legitimate alongside the label and glyph that travel with it.
+/// **Colour is not always backed by a second signal.** A card spells the type out in its
+/// meta row, but a sidebar row carries only the stripe — so on that surface the hue is
+/// the whole channel. That matters here: four hues that stay mutually distinguishable
+/// under *every* kind of colour blindness don't exist within one lightness band —
+/// validated, not assumed, and the run is recorded below.
 ///
 /// The hues are the data-viz reference palette's dark-surface steps. Against this app's
 /// canvas they pass the lightness band, the chroma floor, adjacent-pair CVD separation
 /// (worst ΔE 8.4, protan), the normal-vision floor (worst ΔE 19.3), and 3:1 contrast.
 /// Under all-pairs rather than adjacent, magenta and aqua collapse for deuteranopes
-/// (ΔE 1.6) — which is exactly what the label and glyph are for.
+/// (ΔE 1.6) — which is what the card's label is for, and why the sidebar leans on
+/// `Main` being the one kind that is legible by lightness alone.
 ///
 /// Blue and orange are deliberately absent. Both are spoken for elsewhere on the same
 /// card and would say two things at once: blue is a running loop's presence dot, orange
 /// is "needs attention" on the border and the attention label.
 extension LoopType {
-  /// The kind's colour. Used for the card's edge stripe and its glyph — never for text,
-  /// which keeps its own ink so the colour beside it is what carries identity.
+  /// The kind's colour. Used for the card's edge stripe and entry port, the sidebar
+  /// row's stripe, and the card's glow — never for text, which keeps its own ink so the
+  /// colour beside it is what carries identity.
   var accent: Color {
     switch self {
-    // Deliberately colourless: the four committed types keep the saturated slots, and
-    // grey reads as *provisional* — a canvas of half-finished pokes shouldn't compete
-    // with work that matters.
-    case .sketch: Color(red: 0.486, green: 0.529, blue: 0.580)  // grey  #7c8794
+    // Still the colourless slot — the four committed types keep the saturated ones — but
+    // the brightest value in the palette rather than the dimmest. It used to be a mid
+    // grey chosen to read as *provisional*, which stopped being true when the type
+    // became Main: this is where work starts, not a half-finished poke.
+    //
+    // Lightness is what carries it. At L* 86.8 it sits clear above the four hues' band
+    // (L* 53.6–61.0), where the old grey sat *inside* it at L* 55.8 — worst-case CVD
+    // separation goes from ΔE 9.1 to 20.6, and contrast against the card from 3.8:1 to
+    // 9.9:1. Achromatic-against-chromatic is the one distinction no dichromacy erodes,
+    // which is what the sidebar's colour-only row needs. Kept off pure white so the
+    // card's own title still outranks its chrome.
+    case .sketch: Color(red: 0.827, green: 0.855, blue: 0.890)  // near-white  #d3dae3
     case .goalBased: Color(red: 0.098, green: 0.620, blue: 0.439)  // aqua  #199e70
     case .timeBased: Color(red: 0.788, green: 0.522, blue: 0.000)  // yellow #c98500
     case .turnBased: Color(red: 0.835, green: 0.318, blue: 0.506)  // magenta #d55181
@@ -58,12 +68,19 @@ extension LoopType {
     }
   }
 
-  /// A glyph that says what the kind *does*, so the distinction survives without colour:
-  /// a goal-based loop runs at a target, a time-based one at a clock, a turn-based one
-  /// waits for a person, and a composite one is a stack of loops rather than a session.
+  /// A glyph that says what the kind *does*: a goal-based loop runs at a target, a
+  /// time-based one at a clock, a turn-based one waits for a person, and a composite one
+  /// is a stack of loops rather than a session. Main is the exception — nothing is added
+  /// to it, so it gets the house rather than a mechanism it doesn't have.
+  ///
+  /// Nothing reads this today. The card dropped the glyph channel when it went state-first
+  /// (`LoopCardView`) and the sidebar row draws a stripe, so both are down to colour plus,
+  /// on the card only, the label. Kept because the set is still the right answer if a
+  /// surface ever wants a second channel back — but it is not one now, and `accent` is
+  /// sized on the assumption that it isn't.
   var glyph: String {
     switch self {
-    case .sketch: "scribble"
+    case .sketch: "house"
     case .goalBased: "target"
     case .timeBased: "clock"
     case .turnBased: "person"

--- a/graphcode/Sources/Features/Project/BackendPicker.swift
+++ b/graphcode/Sources/Features/Project/BackendPicker.swift
@@ -82,7 +82,7 @@ struct BackendPicker: View {
     case .sketch:
       // Unreachable while every spiked backend hosts a bare session, but the compiler
       // rightly wants the sentence written down.
-      return "\(name) can't host a sketch."
+      return "\(name) can't host a main loop."
     }
   }
 }

--- a/graphcode/Sources/Features/Project/LoopTypeChooser.swift
+++ b/graphcode/Sources/Features/Project/LoopTypeChooser.swift
@@ -1,7 +1,7 @@
 import GraphcodeKit
 import SwiftUI
 
-/// The four kinds of loop as tiles that explain themselves, with Sketch — the
+/// The four kinds of loop as tiles that explain themselves, with Main — the
 /// starting point that isn't yet any of them — banded above.
 ///
 /// It was a four-segment picker, and the problem with that wasn't the shape — it was
@@ -12,7 +12,7 @@ import SwiftUI
 /// teach.
 ///
 /// The axis the chooser is ordered on is how much you have to decide before the loop
-/// can start. Sketch demands nothing, so it sits above the grid as a full-width band —
+/// can start. Main demands nothing, so it sits above the grid as a full-width band —
 /// deliberately not a fifth tile: an orphan tile in a 2×2 rhythm reads as an
 /// afterthought, and a five-wide row shrinks every explanation to one truncated line.
 /// The labelled rule between them ("or commit to something") is the taxonomy lesson.
@@ -27,7 +27,7 @@ struct LoopTypeChooser: View {
 
   private let columns = [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)]
 
-  /// ⌘1 Sketch · ⌘2 Goal · ⌘3 Timed · ⌘4 Turn · ⌘5 Composite — `allCases` order, which
+  /// ⌘1 Main · ⌘2 Goal · ⌘3 Timed · ⌘4 Turn · ⌘5 Composite — `allCases` order, which
   /// the enum keeps in chooser order on purpose.
   private static let shortcuts = Dictionary(
     uniqueKeysWithValues: LoopType.allCases.enumerated().map { ($1, "\($0 + 1)") })

--- a/graphcode/Sources/Features/Project/NodeDraftForm.swift
+++ b/graphcode/Sources/Features/Project/NodeDraftForm.swift
@@ -54,7 +54,7 @@ struct NodeDraftForm: View {
     .padding(.bottom, 18)
     // Flexible on both axes so the sheet can be dragged larger — a fixed frame is what
     // pinned it. The ideal height grew with the chooser, which is a band and a rule
-    // taller now that Sketch sits above the grid.
+    // taller now that Main sits above the grid.
     .frame(minWidth: 520, idealWidth: 520, maxWidth: .infinity)
     .frame(minHeight: 560, idealHeight: 760, maxHeight: .infinity)
     .background(Theme.sheet)
@@ -114,7 +114,7 @@ struct NodeDraftForm: View {
       }
       if store.draftLoopType == .sketch {
         Text(
-          "Sketch loops don't cut a worktree by default — most of them read rather than "
+          "Main loops don't cut a worktree by default — most of them read rather than "
             + "write. Pick a branch here if this one will."
         )
         .font(.system(size: 11))

--- a/graphcode/Sources/Features/Project/SketchPromotionForm.swift
+++ b/graphcode/Sources/Features/Project/SketchPromotionForm.swift
@@ -39,7 +39,7 @@ struct SketchPromotionForm: View {
           .font(.system(size: 16, weight: .semibold))
       }
       Text(
-        "Keep the session, add a shape — \(node?.title ?? "this sketch") stays "
+        "Keep the session, add a shape — \(node?.title ?? "this loop") stays "
           + "exactly where it is."
       )
       .font(.system(size: 12))

--- a/graphcode/Sources/Features/Welcome/OnboardingPages.swift
+++ b/graphcode/Sources/Features/Welcome/OnboardingPages.swift
@@ -185,7 +185,7 @@ struct OnboardingReadingPage: View {
 }
 
 /// Page 3 — the four kinds, subtitled by what makes each one *stop*, with the edge
-/// lesson folded in underneath. Sketch shows above them as what it is: not a fifth
+/// lesson folded in underneath. Main shows above them as what it is: not a fifth
 /// kind, the place you start before the work has a shape.
 ///
 /// Two pages became one, which is what freed the room for page 2. The tiles are the
@@ -202,7 +202,7 @@ struct OnboardingLoopTypesPage: View {
         .font(.system(size: 25, weight: .bold))
         .tracking(-0.25)
       Text(
-        "They differ in what makes them stop — and a sketch is where you start "
+        "They differ in what makes them stop — and a main loop is where you start "
           + "before choosing one."
       )
       .font(.system(size: 14))

--- a/graphcode/Tests/SketchPromotionTests.swift
+++ b/graphcode/Tests/SketchPromotionTests.swift
@@ -219,7 +219,7 @@ struct SketchPromotionTests {
     await store.handle(
       .promoteNode(byHuman.id, promotion: .goal(GoalSpec(summary: "c")), promotedBy: nil))
 
-    let promotions = entries.value.filter { $0.contains("promoted from sketch") }
+    let promotions = entries.value.filter { $0.contains("promoted from main") }
     #expect(promotions.contains { $0.contains("by itself") })
     #expect(promotions.contains { $0.contains("by Coordinator") })
     #expect(promotions.contains { $0.contains("by a human") })


### PR DESCRIPTION
Two commits: the rename, then the colour and glyph that were still arguing the old name.

## 1 · The rename

Renames the zero-commitment loop type from **Sketch** to **Main** everywhere a human reads it.

| Surface | Before | After |
|---|---|---|
| Card / picker label (`displayName`) | Sketch | **Main** |
| Draft form worktree hint | "Sketch loops don't cut a worktree…" | "Main loops don't cut a worktree…" |
| Onboarding page 3 subtitle | "a sketch is where you start" | "a main loop is where you start" |
| Promotion form | "this sketch stays…" | "this loop stays…" |
| Backend refusal | "can't host a sketch." | "can't host a main loop." |
| `GraphStore` update / promotion refusals | "a sketch loop" / "only a sketch" | "a main loop" / "only a main loop" |
| Promotion memo | "promoted from sketch to…" | "promoted from main to…" |
| CLI help | `--type <sketch\|turn\|goal\|time\|composite>` | `--type <main\|turn\|goal\|time\|composite>` |

The jump palette, card meta row, and onboarding "NOT FOR … LOOPS" badge all read through `LoopType.displayName`, so they follow on their own.

**The identifier and raw value stay `sketch`**, for the same reason `composite` still serialises as `proactive`: every graph on disk carries that word, and a daemon or CLI in `~/.graphcode/bin` can be a version behind the app that wrote it. `--type sketch` is still accepted alongside `--type main`, locally and in the remote shim.

## 2 · The palette slot

The grey was picked to read as *provisional* — "a canvas of half-finished pokes shouldn't compete with work that matters" — which stopped being true the moment the type became Main.

Main keeps the colourless slot; the four committed types keep the saturated ones. What changes is that it takes the **brightest** value rather than the dimmest — and that turns out to be an accessibility fix, not just a mood one.

| | L\* | Contrast on card | Worst-case ΔE to the four hues |
|---|---|---|---|
| `#7c8794` before | 55.8 | 3.81 : 1 | **9.1** |
| `#d3dae3` after | 86.8 | **9.87 : 1** | **20.6** |

The four committed hues span L\* 53.6–61.0. The old grey sat *inside* that band at 55.8, so once dichromacy strips the hue there is nothing left to separate it — under protanopia it renders `#828795` against Turn's `#6a7082`. The new value clears the band, and achromatic-against-chromatic is the one distinction no dichromacy erodes.

<sub>CIEDE2000; Machado et al. 2009 dichromacy matrices at severity 1.0.</sub>

### Why that mattered more than it looked

The old header comment justified the palette by claiming the glyph was a second non-colour channel backing the hue up. It isn't: **nothing has read `LoopType.glyph` since the card went state-first**, and a sidebar row draws only a stripe with no type word beside it — the comment there still says "the kind glyph takes the column" directly above code that fills a 3×14pt rectangle. On that surface the accent is the whole channel, which is exactly where the weakest colour in the set was being used.

The header doc is corrected to say what is actually true.

### The glyph

`scribble` → `house`. The other four name a mechanism (target, clock, person, stack) and a Main loop has none — nothing is added to it — so it gets an identity instead. Flagged in the source: it renders nowhere today, and is kept only because the set is still the right answer if a surface ever wants that channel back.

## Verification

| Check | Result |
|---|---|
| `xcodebuild -workspace graphcode.xcworkspace -scheme graphcode test` | ✅ 1042 tests in 110 suites passed |
| `swiftlint lint` | ✅ 0 serious violations |
| `swift format lint --strict` on changed files | ✅ clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a3ZJKFSZoqmtiaokCrAnZ