### PR TITLE
fix: workspaces switch in creation order, and ⌘` walks them

### DIFF
--- a/GraphcodeKit/Sources/Workspace.swift
+++ b/GraphcodeKit/Sources/Workspace.swift
@@ -108,6 +108,13 @@ extension Workspace {
   /// live in one workspace's directory — making every other workspace write into it,
   /// which is the coupling this feature exists to avoid — and would go stale the moment
   /// someone moved a directory by hand. The directory *is* the record.
+  ///
+  /// Ordered oldest first, which is to say the order they were created in — the default
+  /// workspace, then each named one behind it. Alphabetical is what this was, and it put
+  /// a workspace created today in the middle of the list, moving every ⌥⌘<n> after it:
+  /// the numbers are a habit and a habit cannot survive a list that reshuffles. Creation
+  /// order only ever appends. A rename keeps its place too, since `moveItem` carries the
+  /// creation date with the directory.
   public static func all(
     home: URL = URL(fileURLWithPath: NSHomeDirectory()),
     fileManager: FileManager = .default
@@ -116,15 +123,24 @@ extension Workspace {
     // would hide the whole result set.
     let entries =
       (try? fileManager.contentsOfDirectory(
-        at: home, includingPropertiesForKeys: [.isDirectoryKey], options: [])) ?? []
+        at: home, includingPropertiesForKeys: [.isDirectoryKey, .creationDateKey],
+        options: [])) ?? []
 
     let named =
       entries
       .filter { $0.lastPathComponent.hasPrefix(directoryPrefix) }
       .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? true }
-      .map { workspace(for: $0, home: home) }
+      .map { (workspace: workspace(for: $0, home: home), created: creationDate(of: $0)) }
 
-    var found = [Workspace.default] + named.sorted { $0.slug < $1.slug }
+    // Slug breaks a tie rather than leaving `sorted` to decide: two directories created
+    // in the same second are ordinary on a restore from backup, and an order that is
+    // stable between two calls is the whole point of this.
+    let ordered = named.sorted {
+      $0.created == $1.created
+        ? $0.workspace.slug < $1.workspace.slug : $0.created < $1.created
+    }
+
+    var found = [Workspace.default] + ordered.map(\.workspace)
     // The current workspace may be somewhere the scan can't see it — a developer's
     // `GRAPHCODE_SUPPORT_DIR=/tmp/…`, say. A switcher that omits where you already are
     // reads as a bug.
@@ -133,6 +149,13 @@ extension Workspace {
       found.append(current)
     }
     return found
+  }
+
+  /// A directory with no readable creation date sorts to the end rather than the front:
+  /// the unknown case is a directory the scan could not stat, and putting it first would
+  /// renumber every workspace behind it.
+  private static func creationDate(of url: URL) -> Date {
+    (try? url.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantFuture
   }
 
   /// Turns what a human typed into something that is safe as a directory suffix, as a

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ graphs and its own `graphcoded`. Nothing is shared between them — a loop in on
 other — and the switcher at the foot of the sidebar says which one you are in. The CLI follows the
 same variable the app sets: `GRAPHCODE_SUPPORT_DIR=~/.graphcode-work graphcode status <project>`.
 
-**⌥⌘1 … ⌥⌘9** switch between them in menu order and **⌥⌘N** makes a new one. **Rename Workspace**
+**⌥⌘1 … ⌥⌘9** switch between them and **⌘`** steps to the next one (**⌘⇧`** back), both
+in the order the workspaces were created; **⌥⌘N** makes a new one. **Rename Workspace**
 moves its folder, taking its projects and loops with it; **Delete Workspace** ends that workspace's
 terminal sessions, stops its daemon, and moves its folder to the Trash. Neither is offered for the
 default workspace or for whichever one you are in.

--- a/docs/index.html
+++ b/docs/index.html
@@ -486,7 +486,7 @@ description: Graph engineering for coding agents on macOS — loops connected on
   <div class="section-intro">
     <div class="kicker">03 — WORKSPACES</div>
     <h2>One window per line of work.</h2>
-    <p class="lede">A workspace is a whole second GraphCode — its own projects, loops and daemon, in its own window with its own Dock tile. ⌥⌘1…9 to switch, or put one on each screen. Nothing is shared between them — and a loop in one can still message a loop in the other, straight into its running session.</p>
+    <p class="lede">A workspace is a whole second GraphCode — its own projects, loops and daemon, in its own window with its own Dock tile. ⌥⌘1…9 or ⌘` to switch, or put one on each screen. Nothing is shared between them — and a loop in one can still message a loop in the other, straight into its running session.</p>
   </div>
   <div class="demo-frame">
     <div class="demo-bar">

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -41,9 +41,16 @@ unrelated lines of work apart. Nothing is shared between them, and each gets its
 tile, so one can sit on a second screen. **File ▸ Workspace** lists them. (For the tabs
 and splits *inside* a loop, see [Terminals](#terminals).)
 
+The list is in the order the workspaces were created — Default first, then each one
+behind it — and both the numbers and ⌘` walk it. Creating a workspace only ever adds to
+the end, so ⌥⌘3 stays the workspace it was yesterday; renaming one leaves it where it
+is too.
+
 | Shortcut | Does |
 |---|---|
-| ⌥⌘1 … ⌥⌘9 | Switch to that workspace, in the order the menu lists them (⌥⌘1 is the default one). Raises its window, or opens it if it isn't running |
+| ⌥⌘1 … ⌥⌘9 | Switch to that workspace. Raises its window, or opens it if it isn't running |
+| ⌘` | Next workspace, wrapping round at the end |
+| ⌘⇧` | Previous workspace |
 | ⌥⌘N | New workspace — name it and it opens straight away |
 
 **Rename Workspace** and **Delete Workspace** are in the same menu. A rename moves the

--- a/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Workspaces.swift
@@ -136,6 +136,9 @@ extension AppFeature {
     case createConfirmed
     /// Raise (or launch) the instance that owns this workspace.
     case switchRequested(Workspace)
+    /// ⌘` and ⌘⇧` — the workspace `offset` places along from this one in creation order,
+    /// wrapping at both ends.
+    case cycleRequested(offset: Int)
     case switcherPresented(Bool)
     case manageRequested
     case manageDismissed
@@ -301,6 +304,20 @@ struct AppWorkspacesReducer: Reducer {
       case .workspaces(.switchRequested(let workspace)):
         guard workspace.id != state.workspaces.current.id else { return .none }
         return .run { [open = workspaces.open] _ in open(workspace) }
+
+      case .workspaces(.cycleRequested(let offset)):
+        // Re-read rather than cycling `known`: this is a keystroke, not a menu being
+        // opened, so nothing has necessarily refreshed the list since launch — and a
+        // workspace another instance created since then is one ⌘` would skip over.
+        let known = workspaces.list()
+        state.workspaces.known = known
+        guard known.count > 1,
+          let index = known.firstIndex(where: { $0.id == state.workspaces.current.id })
+        else { return .none }
+        // `%` keeps a negative dividend negative in Swift, so ⌘⇧` at the head of the
+        // list would index -1 without the extra `+ known.count`.
+        let next = known[((index + offset) % known.count + known.count) % known.count]
+        return .send(.workspaces(.switchRequested(next)))
 
       case .workspaces(.renameRequested(let workspace)):
         if let refusal = workspace.refusal(for: .rename, current: state.workspaces.current) {

--- a/graphcode/Sources/Features/Welcome/OnboardingPages.swift
+++ b/graphcode/Sources/Features/Welcome/OnboardingPages.swift
@@ -393,6 +393,7 @@ struct OnboardingWorkspacesPage: View {
         fact("Separate", "projects, loops, terminal layouts, agent default")
         fact("Shared", "the app itself, and nothing else")
         fact("Make one", "File ▸ Workspace ▸ New Workspace…   ⌥⌘N")
+        fact("Switch", "⌥⌘1 … ⌥⌘9, or ⌘` for the next one")
       }
       .frame(width: 440, alignment: .leading)
       .padding(.top, 12)

--- a/graphcode/Sources/Features/Workspaces/WorkspaceNewsView.swift
+++ b/graphcode/Sources/Features/Workspaces/WorkspaceNewsView.swift
@@ -42,7 +42,7 @@ struct WorkspaceNewsView: View {
           "rectangle.split.2x1", "Make one from File ▸ Workspace",
           "It opens in its own window, with its own Dock tile.")
         item(
-          "list.bullet", "Switch with ⌥⌘1 … ⌥⌘9",
+          "list.bullet", "Switch with ⌥⌘1 … ⌥⌘9, or ⌘` for the next one",
           "Or from the workspace name at the foot of the sidebar.")
         item(
           "arrow.up.to.line", "Nothing moved",

--- a/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/graphcode/Sources/Features/Workspaces/WorkspaceSwitcher.swift
@@ -35,6 +35,16 @@ struct WorkspaceMenuItems: View {
       .modifier(WorkspaceShortcut(index: showsShortcuts ? index : nil))
     }
     Divider()
+    // ⌘` walks the same list the rows above are numbered in, which is the point of it:
+    // ⌥⌘<n> is for the workspace you can name, ⌘` for the next one along when you have
+    // more of them than you have fingers.
+    Button("Next Workspace") { store.send(.workspaces(.cycleRequested(offset: 1))) }
+      .modifier(CycleShortcut(isEnabled: showsShortcuts, isBackwards: false))
+      .disabled(store.workspaces.known.count < 2)
+    Button("Previous Workspace") { store.send(.workspaces(.cycleRequested(offset: -1))) }
+      .modifier(CycleShortcut(isEnabled: showsShortcuts, isBackwards: true))
+      .disabled(store.workspaces.known.count < 2)
+    Divider()
     Button("New Workspace…") { store.send(.workspaces(.newRequested)) }
       .modifier(NewWorkspaceShortcut(isEnabled: showsShortcuts))
     Button("Manage Workspaces…") { store.send(.workspaces(.manageRequested)) }
@@ -53,6 +63,24 @@ private struct WorkspaceShortcut: ViewModifier {
   func body(content: Content) -> some View {
     if let index, index < 9, let key = KeyEquivalent(exactly: index + 1) {
       content.keyboardShortcut(key, modifiers: [.command, .option])
+    } else {
+      content
+    }
+  }
+}
+
+/// ⌘` and ⌘⇧`, the pair macOS spends on cycling a single app's windows.
+///
+/// Taking them is safe here and is the only binding that would read as native: a
+/// workspace is a separate *instance*, each with one window, so the system's own ⌘`
+/// has nothing to cycle within any of them.
+private struct CycleShortcut: ViewModifier {
+  let isEnabled: Bool
+  let isBackwards: Bool
+
+  func body(content: Content) -> some View {
+    if isEnabled {
+      content.keyboardShortcut("`", modifiers: isBackwards ? [.command, .shift] : [.command])
     } else {
       content
     }

--- a/graphcode/Tests/WorkspaceCycleTests.swift
+++ b/graphcode/Tests/WorkspaceCycleTests.swift
@@ -1,0 +1,111 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// ⌘` and ⌘⇧` — stepping to the next workspace rather than naming one with ⌥⌘<n>.
+///
+/// Issue #175. The list these walk is `Workspace.all()`, which is in creation order; what
+/// is pinned here is the walking itself — that it wraps at both ends, that it re-reads the
+/// list rather than trusting whatever the last menu opening left in state, and that a
+/// machine with one workspace gets nothing rather than a switch to itself.
+@Suite
+struct WorkspaceCycleTests {
+  private func workspace(_ slug: String) -> Workspace {
+    Workspace(slug: slug, url: URL(fileURLWithPath: "/tmp/.graphcode-\(slug)"))
+  }
+
+  private func state(current: Workspace) -> AppFeature.State {
+    var state = AppFeature.State()
+    state.workspaces.current = current
+    return state
+  }
+
+  @MainActor
+  private func store(
+    current: Workspace, list: [Workspace], opened: LockIsolated<[Workspace]>
+  ) -> TestStoreOf<AppFeature> {
+    let store = TestStore(initialState: state(current: current)) {
+      AppFeature()
+    } withDependencies: {
+      $0.workspaceClient.list = { list }
+      $0.workspaceClient.open = { workspace in opened.withValue { $0.append(workspace) } }
+    }
+    store.exhaustivity = .off
+    return store
+  }
+
+  @Test
+  @MainActor
+  func nextGoesOnePlaceDownTheList() async {
+    let work = workspace("work")
+    let oss = workspace("oss")
+    let opened = LockIsolated<[Workspace]>([])
+    let store = store(current: work, list: [.default, work, oss], opened: opened)
+
+    await store.send(.workspaces(.cycleRequested(offset: 1)))
+    await store.receive(\.workspaces.switchRequested)
+
+    #expect(opened.value == [oss])
+  }
+
+  @Test
+  @MainActor
+  func nextWrapsRoundFromTheLastToTheFirst() async {
+    let work = workspace("work")
+    let oss = workspace("oss")
+    let opened = LockIsolated<[Workspace]>([])
+    let store = store(current: oss, list: [.default, work, oss], opened: opened)
+
+    await store.send(.workspaces(.cycleRequested(offset: 1)))
+    await store.receive(\.workspaces.switchRequested)
+
+    #expect(opened.value == [.default])
+  }
+
+  @Test
+  @MainActor
+  func previousWrapsRoundFromTheFirstToTheLast() async {
+    // `%` keeps a negative dividend negative in Swift, so this is the case that indexes
+    // -1 if the modulo is written the obvious way.
+    let work = workspace("work")
+    let oss = workspace("oss")
+    let opened = LockIsolated<[Workspace]>([])
+    let store = store(current: .default, list: [.default, work, oss], opened: opened)
+
+    await store.send(.workspaces(.cycleRequested(offset: -1)))
+    await store.receive(\.workspaces.switchRequested)
+
+    #expect(opened.value == [oss])
+  }
+
+  @Test
+  @MainActor
+  func oneWorkspaceHasNowhereToGo() async {
+    let opened = LockIsolated<[Workspace]>([])
+    let store = store(current: .default, list: [.default], opened: opened)
+
+    await store.send(.workspaces(.cycleRequested(offset: 1)))
+
+    #expect(opened.value.isEmpty)
+  }
+
+  @Test
+  @MainActor
+  func theListIsReReadRatherThanTakenFromState() async {
+    // A keystroke, not a menu opening: nothing has necessarily refreshed `known` since
+    // launch, and a workspace another instance created since then is one ⌘` must not
+    // skip over.
+    let work = workspace("work")
+    let opened = LockIsolated<[Workspace]>([])
+    let store = store(current: .default, list: [.default, work], opened: opened)
+
+    await store.send(.workspaces(.cycleRequested(offset: 1)))
+    await store.receive(\.workspaces.switchRequested)
+
+    #expect(opened.value == [work])
+    #expect(store.state.workspaces.known == [.default, work])
+  }
+}

--- a/graphcode/Tests/WorkspaceTests.swift
+++ b/graphcode/Tests/WorkspaceTests.swift
@@ -148,9 +148,49 @@ struct WorkspaceTests {
     #expect(slugs.contains("work"))
     #expect(slugs.contains("oss"))
     #expect(!slugs.contains("ssh"))
-    // The default first, then alphabetical — a list that reorders itself between openings
-    // is a list nobody can build a habit on.
-    #expect(slugs.prefix(3) == ["", "oss", "work"])
+    // The default first, then the order they were made in — issue #175. Alphabetical is
+    // what this was, and it is why "oss" used to arrive in front of a "work" that had
+    // been ⌥⌘2 for a month.
+    #expect(slugs.prefix(3) == ["", "work", "oss"])
+  }
+
+  @Test
+  func creatingAWorkspaceOnlyEverAddsToTheEndOfTheList() throws {
+    // The whole reason #175 is a bug and not a preference: ⌥⌘<n> is muscle memory, and
+    // alphabetical order re-pointed those keys at different workspaces every time a name
+    // sorted early. Dates are set explicitly rather than trusted to the order the
+    // directories were made — the assertion is about the sort, not about the filesystem's
+    // timestamp resolution.
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    for (name, day) in [("work", 1.0), ("zebra", 2.0), ("alpha", 3.0)] {
+      let workspace = try Workspace.create(name: name, home: home)
+      try FileManager.default.setAttributes(
+        [.creationDate: Date(timeIntervalSince1970: day * 86_400)],
+        ofItemAtPath: workspace.url.path)
+    }
+
+    #expect(Workspace.all(home: home).map(\.slug).prefix(4) == ["", "work", "zebra", "alpha"])
+  }
+
+  @Test
+  func renamingAWorkspaceKeepsItsPlaceInTheList() throws {
+    // `moveItem` carries the creation date across, so the one gesture that changes a
+    // workspace's name does not change which number switches to it.
+    let home = makeHome()
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    let first = try Workspace.create(name: "work", home: home)
+    try FileManager.default.setAttributes(
+      [.creationDate: Date(timeIntervalSince1970: 86_400)], ofItemAtPath: first.url.path)
+    let second = try Workspace.create(name: "oss", home: home)
+    try FileManager.default.setAttributes(
+      [.creationDate: Date(timeIntervalSince1970: 172_800)], ofItemAtPath: second.url.path)
+
+    _ = try first.renamed(to: "zzz last", home: home)
+
+    #expect(Workspace.all(home: home).map(\.slug).prefix(3) == ["", "zzz-last", "oss"])
   }
 
   @Test


### PR DESCRIPTION
Closes #175.

Two halves of the same complaint.

**The order.** `Workspace.all()` sorted named workspaces alphabetically, so creating one whose name sorted early moved every ⌥⌘<n> behind it onto a different workspace. It is creation order now — Default first, then each one behind it — which only ever appends. A rename keeps its place too, since `moveItem` carries the creation date across.

**The shortcut.** There was no ⌘` binding at all. **Next Workspace** (⌘`) and **Previous Workspace** (⌘⇧`) join `File ▸ Workspace`, walking the same list the numbers are drawn from and wrapping at both ends. The reducer re-reads the list rather than trusting `known` — a keystroke is not a menu opening, and a workspace another instance created since launch is one ⌘` must not skip.

Taking ⌘`/⌘⇧` from the system is safe here: a workspace is a separate app *instance* with one window, so macOS's own window-cycling has nothing to cycle within any of them.

**Docs** — `docs/shortcuts.md` (new rows + a paragraph on what the order is), `README.md`, `docs/index.html`, plus the in-app strings in `WorkspaceNewsView` and `OnboardingPages`.

**Tests** — `WorkspaceCycleTests` (5: step, wrap both ends, single-workspace no-op, list re-read) and three in `WorkspaceTests` for the ordering, including that a rename does not reshuffle. Full suite green; `make check` exits 0 with the same 111/0-serious baseline as main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7EPtZfv4aVREGYV7rDngv