### PR TITLE
fix: worktree hygiene sees merged PRs, and says when a removal was refused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Tuist
 .build/
+# and as a symlink: a worktree that shares the primary checkout's build directory has
+# `.build` as a link, which `.build/` does not match — it then reads as an untracked
+# file forever, and worktree hygiene calls the whole directory dirty because of it.
+.build
 *.xcodeproj
 *.xcworkspace
 Derived/

--- a/GraphcodeKit/Sources/Domain/WorktreeHygiene.swift
+++ b/GraphcodeKit/Sources/Domain/WorktreeHygiene.swift
@@ -2,15 +2,17 @@ import Foundation
 
 /// What git can say about one worktree, read once and carried as plain values.
 ///
-/// `commitsNotLanded` comes from `git cherry` against the default branch, so squash and
-/// rebase merges count as landed. `git branch --merged` alone would call almost every
-/// reclaimable worktree unmerged on a squash-merge repo — the safe group would come back
-/// empty exactly where the feature is needed most.
+/// Whether the work landed is two readings, not one, because `git cherry` alone answers
+/// wrongly for a squash-merged PR of more than one commit — see `WorktreeLanding`, which
+/// is where both are taken.
 public struct WorktreeGitFacts: Codable, Equatable, Sendable {
   /// The branch `commitsNotLanded` was measured against, for the row's summary line.
   public var defaultBranch: String
   /// Patches on this branch with no equivalent in the default branch.
   public var commitsNotLanded: Int
+  /// The branch's whole diff is in the default branch as one squashed commit — the
+  /// merge `commitsNotLanded` cannot see.
+  public var squashLanded: Bool
   /// Staged, unstaged **and untracked** files — untracked included, because that is
   /// where a half-finished experiment lives.
   public var dirtyFileCount: Int
@@ -24,12 +26,13 @@ public struct WorktreeGitFacts: Codable, Equatable, Sendable {
   public var locked: Bool
   public var sizeBytes: Int64?
 
-  public var landed: Bool { commitsNotLanded == 0 }
+  public var landed: Bool { commitsNotLanded == 0 || squashLanded }
   public var clean: Bool { dirtyFileCount == 0 }
 
   public init(
     defaultBranch: String,
     commitsNotLanded: Int,
+    squashLanded: Bool = false,
     dirtyFileCount: Int,
     pushed: Bool,
     prunable: Bool = false,
@@ -38,6 +41,7 @@ public struct WorktreeGitFacts: Codable, Equatable, Sendable {
   ) {
     self.defaultBranch = defaultBranch
     self.commitsNotLanded = commitsNotLanded
+    self.squashLanded = squashLanded
     self.dirtyFileCount = dirtyFileCount
     self.pushed = pushed
     self.prunable = prunable
@@ -109,7 +113,11 @@ public struct WorktreeAssessment: Identifiable, Equatable, Sendable {
     // Locked means a human action stands between here and removal (`git worktree
     // unlock`) — that is "look before removing" by definition, however clean it is.
     if facts.locked { return .lookBeforeRemoving }
-    if facts.landed && facts.clean && facts.pushed, case .none = binding {
+    // Not `pushed`: once the work has landed, every commit on the branch already has an
+    // equivalent in the default branch, so an unpushed tip is nothing left to lose. It
+    // is also the *normal* state of a merged PR — the forge deletes the remote branch,
+    // and `@{upstream}` has answered "gone" ever since.
+    if facts.landed && facts.clean, case .none = binding {
       return .safeToRemove
     }
     return .lookBeforeRemoving
@@ -126,7 +134,18 @@ public struct WorktreeAssessment: Identifiable, Equatable, Sendable {
   /// case the sweeper confirms before forcing.
   public var removalDiscardsFiles: Bool { !facts.prunable && !facts.clean }
 
+  /// How the branch's work reached the default branch, said plainly — this is the line
+  /// that has to answer "but that PR is merged" before anything else on the row does.
+  public var mergedPhrase: String {
+    facts.squashLanded
+      ? "squash-merged into \(facts.defaultBranch)"
+      : "merged into \(facts.defaultBranch)"
+  }
+
   /// The mono summary line under the branch name — what you'd lose, in its own words.
+  /// A landed branch says so first, whatever else is wrong with the directory: leading
+  /// with "1 file uncommitted" on a merged PR is what makes the sweeper look like it
+  /// never noticed the merge.
   public var summary: String {
     if facts.prunable {
       guard !facts.landed else { return "stale admin file · nothing on disk to lose" }
@@ -136,10 +155,12 @@ public struct WorktreeAssessment: Identifiable, Equatable, Sendable {
     }
     if binding.isRunning { return "a loop is running in it" }
     if tier == .safeToRemove {
-      return "landed in \(facts.defaultBranch) · clean tree · no loop bound"
+      return "\(mergedPhrase) · clean tree · no loop bound"
     }
     var reasons: [String] = []
-    if facts.commitsNotLanded > 0 {
+    if facts.landed {
+      reasons.append(mergedPhrase)
+    } else {
       let unit = facts.commitsNotLanded == 1 ? "commit" : "commits"
       reasons.append("\(facts.commitsNotLanded) \(unit) not in \(facts.defaultBranch)")
     }
@@ -147,14 +168,11 @@ public struct WorktreeAssessment: Identifiable, Equatable, Sendable {
       let unit = facts.dirtyFileCount == 1 ? "file" : "files"
       reasons.append("\(facts.dirtyFileCount) \(unit) uncommitted")
     }
-    if !facts.pushed { reasons.append("not pushed") }
+    // Only when the work is still only here: a merged branch whose remote copy the
+    // forge deleted is "not pushed" too, and saying so reads as a reason to keep it.
+    if !facts.pushed && !facts.landed { reasons.append("not pushed") }
     if facts.locked { reasons.append("locked") }
-    if case .stopped = binding {
-      reasons =
-        reasons.isEmpty
-        ? ["merged · but a stopped loop still points here"]
-        : reasons + ["a stopped loop still points here"]
-    }
+    if case .stopped = binding { reasons.append("a stopped loop still points here") }
     return reasons.joined(separator: " · ")
   }
 }

--- a/GraphcodeKit/Sources/Domain/WorktreeLanding.swift
+++ b/GraphcodeKit/Sources/Domain/WorktreeLanding.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// What one worktree's branch has managed to get into the default branch.
+public struct WorktreeLandedReading: Equatable, Sendable {
+  /// Patches on the branch with no equivalent upstream, per `git cherry`.
+  public var commitsNotLanded: Int
+  /// The branch's whole diff is upstream as a single squashed commit.
+  public var squashLanded: Bool
+
+  public init(commitsNotLanded: Int, squashLanded: Bool) {
+    self.commitsNotLanded = commitsNotLanded
+    self.squashLanded = squashLanded
+  }
+
+  public var landed: Bool { commitsNotLanded == 0 || squashLanded }
+}
+
+/// Deciding whether a branch's work has already reached the default branch — the one
+/// question the sweeper's whole safe tier rests on.
+///
+/// `git cherry` alone gets this wrong twice, and both ways round in daily use:
+///
+/// * **Squash merges of more than one commit.** `cherry` matches patch-ids commit by
+///   commit; "Squash and merge" collapses N commits into one combined patch that
+///   matches none of them, so a merged three-commit PR reads as three commits not
+///   landed — forever. The squash probe below is the standard fix: replay the branch's
+///   *whole* diff as one throwaway commit on the merge base and ask `cherry` about
+///   that instead.
+/// * **A stale local default branch.** A PR merged on the forge is not in local `main`
+///   until someone fetches, and a checkout that has been running loops all day is
+///   normally behind. Measuring against `origin/main` as well costs one `cherry` and
+///   answers "is it merged" rather than "have I pulled it yet".
+///
+/// The runner is injected so the sequence is one implementation for both the local and
+/// the SSH client, and testable without a repository.
+public enum WorktreeLanding {
+  public typealias Git = @Sendable (_ arguments: [String]) async -> String?
+
+  /// The refs to measure against — the local default branch, and its remote-tracking
+  /// counterpart when that exists and has moved somewhere else.
+  public static func bases(
+    defaultBranch: String, localTip: String?, remoteTip: String?
+  ) -> [String] {
+    let remote = "refs/remotes/origin/\(defaultBranch)"
+    guard let remoteTip, !remoteTip.isEmpty else { return [defaultBranch] }
+    guard let localTip, !localTip.isEmpty else { return [remote] }
+    return localTip == remoteTip ? [defaultBranch] : [defaultBranch, remote]
+  }
+
+  public static func reading(
+    tip: String, bases: [String], git: Git
+  ) async -> WorktreeLandedReading {
+    var best = WorktreeLandedReading(commitsNotLanded: 1, squashLanded: false)
+    for base in bases {
+      let notLanded = notLandedCount(await git(["cherry", base, tip]))
+      if notLanded == 0 { return WorktreeLandedReading(commitsNotLanded: 0, squashLanded: false) }
+      if await isSquashLanded(tip: tip, base: base, git: git) {
+        return WorktreeLandedReading(commitsNotLanded: notLanded, squashLanded: true)
+      }
+      best.commitsNotLanded = min(best.commitsNotLanded, notLanded)
+    }
+    return best
+  }
+
+  /// A failed or missing `cherry` counts as one commit not landed: every read here
+  /// fails toward the cautious answer, so a git hiccup can only move a worktree *out*
+  /// of the safe tier.
+  static func notLandedCount(_ cherryOutput: String?) -> Int {
+    guard let cherryOutput else { return 1 }
+    let plus = cherryOutput.split(separator: "\n").filter { $0.hasPrefix("+") }.count
+    return plus
+  }
+
+  /// Squashes the branch into one throwaway commit on the merge base and asks `cherry`
+  /// whether *that* patch is upstream. The commit is written to the object store but
+  /// referenced by nothing, so it is ordinary gc fodder.
+  private static func isSquashLanded(tip: String, base: String, git: Git) async -> Bool {
+    guard let mergeBase = await trimmed(git(["merge-base", base, tip])),
+      let tipCommit = await trimmed(git(["rev-parse", tip])),
+      // An ancestor has nothing to squash; `cherry` already answered for it.
+      mergeBase != tipCommit,
+      let tree = await trimmed(git(["rev-parse", "\(tip)^{tree}"])),
+      let probe = await trimmed(
+        git(["commit-tree", tree, "-p", mergeBase, "-m", "graphcode-landed-probe"])),
+      let verdict = await trimmed(git(["cherry", base, probe]))
+    else { return false }
+    return verdict.hasPrefix("-")
+  }
+
+  private static func trimmed(_ output: String?) -> String? {
+    guard let value = output?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty
+    else { return nil }
+    return value
+  }
+}

--- a/GraphcodeKit/Sources/Domain/WorktreeRef.swift
+++ b/GraphcodeKit/Sources/Domain/WorktreeRef.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// An optional git worktree binding for a `LoopNode` — deliberately minimal: only what
 /// `GitClient` needs to create, list, and remove a worktree. See
 /// docs/02-graph-of-loops.md.
@@ -12,5 +14,11 @@ public struct WorktreeRef: Identifiable, Codable, Equatable, Hashable, Sendable 
     self.repositoryPath = repositoryPath
     self.worktreePath = worktreePath
     self.branch = branch
+  }
+
+  /// What to call this worktree in a row or an error line. A detached worktree has no
+  /// branch to name, so its folder stands in.
+  public var displayName: String {
+    branch.isEmpty ? (worktreePath as NSString).lastPathComponent : branch
   }
 }

--- a/graphcode/Sources/Clients/GitClient.swift
+++ b/graphcode/Sources/Clients/GitClient.swift
@@ -85,6 +85,7 @@ extension GitClient: DependencyKey {
       let blocks = parseWorktreeBlocks(output)
         .filter { resolvedPath($0.path) != repoPath }
       let defaultBranch = await discoverDefaultBranch(repositoryPath)
+      let bases = await landingBases(defaultBranch, repositoryPath: repositoryPath)
       // Concurrent, bounded: serial inspection scaled linearly with the backlog — the
       // repositories that need the sweeper most were the ones it was slowest on. Six
       // at a time keeps the process count civil (each inspection is up to three gits).
@@ -101,7 +102,8 @@ extension GitClient: DependencyKey {
               id: block.branch ?? block.path, repositoryPath: repositoryPath,
               worktreePath: block.path, branch: block.branch ?? "")
             let facts = await gitFacts(
-              for: block, defaultBranch: defaultBranch, repositoryPath: repositoryPath)
+              for: block, defaultBranch: defaultBranch, bases: bases,
+              repositoryPath: repositoryPath)
             return (index, WorktreeInspection(ref: ref, facts: facts))
           }
         }
@@ -141,7 +143,7 @@ extension GitClient: DependencyKey {
       }
       // A detached worktree has no ref to delete; its ref travels with an empty branch.
       guard !worktree.branch.isEmpty else { return }
-      // `-D`, not `-d`: the landed check was `git cherry`, which counts squash merges —
+      // `-D`, not `-d`: the landed check counts squash merges (`WorktreeLanding`) —
       // exactly the branches `-d` would refuse. A branch that is already gone shouldn't
       // fail a removal that succeeded.
       _ = try? await run("git", ["-C", worktree.repositoryPath, "branch", "-D", worktree.branch])
@@ -420,6 +422,18 @@ private func discoverDefaultBranch(_ repositoryPath: String) async -> String {
   return current.trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
+/// The refs this repository's worktrees are measured as landed against, read once per
+/// inspection rather than per worktree.
+private func landingBases(_ defaultBranch: String, repositoryPath: String) async -> [String] {
+  func tip(_ ref: String) async -> String? {
+    try? await run("git", ["-C", repositoryPath, "rev-parse", "--verify", "--quiet", ref])
+  }
+  return WorktreeLanding.bases(
+    defaultBranch: defaultBranch,
+    localTip: await tip("refs/heads/\(defaultBranch)"),
+    remoteTip: await tip("refs/remotes/origin/\(defaultBranch)"))
+}
+
 /// Reads one worktree's signals. Every read fails toward the cautious answer — an
 /// unreadable status counts as dirty, a failed cherry as unlanded, a missing upstream
 /// as unpushed — so a git hiccup can only move a worktree *out* of the safe tier.
@@ -428,20 +442,23 @@ private func discoverDefaultBranch(_ repositoryPath: String) async -> String {
 /// "nothing on disk to lose" was once assumed for these, and a pruned registration is
 /// exactly the case where deleting the branch would orphan unlanded commits.
 private func gitFacts(
-  for block: WorktreeBlock, defaultBranch: String, repositoryPath: String
+  for block: WorktreeBlock, defaultBranch: String, bases: [String], repositoryPath: String
 ) async -> WorktreeGitFacts {
-  // Cherry against the branch when there is one, the recorded HEAD when detached —
+  // Measured against the branch when there is one, the recorded HEAD when detached —
   // both answer "does anything here exist only in this worktree".
   let tip = block.branch.map { "refs/heads/\($0)" } ?? block.head
-  let cherry = await tip.asyncFlatMap { tip in
-    try? await run("git", ["-C", repositoryPath, "cherry", defaultBranch, tip])
-  }
-  let commitsNotLanded = (cherry ?? "+").split(separator: "\n")
-    .filter { $0.hasPrefix("+") }.count
+  let landing =
+    await tip.asyncFlatMap { tip in
+      await WorktreeLanding.reading(tip: tip, bases: bases) { arguments in
+        try? await run("git", ["-C", repositoryPath] + arguments)
+      }
+    } ?? WorktreeLandedReading(commitsNotLanded: 1, squashLanded: false)
+  let commitsNotLanded = landing.commitsNotLanded
 
   if block.prunable {
     return WorktreeGitFacts(
-      defaultBranch: defaultBranch, commitsNotLanded: commitsNotLanded, dirtyFileCount: 0,
+      defaultBranch: defaultBranch, commitsNotLanded: commitsNotLanded,
+      squashLanded: landing.squashLanded, dirtyFileCount: 0,
       pushed: true, prunable: true, locked: block.locked)
   }
   let status = try? await run("git", ["-C", block.path, "status", "--porcelain"])
@@ -452,6 +469,7 @@ private func gitFacts(
     ahead.flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) } == 0
   return WorktreeGitFacts(
     defaultBranch: defaultBranch, commitsNotLanded: commitsNotLanded,
+    squashLanded: landing.squashLanded,
     dirtyFileCount: dirtyFileCount, pushed: pushed, prunable: false, locked: block.locked,
     sizeBytes: nil)
 }

--- a/graphcode/Sources/Clients/RemoteGitClient.swift
+++ b/graphcode/Sources/Clients/RemoteGitClient.swift
@@ -39,6 +39,7 @@ extension RemoteGitClient: DependencyKey {
       let blocks = parseWorktreeBlocks(output)
         .filter { RemoteProjectLocation.normalizedPath($0.path) != repositoryPath }
       let defaultBranch = await discoverDefaultBranch(location)
+      let bases = await remoteLandingBases(defaultBranch, location: location)
       var inspections = [WorktreeInspection?](repeating: nil, count: blocks.count)
       await withTaskGroup(of: (Int, WorktreeInspection)?.self) { group in
         var next = 0
@@ -52,7 +53,7 @@ extension RemoteGitClient: DependencyKey {
               id: block.branch ?? block.path, repositoryPath: location.projectPath,
               worktreePath: block.path, branch: block.branch ?? "")
             let facts = await remoteGitFacts(
-              for: block, defaultBranch: defaultBranch, location: location)
+              for: block, defaultBranch: defaultBranch, bases: bases, location: location)
             return (index, WorktreeInspection(ref: ref, facts: facts))
           }
         }
@@ -261,21 +262,41 @@ private func discoverDefaultBranch(_ location: RemoteProjectLocation) async -> S
   return current.trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
+/// `landingBases`, one SSH round trip per ref rather than a local `git`.
+private func remoteLandingBases(
+  _ defaultBranch: String, location: RemoteProjectLocation
+) async -> [String] {
+  let quoted = RemoteProjectLocation.shellQuoted
+  func tip(_ ref: String) async -> String? {
+    try? await runSSH(
+      location, "git -C \(quoted(location.remotePath)) rev-parse --verify --quiet \(ref)")
+  }
+  return WorktreeLanding.bases(
+    defaultBranch: defaultBranch,
+    localTip: await tip("refs/heads/\(defaultBranch)"),
+    remoteTip: await tip("refs/remotes/origin/\(defaultBranch)"))
+}
+
 private func remoteGitFacts(
-  for block: WorktreeBlock, defaultBranch: String, location: RemoteProjectLocation
+  for block: WorktreeBlock, defaultBranch: String, bases: [String],
+  location: RemoteProjectLocation
 ) async -> WorktreeGitFacts {
   let quoted = RemoteProjectLocation.shellQuoted
   let repoPath = location.remotePath
   let tip = block.branch.map { "refs/heads/\($0)" } ?? block.head
-  let cherry = await tip.asyncFlatMap { tip in
-    try? await runSSH(location, "git -C \(quoted(repoPath)) cherry \(defaultBranch) \(tip)")
-  }
-  let commitsNotLanded = (cherry ?? "+").split(separator: "\n")
-    .filter { $0.hasPrefix("+") }.count
+  let landing =
+    await tip.asyncFlatMap { tip in
+      await WorktreeLanding.reading(tip: tip, bases: bases) { arguments in
+        let command = arguments.map(quoted).joined(separator: " ")
+        return try? await runSSH(location, "git -C \(quoted(repoPath)) \(command)")
+      }
+    } ?? WorktreeLandedReading(commitsNotLanded: 1, squashLanded: false)
+  let commitsNotLanded = landing.commitsNotLanded
 
   if block.prunable {
     return WorktreeGitFacts(
-      defaultBranch: defaultBranch, commitsNotLanded: commitsNotLanded, dirtyFileCount: 0,
+      defaultBranch: defaultBranch, commitsNotLanded: commitsNotLanded,
+      squashLanded: landing.squashLanded, dirtyFileCount: 0,
       pushed: true, prunable: true, locked: block.locked)
   }
   let status = try? await runSSH(location, "git -C \(quoted(block.path)) status --porcelain")
@@ -285,6 +306,7 @@ private func remoteGitFacts(
   let pushed = ahead.flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) } == 0
   return WorktreeGitFacts(
     defaultBranch: defaultBranch, commitsNotLanded: commitsNotLanded,
+    squashLanded: landing.squashLanded,
     dirtyFileCount: dirtyFileCount, pushed: pushed, prunable: false, locked: block.locked,
     sizeBytes: nil)
 }

--- a/graphcode/Sources/Features/App/AppFeature+Worktrees.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Worktrees.swift
@@ -33,8 +33,14 @@ extension AppFeature {
     case statsReloadRequested(projectPath: String)
     /// The one gate every removal passes through, *at removal time*: candidates whose
     /// worktree is bound to a currently-running loop — in any open project — are
-    /// dropped here, whatever a snapshot claimed when they were selected.
-    case performRemovals(projectPath: String, candidates: [WorktreeRemovalCandidate])
+    /// dropped here, whatever a snapshot claimed when they were selected. `blocked`
+    /// carries what the caller already refused to attempt, so one report covers both.
+    case performRemovals(
+      projectPath: String, candidates: [WorktreeRemovalCandidate], blocked: [String])
+    /// Every removal reports back, even when it worked: a removal that git refused
+    /// used to be swallowed whole, and a sweeper that closes on a click it did not
+    /// carry out is indistinguishable from one that did.
+    case removalsFinished(projectPath: String, failures: [String])
     case settingsRequested(projectPath: String)
     case settingsDismissed
   }
@@ -126,21 +132,23 @@ struct AppWorktreesReducer: Reducer {
         guard let path else { return .none }
         return reloadStats(path, nodes: allNodes(in: state))
 
-      // Remove closes the sheet and the removal happens back here, in the background —
-      // a child effect would die with the sheet's state the moment it nils. The child
-      // reducer ran first: if it raised the discard confirmation, nothing happens yet.
+      // Remove keeps the sheet up and does the work back here, in the background — a
+      // child effect would die with the sheet's state the moment it nils, and the sheet
+      // is where the answer has to land. The child reducer ran first: if it raised the
+      // discard confirmation, nothing happens yet.
       //
       // The sheet's assessments can be minutes old, so nothing is removed off them
       // directly: the effect re-inspects git (fresh dirtiness, fresh prunability;
       // vanished rows drop out) and routes through `.performRemovals`, where bindings
-      // are re-read from the *live* graphs. `force` alone survives from the click —
-      // it is the human's consent, not a measurement.
+      // are re-read from the *live* graphs.
       case .worktrees(.sweep(.removeTapped)), .worktrees(.sweep(.removeConfirmed)):
-        guard let sweep = state.worktreeSweep, !sweep.isConfirmingRemoval else { return .none }
+        guard let sweep = state.worktreeSweep, !sweep.isConfirmingRemoval, !sweep.isRemoving
+        else { return .none }
         let doomed = sweep.selected
         guard !doomed.isEmpty else { return .none }
         let path = sweep.projectPath
-        state.worktreeSweep = nil
+        state.worktreeSweep?.failure = nil
+        state.worktreeSweep?.isRemoving = true
         return .run { [gitClient, remoteGitClient] send in
           let fresh: [WorktreeInspection]
           if let location = RemoteProjectLocation.parse(projectPath: path) {
@@ -150,37 +158,74 @@ struct AppWorktreesReducer: Reducer {
           }
           let freshByPath = Dictionary(
             uniqueKeysWithValues: fresh.map { ($0.ref.worktreePath, $0) })
-          let candidates = doomed.compactMap { assessment -> WorktreeRemovalCandidate? in
-            guard let current = freshByPath[assessment.ref.worktreePath] else { return nil }
-            return WorktreeRemovalCandidate(
-              ref: current.ref,
-              prunable: current.facts.prunable,
-              force: assessment.removalDiscardsFiles)
+          var candidates: [WorktreeRemovalCandidate] = []
+          var blocked: [String] = []
+          for assessment in doomed {
+            guard let current = freshByPath[assessment.ref.worktreePath] else { continue }
+            // Forcing is decided on what git says *now*; consent is what the human gave
+            // to the sheet. A worktree that has grown uncommitted files since the list
+            // was built would fail an unforced removal without a word, so it is refused
+            // out loud instead.
+            let needsForce = !current.facts.prunable && !current.facts.clean
+            guard !needsForce || assessment.removalDiscardsFiles else {
+              blocked.append(
+                "\(current.ref.displayName): uncommitted files appeared since this list "
+                  + "was built — reopen Worktrees and confirm the discard")
+              continue
+            }
+            candidates.append(
+              WorktreeRemovalCandidate(
+                ref: current.ref, prunable: current.facts.prunable, force: needsForce))
           }
-          await send(.worktrees(.performRemovals(projectPath: path, candidates: candidates)))
+          await send(
+            .worktrees(
+              .performRemovals(projectPath: path, candidates: candidates, blocked: blocked)))
         }
 
-      case .worktrees(.performRemovals(let path, let candidates)):
+      case .worktrees(.performRemovals(let path, let candidates, let blocked)):
         // The removal-time binding check, against every open project's current graph.
         let occupied = Set(
           allNodes(in: state).filter { !$0.isResolved }
             .compactMap(\.worktreeBinding?.worktreePath))
+        let claimed = candidates.filter { occupied.contains($0.ref.worktreePath) }
         let cleared = candidates.filter { !occupied.contains($0.ref.worktreePath) }
-        guard !cleared.isEmpty else { return .none }
+        let refused =
+          blocked
+          + claimed.map { "\($0.ref.displayName): a loop is running in it now" }
+        guard !cleared.isEmpty else {
+          return .send(.worktrees(.removalsFinished(projectPath: path, failures: refused)))
+        }
         return .run { [gitClient, remoteGitClient] send in
+          var failures = refused
           for candidate in cleared {
-            // Failures are quiet by design — the stats reload tells the truth either
-            // way, and whatever survived is there on reopen.
-            if let location = RemoteProjectLocation.parse(projectPath: path) {
-              try? await remoteGitClient.removeWorktreeAndBranch(
-                location, candidate.ref, candidate.prunable, candidate.force)
-            } else {
-              try? await gitClient.removeWorktreeAndBranch(
-                candidate.ref, candidate.prunable, candidate.force)
+            do {
+              if let location = RemoteProjectLocation.parse(projectPath: path) {
+                try await remoteGitClient.removeWorktreeAndBranch(
+                  location, candidate.ref, candidate.prunable, candidate.force)
+              } else {
+                try await gitClient.removeWorktreeAndBranch(
+                  candidate.ref, candidate.prunable, candidate.force)
+              }
+            } catch {
+              failures.append("\(candidate.ref.displayName): \(Self.reason(error))")
             }
           }
-          await send(.worktrees(.statsReloadRequested(projectPath: path)))
+          await send(.worktrees(.removalsFinished(projectPath: path, failures: failures)))
         }
+
+      case .worktrees(.removalsFinished(let path, let failures)):
+        let reload = reloadStats(path, nodes: allNodes(in: state))
+        guard state.worktreeSweep?.projectPath == path else { return reload }
+        state.worktreeSweep?.isRemoving = false
+        guard !failures.isEmpty else {
+          state.worktreeSweep = nil
+          return reload
+        }
+        // The sheet stays up with the reason on it, and re-reads git so the rows agree
+        // with what is actually still there.
+        state.worktreeSweep?.failure = failures.joined(separator: "\n")
+        state.worktreeSweep?.selection = []
+        return .merge(reload, .send(.worktrees(.sweep(.task))))
 
       // Selecting a folder re-reads its worktrees — the one moment a worktree created
       // outside the app (a terminal's `git worktree add`, a loop's own plumbing) gets
@@ -241,12 +286,30 @@ struct AppWorktreesReducer: Reducer {
           .worktrees(
             .performRemovals(
               projectPath: path,
-              candidates: [WorktreeRemovalCandidate(ref: ref, prunable: false, force: false)])))
+              candidates: [WorktreeRemovalCandidate(ref: ref, prunable: false, force: false)],
+              blocked: [])))
 
       default:
         return .none
       }
     }
+  }
+}
+
+/// The reducer's helpers, in an extension so the reducer body stays the only thing
+/// in the type.
+extension AppWorktreesReducer {
+  /// Git's own words for why a removal failed, without the Swift error wrapper around
+  /// them — "contains modified or untracked files" is the whole answer, and the rest of
+  /// `GitClientError`'s description is noise on a sheet.
+  static func reason(_ error: any Error) -> String {
+    guard case .commandFailed(_, _, let output) = error as? GitClientError else {
+      return String(describing: error)
+    }
+    let lines = output.split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
+    let message = lines.first { !$0.isEmpty && !$0.hasPrefix("hint:") } ?? ""
+    guard !message.isEmpty else { return String(describing: error) }
+    return message.hasPrefix("fatal: ") ? String(message.dropFirst("fatal: ".count)) : message
   }
 
   /// The global graph is not a folder — it has nothing to sweep.
@@ -396,7 +459,8 @@ struct AppWorktreesReducer: Reducer {
               candidates: [
                 WorktreeRemovalCandidate(
                   ref: inspection.ref, prunable: inspection.facts.prunable, force: false)
-              ])))
+              ],
+              blocked: [])))
       case .ask:
         await send(
           .projects(

--- a/graphcode/Sources/Features/Worktrees/WorktreeSweepFeature.swift
+++ b/graphcode/Sources/Features/Worktrees/WorktreeSweepFeature.swift
@@ -24,6 +24,9 @@ struct WorktreeSweepFeature {
     /// Up while the "this discards uncommitted files" confirmation is showing — the
     /// gate between selecting a dirty worktree and actually forcing it away.
     var isConfirmingRemoval = false
+    /// Up from the click until every removal has answered. The sheet stays on screen
+    /// for it: git can refuse a removal, and that refusal has nowhere else to land.
+    var isRemoving = false
     /// Worktree paths whose `git worktree unlock` is in flight — their button is
     /// disabled so a double click can't race two unlocks.
     var unlocking: Set<String> = []
@@ -60,9 +63,9 @@ struct WorktreeSweepFeature {
     case rowToggled(String)
     case allSafeToggled
     /// Remove doesn't remove here: this scope only decides whether the discard
-    /// confirmation must intervene. `AppWorktreesReducer` intercepts the same actions,
-    /// closes the sheet, and runs the removal in the background — the sheet must not
-    /// outlive the click, and a child effect would die with the sheet's state.
+    /// confirmation must intervene. `AppWorktreesReducer` intercepts the same actions
+    /// and runs the removal — it is the only scope that can see every project's loops,
+    /// and a child effect would die with the sheet's state.
     case removeTapped
     /// The dirty-selection confirmation's two exits.
     case removeConfirmed
@@ -148,7 +151,8 @@ struct WorktreeSweepFeature {
         return .none
 
       case .rowToggled(let id):
-        guard let assessment = state.assessments?.first(where: { $0.id == id }),
+        guard !state.isRemoving,
+          let assessment = state.assessments?.first(where: { $0.id == id }),
           assessment.isRemovable
         else { return .none }
         if state.selection.contains(id) {
@@ -171,6 +175,7 @@ struct WorktreeSweepFeature {
         // Losing uncommitted files is the one cost a click alone must not carry —
         // the confirmation names it before anything is forced. A clean selection
         // passes straight through to the parent's interception.
+        guard !state.isRemoving else { return .none }
         if state.selected.contains(where: \.removalDiscardsFiles) {
           state.isConfirmingRemoval = true
         }

--- a/graphcode/Sources/Features/Worktrees/WorktreeSweepView.swift
+++ b/graphcode/Sources/Features/Worktrees/WorktreeSweepView.swift
@@ -39,7 +39,8 @@ struct WorktreeSweepView: View {
         Text(failure)
           .font(.system(size: 11))
           .foregroundStyle(Color(red: 1.0, green: 0.541, blue: 0.502))
-          .lineLimit(3)
+          .lineLimit(6)
+          .fixedSize(horizontal: false, vertical: true)
       }
       Divider().overlay(.white.opacity(0.08))
       footer
@@ -222,11 +223,8 @@ struct WorktreeSweepView: View {
     return assessment.ref.worktreePath
   }
 
-  /// A detached worktree has no branch to name, so its folder stands in.
   private func rowTitle(_ assessment: WorktreeAssessment) -> String {
-    assessment.ref.branch.isEmpty
-      ? (assessment.ref.worktreePath as NSString).lastPathComponent
-      : assessment.ref.branch
+    assessment.ref.displayName
   }
 
   private func rowContext(_ assessment: WorktreeAssessment) -> String? {
@@ -293,21 +291,28 @@ struct WorktreeSweepView: View {
       }
     } else {
       HStack(spacing: 12) {
+        if store.isRemoving { ProgressView().controlSize(.small) }
         Text(footerSummary)
           .font(.system(size: 12))
           .foregroundStyle(.white.opacity(0.62))
         Spacer()
         Button("Cancel") { dismiss() }
           .keyboardShortcut(.cancelAction)
-        Button("Remove \(store.selected.count)") { store.send(.removeTapped) }
-          .keyboardShortcut(.defaultAction)
-          .disabled(store.selected.isEmpty)
+          .disabled(store.isRemoving)
+        Button(store.isRemoving ? "Removing…" : "Remove \(store.selected.count)") {
+          store.send(.removeTapped)
+        }
+        .keyboardShortcut(.defaultAction)
+        .disabled(store.selected.isEmpty || store.isRemoving)
       }
     }
   }
 
   private var footerSummary: String {
     let count = store.selected.count
+    guard !store.isRemoving else {
+      return "Removing \(count == 1 ? "1 worktree" : "\(count) worktrees")…"
+    }
     guard count > 0 else { return "Nothing selected" }
     let what = count == 1 ? "1 worktree" : "\(count) worktrees"
     guard store.selectedBytes > 0 else { return "Removes \(what)" }

--- a/graphcode/Tests/WorktreeHygieneTests.swift
+++ b/graphcode/Tests/WorktreeHygieneTests.swift
@@ -15,12 +15,13 @@ struct WorktreeHygieneTests {
   }
 
   private func facts(
-    notLanded: Int = 0, dirty: Int = 0, pushed: Bool = true, prunable: Bool = false,
-    locked: Bool = false, size: Int64? = 100
+    notLanded: Int = 0, squashLanded: Bool = false, dirty: Int = 0, pushed: Bool = true,
+    prunable: Bool = false, locked: Bool = false, size: Int64? = 100
   ) -> WorktreeGitFacts {
     WorktreeGitFacts(
-      defaultBranch: "main", commitsNotLanded: notLanded, dirtyFileCount: dirty,
-      pushed: pushed, prunable: prunable, locked: locked, sizeBytes: size)
+      defaultBranch: "main", commitsNotLanded: notLanded, squashLanded: squashLanded,
+      dirtyFileCount: dirty, pushed: pushed, prunable: prunable, locked: locked,
+      sizeBytes: size)
   }
 
   private func node(
@@ -30,11 +31,44 @@ struct WorktreeHygieneTests {
   }
 
   @Test
-  func landedCleanPushedAndUnboundIsSafe() {
+  func landedCleanAndUnboundIsSafe() {
     let assessment = WorktreeAssessment(ref: ref(), facts: facts(), binding: .none)
 
     #expect(assessment.tier == .safeToRemove)
-    #expect(assessment.summary == "landed in main · clean tree · no loop bound")
+    #expect(assessment.summary == "merged into main · clean tree · no loop bound")
+  }
+
+  @Test
+  func aSquashMergedBranchIsSafeAndSaysSo() {
+    // `git cherry` counts every commit of a squash-merged PR as unlanded — the whole
+    // branch arrived upstream as one combined patch that matches none of them.
+    let assessment = WorktreeAssessment(
+      ref: ref(), facts: facts(notLanded: 3, squashLanded: true), binding: .none)
+
+    #expect(assessment.facts.landed)
+    #expect(assessment.tier == .safeToRemove)
+    #expect(assessment.summary == "squash-merged into main · clean tree · no loop bound")
+  }
+
+  @Test
+  func aMergedBranchWhoseRemoteIsGoneIsStillSafe() {
+    // The forge deletes the branch on merge, so `@{upstream}` has read "gone" — and
+    // unpushed — ever since. Nothing is lost by removing it: every commit has an
+    // equivalent in main.
+    let assessment = WorktreeAssessment(ref: ref(), facts: facts(pushed: false), binding: .none)
+
+    #expect(assessment.tier == .safeToRemove)
+    #expect(!assessment.summary.contains("not pushed"))
+  }
+
+  @Test
+  func aMergedWorktreeSaysMergedEvenWhenSomethingElseIsWrong() {
+    // The complaint this answers: a merged PR whose directory has build residue read
+    // as "1 file uncommitted" and never mentioned the merge at all.
+    let dirty = WorktreeAssessment(ref: ref(), facts: facts(dirty: 1), binding: .none)
+
+    #expect(dirty.tier == .lookBeforeRemoving)
+    #expect(dirty.summary == "merged into main · 1 file uncommitted")
   }
 
   @Test
@@ -47,8 +81,8 @@ struct WorktreeHygieneTests {
       WorktreeAssessment(ref: ref(), facts: facts(dirty: 2), binding: .none).tier
         == .lookBeforeRemoving)
     #expect(
-      WorktreeAssessment(ref: ref(), facts: facts(pushed: false), binding: .none).tier
-        == .lookBeforeRemoving)
+      WorktreeAssessment(ref: ref(), facts: facts(notLanded: 1, pushed: false), binding: .none)
+        .tier == .lookBeforeRemoving)
     #expect(
       WorktreeAssessment(
         ref: ref(), facts: facts(), binding: .stopped(loopTitle: "looper")
@@ -103,10 +137,11 @@ struct WorktreeHygieneTests {
 
     let onlyBound = WorktreeAssessment(
       ref: ref(), facts: facts(), binding: .stopped(loopTitle: "looper"))
-    #expect(onlyBound.summary == "merged · but a stopped loop still points here")
+    #expect(onlyBound.summary == "merged into main · a stopped loop still points here")
 
-    let unpushed = WorktreeAssessment(ref: ref(), facts: facts(pushed: false), binding: .none)
-    #expect(unpushed.summary == "not pushed")
+    let unpushed = WorktreeAssessment(
+      ref: ref(), facts: facts(notLanded: 1, pushed: false), binding: .none)
+    #expect(unpushed.summary == "1 commit not in main · not pushed")
   }
 
   @Test

--- a/graphcode/Tests/WorktreeLandingTests.swift
+++ b/graphcode/Tests/WorktreeLandingTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import GraphcodeKit
+import Testing
+
+/// "Has this branch already landed?" — the question the safe tier rests on, and the one
+/// `git cherry` alone answers wrongly for a squash-merged PR of more than one commit.
+///
+/// The git runner is a script of expected commands, so each case fixes both the answer
+/// *and* the sequence that produced it.
+@Suite
+struct WorktreeLandingTests {
+  private actor Recorder {
+    private let answers: [String: String]
+    private(set) var calls: [String] = []
+
+    init(_ answers: [String: String]) { self.answers = answers }
+
+    func run(_ arguments: [String]) -> String? {
+      let command = arguments.joined(separator: " ")
+      calls.append(command)
+      return answers[command]
+    }
+  }
+
+  private func reading(
+    tip: String = "refs/heads/feat", bases: [String] = ["main"], _ answers: [String: String]
+  ) async -> (WorktreeLandedReading, [String]) {
+    let recorder = Recorder(answers)
+    let result = await WorktreeLanding.reading(tip: tip, bases: bases) { arguments in
+      await recorder.run(arguments)
+    }
+    return (result, await recorder.calls)
+  }
+
+  @Test
+  func aCherryCleanBranchNeedsNoSquashProbe() async {
+    let (result, calls) = await reading(["cherry main refs/heads/feat": "- abc123"])
+
+    #expect(result == WorktreeLandedReading(commitsNotLanded: 0, squashLanded: false))
+    #expect(result.landed)
+    #expect(calls == ["cherry main refs/heads/feat"])
+  }
+
+  @Test
+  func aSquashMergedBranchLandsThroughTheProbe() async {
+    // Three commits, one combined patch upstream: `cherry` sees three strangers, the
+    // probe replays them as the one commit the merge actually made.
+    let (result, calls) = await reading([
+      "cherry main refs/heads/feat": "+ a\n+ b\n+ c",
+      "merge-base main refs/heads/feat": "base0",
+      "rev-parse refs/heads/feat": "tip0",
+      "rev-parse refs/heads/feat^{tree}": "tree0",
+      "commit-tree tree0 -p base0 -m graphcode-landed-probe": "probe0",
+      "cherry main probe0": "- probe0",
+    ])
+
+    #expect(result.landed)
+    #expect(result.squashLanded)
+    #expect(result.commitsNotLanded == 3)
+    #expect(calls.last == "cherry main probe0")
+  }
+
+  /// Also the shape of "squash-merged, then someone added another commit": the probe
+  /// hashes the branch's *current* tree, so the extra work stops it matching.
+  @Test
+  func unmergedWorkStaysUnmerged() async {
+    let (result, _) = await reading([
+      "cherry main refs/heads/feat": "+ a",
+      "merge-base main refs/heads/feat": "base0",
+      "rev-parse refs/heads/feat": "tip0",
+      "rev-parse refs/heads/feat^{tree}": "tree0",
+      "commit-tree tree0 -p base0 -m graphcode-landed-probe": "probe0",
+      "cherry main probe0": "+ probe0",
+    ])
+
+    #expect(!result.landed)
+    #expect(result.commitsNotLanded == 1)
+  }
+
+  @Test
+  func aStaleLocalDefaultBranchIsNotTheLastWord() async {
+    // The PR merged on the forge an hour ago; nobody has fetched since. Local `main`
+    // says unmerged, `origin/main` says merged, and merged is the truth.
+    let (result, _) = await reading(
+      bases: ["main", "refs/remotes/origin/main"],
+      [
+        "cherry main refs/heads/feat": "+ a",
+        "merge-base main refs/heads/feat": "base0",
+        "rev-parse refs/heads/feat": "tip0",
+        "rev-parse refs/heads/feat^{tree}": "tree0",
+        "commit-tree tree0 -p base0 -m graphcode-landed-probe": "probe0",
+        "cherry main probe0": "+ probe0",
+        "cherry refs/remotes/origin/main refs/heads/feat": "- a",
+      ])
+
+    #expect(result.landed)
+  }
+
+  @Test
+  func anAncestorTipSkipsTheProbeEntirely() async {
+    // merge-base == tip means the branch is already an ancestor; there is nothing to
+    // squash, and `commit-tree` would only write a pointless object.
+    let (result, calls) = await reading([
+      "cherry main refs/heads/feat": "+ a",
+      "merge-base main refs/heads/feat": "same",
+      "rev-parse refs/heads/feat": "same",
+    ])
+
+    #expect(!result.landed)
+    #expect(!calls.contains { $0.hasPrefix("commit-tree") })
+  }
+
+  @Test
+  func aFailedReadCountsAsUnlanded() async {
+    // Every read here fails toward the cautious answer: a git hiccup can only move a
+    // worktree out of the safe tier, never into it.
+    let (result, _) = await reading([:])
+
+    #expect(!result.landed)
+    #expect(result.commitsNotLanded == 1)
+  }
+
+  @Test
+  func theRemoteDefaultIsMeasuredOnlyWhenItHasMovedAhead() {
+    #expect(
+      WorktreeLanding.bases(defaultBranch: "main", localTip: "a", remoteTip: "a") == ["main"])
+    #expect(
+      WorktreeLanding.bases(defaultBranch: "main", localTip: "a", remoteTip: "b")
+        == ["main", "refs/remotes/origin/main"])
+    // A repository with no remote at all still has a local default branch to answer for.
+    #expect(WorktreeLanding.bases(defaultBranch: "main", localTip: "a", remoteTip: nil) == ["main"])
+    #expect(
+      WorktreeLanding.bases(defaultBranch: "main", localTip: nil, remoteTip: "b")
+        == ["refs/remotes/origin/main"])
+  }
+}

--- a/graphcode/Tests/WorktreeRemovalTests.swift
+++ b/graphcode/Tests/WorktreeRemovalTests.swift
@@ -1,0 +1,221 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// Removing a worktree: the removal is the app's effect, not the sheet's, it re-reads
+/// git rather than trusting a minutes-old row, and — the part that used to be missing —
+/// it says so when it could not go through.
+@Suite
+struct WorktreeRemovalTests {
+  private func inspection(
+    branch: String, dirty: Int = 0, size: Int64? = 100, locked: Bool = false
+  ) -> WorktreeInspection {
+    WorktreeInspection(
+      ref: WorktreeRef(
+        id: branch, repositoryPath: "/repo", worktreePath: "/repo-\(branch)",
+        branch: branch),
+      facts: WorktreeGitFacts(
+        defaultBranch: "main", commitsNotLanded: 0, dirtyFileCount: dirty, pushed: true,
+        locked: locked, sizeBytes: size))
+  }
+
+  /// The state a sheet mid-use would hold, for the app-level removal tests.
+  private func openSweep(
+    _ inspections: [WorktreeInspection], selecting: [String]
+  ) -> WorktreeSweepFeature.State {
+    var sweep = WorktreeSweepFeature.State(
+      projectPath: "/repo", projectName: "repo", nodes: [])
+    sweep.assessments = WorktreeSweepFeature.assessments(inspections, nodes: [])
+    sweep.selection = Set(selecting)
+    return sweep
+  }
+
+  @Test
+  @MainActor
+  func removeRunsInTheAppAndClosesTheSheetOnceItHasAnswered() async {
+    // The removal is the app's effect, not the sheet's — it has to outlive the click.
+    // The sheet closes when every removal has answered, and not before: a refusal has
+    // nowhere else to be reported.
+    let safe = inspection(branch: "landed")
+    let dirty = inspection(branch: "wip", dirty: 2)
+    let removed = LockIsolated<[String]>([])
+    var initial = AppFeature.State(projects: [
+      ProjectFeature.State(
+        graph: LoopGraph(scope: .project(ProjectRef(path: "/repo", name: "repo"))))
+    ])
+    initial.worktreeSweep = openSweep([safe, dirty], selecting: [safe.ref.worktreePath])
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.gitClient.inspectWorktrees = { _ in [safe, dirty] }
+      $0.gitClient.worktreeSizeBytes = { _ in nil }
+      $0.gitClient.removeWorktreeAndBranch = { ref, _, _ in
+        removed.withValue { $0.append(ref.branch) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.worktrees(.sweep(.removeTapped))) {
+      $0.worktreeSweep?.isRemoving = true
+    }
+    await store.receive(\.worktrees.removalsFinished)
+
+    // Only what was selected — the dirty worktree was never touched.
+    #expect(removed.value == ["landed"])
+    #expect(store.state.worktreeSweep == nil)
+    await store.finish()
+  }
+
+  @Test
+  @MainActor
+  func aWorktreeClaimedByALoopAfterSelectionIsNotRemoved() async {
+    // The sheet's assessment can be minutes old. Removal re-checks the live graphs:
+    // a loop that started in the worktree after selection keeps it alive, whatever
+    // the row claimed when it was ticked.
+    let claimed = inspection(branch: "landed")
+    let free = inspection(branch: "spare")
+    let removed = LockIsolated<[String]>([])
+    let runner = LoopNode(
+      title: "Started late", loopType: .goalBased, worktreeBinding: claimed.ref,
+      state: .running)
+    var initial = AppFeature.State(projects: [
+      ProjectFeature.State(
+        graph: LoopGraph(
+          scope: .project(ProjectRef(path: "/repo", name: "repo")), nodes: [runner]))
+    ])
+    initial.worktreeSweep = openSweep(
+      [claimed, free], selecting: [claimed.ref.worktreePath, free.ref.worktreePath])
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.gitClient.inspectWorktrees = { _ in [claimed, free] }
+      $0.gitClient.worktreeSizeBytes = { _ in nil }
+      $0.gitClient.removeWorktreeAndBranch = { ref, _, _ in
+        removed.withValue { $0.append(ref.branch) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.worktrees(.sweep(.removeTapped))) {
+      $0.worktreeSweep?.isRemoving = true
+    }
+    await store.receive(\.worktrees.removalsFinished)
+
+    #expect(removed.value == ["spare"])
+    // Dropping it silently is what made a click look like it did nothing: the sheet
+    // stays up and names the worktree it could not take.
+    #expect(store.state.worktreeSweep?.failure?.contains("landed") == true)
+    await store.finish()
+  }
+
+  @Test
+  @MainActor
+  func aRemovalGitRefusesLeavesTheSheetUpWithGitsReason() async {
+    // The bug this closes: `try?` swallowed every refusal, the sheet closed, the row
+    // came back on reopen, and nothing anywhere said why.
+    let stuck = inspection(branch: "landed")
+    var initial = AppFeature.State(projects: [
+      ProjectFeature.State(
+        graph: LoopGraph(scope: .project(ProjectRef(path: "/repo", name: "repo"))))
+    ])
+    initial.worktreeSweep = openSweep([stuck], selecting: [stuck.ref.worktreePath])
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.gitClient.inspectWorktrees = { _ in [stuck] }
+      $0.gitClient.worktreeSizeBytes = { _ in nil }
+      $0.gitClient.removeWorktreeAndBranch = { _, _, _ in
+        throw GitClientError.commandFailed(
+          command: "git worktree remove", status: 128,
+          output: "fatal: validation failed, cannot remove working tree\nhint: retry")
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.worktrees(.sweep(.removeTapped)))
+    await store.receive(\.worktrees.removalsFinished)
+
+    #expect(store.state.worktreeSweep != nil)
+    #expect(store.state.worktreeSweep?.isRemoving == false)
+    #expect(
+      store.state.worktreeSweep?.failure
+        == "landed: validation failed, cannot remove working tree")
+    await store.finish()
+  }
+
+  @Test
+  @MainActor
+  func aWorktreeThatTurnedDirtyAfterSelectionIsRefusedOutLoud() async {
+    // Consent is the human's, measured freshness is git's. A clean row that grew
+    // uncommitted files since the list was built would fail an unforced removal
+    // without a word, so it is never attempted.
+    let listed = inspection(branch: "landed")
+    let nowDirty = inspection(branch: "landed", dirty: 3)
+    let removed = LockIsolated<[String]>([])
+    var initial = AppFeature.State(projects: [
+      ProjectFeature.State(
+        graph: LoopGraph(scope: .project(ProjectRef(path: "/repo", name: "repo"))))
+    ])
+    initial.worktreeSweep = openSweep([listed], selecting: [listed.ref.worktreePath])
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.gitClient.inspectWorktrees = { _ in [nowDirty] }
+      $0.gitClient.worktreeSizeBytes = { _ in nil }
+      $0.gitClient.removeWorktreeAndBranch = { ref, _, _ in
+        removed.withValue { $0.append(ref.branch) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.worktrees(.sweep(.removeTapped)))
+    await store.receive(\.worktrees.removalsFinished)
+
+    #expect(removed.value.isEmpty)
+    #expect(store.state.worktreeSweep?.failure?.contains("uncommitted files appeared") == true)
+    await store.finish()
+  }
+
+  @Test
+  @MainActor
+  func aDirtySelectionConfirmsThenForcesInTheBackground() async {
+    let dirty = inspection(branch: "wip", dirty: 2)
+    let clean = inspection(branch: "landed")
+    let forced = LockIsolated<[String: Bool]>([:])
+    var initial = AppFeature.State(projects: [
+      ProjectFeature.State(
+        graph: LoopGraph(scope: .project(ProjectRef(path: "/repo", name: "repo"))))
+    ])
+    initial.worktreeSweep = openSweep(
+      [dirty, clean], selecting: [dirty.ref.worktreePath, clean.ref.worktreePath])
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.gitClient.inspectWorktrees = { _ in [dirty, clean] }
+      $0.gitClient.worktreeSizeBytes = { _ in nil }
+      $0.gitClient.removeWorktreeAndBranch = { ref, _, force in
+        forced.withValue { $0[ref.branch] = force }
+      }
+    }
+    store.exhaustivity = .off
+
+    // The dirty selection raises the confirmation and the sheet stays up.
+    await store.send(.worktrees(.sweep(.removeTapped))) {
+      $0.worktreeSweep?.isConfirmingRemoval = true
+    }
+    // Confirming starts the removal; --force reaches exactly the row whose removal
+    // discards files.
+    await store.send(.worktrees(.sweep(.removeConfirmed))) {
+      $0.worktreeSweep?.isConfirmingRemoval = false
+      $0.worktreeSweep?.isRemoving = true
+    }
+    await store.receive(\.worktrees.removalsFinished)
+
+    #expect(forced.value == ["wip": true, "landed": false])
+    #expect(store.state.worktreeSweep == nil)
+    await store.finish()
+  }
+}

--- a/graphcode/Tests/WorktreeSweepFeatureTests.swift
+++ b/graphcode/Tests/WorktreeSweepFeatureTests.swift
@@ -90,88 +90,6 @@ struct WorktreeSweepFeatureTests {
     await store.send(.rowToggled(worktree.ref.worktreePath))
   }
 
-  /// The state a sheet mid-use would hold, for the app-level removal tests.
-  private func openSweep(
-    _ inspections: [WorktreeInspection], selecting: [String]
-  ) -> WorktreeSweepFeature.State {
-    var sweep = WorktreeSweepFeature.State(
-      projectPath: "/repo", projectName: "repo", nodes: [])
-    sweep.assessments = WorktreeSweepFeature.assessments(inspections, nodes: [])
-    sweep.selection = Set(selecting)
-    return sweep
-  }
-
-  @Test
-  @MainActor
-  func removeClosesTheSheetAndRemovesInTheBackground() async {
-    // The sheet must not outlive the click — the removal is the app's effect now, so
-    // it survives the sheet's state being cleared, and the stats refresh afterwards.
-    let safe = inspection(branch: "landed")
-    let dirty = inspection(branch: "wip", dirty: 2)
-    let removed = LockIsolated<[String]>([])
-    var initial = AppFeature.State(projects: [
-      ProjectFeature.State(
-        graph: LoopGraph(scope: .project(ProjectRef(path: "/repo", name: "repo"))))
-    ])
-    initial.worktreeSweep = openSweep([safe, dirty], selecting: [safe.ref.worktreePath])
-    let store = TestStore(initialState: initial) {
-      AppFeature()
-    } withDependencies: {
-      $0.gitClient.inspectWorktrees = { _ in [safe, dirty] }
-      $0.gitClient.worktreeSizeBytes = { _ in nil }
-      $0.gitClient.removeWorktreeAndBranch = { ref, _, _ in
-        removed.withValue { $0.append(ref.branch) }
-      }
-    }
-    store.exhaustivity = .off
-
-    await store.send(.worktrees(.sweep(.removeTapped))) {
-      $0.worktreeSweep = nil
-    }
-    await store.finish()
-
-    // Only what was selected — the dirty worktree was never touched.
-    #expect(removed.value == ["landed"])
-  }
-
-  @Test
-  @MainActor
-  func aWorktreeClaimedByALoopAfterSelectionIsNotRemoved() async {
-    // The sheet's assessment can be minutes old. Removal re-checks the live graphs:
-    // a loop that started in the worktree after selection keeps it alive, whatever
-    // the row claimed when it was ticked.
-    let claimed = inspection(branch: "landed")
-    let free = inspection(branch: "spare")
-    let removed = LockIsolated<[String]>([])
-    let runner = LoopNode(
-      title: "Started late", loopType: .goalBased, worktreeBinding: claimed.ref,
-      state: .running)
-    var initial = AppFeature.State(projects: [
-      ProjectFeature.State(
-        graph: LoopGraph(
-          scope: .project(ProjectRef(path: "/repo", name: "repo")), nodes: [runner]))
-    ])
-    initial.worktreeSweep = openSweep(
-      [claimed, free], selecting: [claimed.ref.worktreePath, free.ref.worktreePath])
-    let store = TestStore(initialState: initial) {
-      AppFeature()
-    } withDependencies: {
-      $0.gitClient.inspectWorktrees = { _ in [claimed, free] }
-      $0.gitClient.worktreeSizeBytes = { _ in nil }
-      $0.gitClient.removeWorktreeAndBranch = { ref, _, _ in
-        removed.withValue { $0.append(ref.branch) }
-      }
-    }
-    store.exhaustivity = .off
-
-    await store.send(.worktrees(.sweep(.removeTapped))) {
-      $0.worktreeSweep = nil
-    }
-    await store.finish()
-
-    #expect(removed.value == ["spare"])
-  }
-
   @Test
   @MainActor
   func theCanvasMenuOpensTheSweeperScopedToItsOwnFolder() async {
@@ -194,43 +112,6 @@ struct WorktreeSweepFeatureTests {
     // Mirrored into the project's own state — the canvas menu's count reads it there.
     #expect(store.state.worktreeStats["/repo"] == stats)
     #expect(store.state.projects[id: "/repo"]?.worktreeStats == stats)
-  }
-
-  @Test
-  @MainActor
-  func aDirtySelectionConfirmsThenForcesInTheBackground() async {
-    let dirty = inspection(branch: "wip", dirty: 2)
-    let clean = inspection(branch: "landed")
-    let forced = LockIsolated<[String: Bool]>([:])
-    var initial = AppFeature.State(projects: [
-      ProjectFeature.State(
-        graph: LoopGraph(scope: .project(ProjectRef(path: "/repo", name: "repo"))))
-    ])
-    initial.worktreeSweep = openSweep(
-      [dirty, clean], selecting: [dirty.ref.worktreePath, clean.ref.worktreePath])
-    let store = TestStore(initialState: initial) {
-      AppFeature()
-    } withDependencies: {
-      $0.gitClient.inspectWorktrees = { _ in [dirty, clean] }
-      $0.gitClient.worktreeSizeBytes = { _ in nil }
-      $0.gitClient.removeWorktreeAndBranch = { ref, _, force in
-        forced.withValue { $0[ref.branch] = force }
-      }
-    }
-    store.exhaustivity = .off
-
-    // The dirty selection raises the confirmation and the sheet stays up.
-    await store.send(.worktrees(.sweep(.removeTapped))) {
-      $0.worktreeSweep?.isConfirmingRemoval = true
-    }
-    // Confirming closes it; --force reaches exactly the row whose removal discards
-    // files.
-    await store.send(.worktrees(.sweep(.removeConfirmed))) {
-      $0.worktreeSweep = nil
-    }
-    await store.finish()
-
-    #expect(forced.value == ["wip": true, "landed": false])
   }
 
   @Test


### PR DESCRIPTION
## What was wrong

**Merged PRs didn't read as merged.** Landing came from `git cherry` against the local default branch, which is wrong two ways:

| Case | Old reading | Why |
|---|---|---|
| GitHub "Squash and merge" of a 3-commit PR | `3 commits not in main`, forever | the squash is one combined patch; it matches none of the three patch-ids |
| PR merged on GitHub, nobody has fetched | `N commits not in main` | the merge is in `origin/main`, not local `main` |
| Merged PR whose remote branch GitHub deleted | `not pushed` | `@{upstream}` is gone, so `pushed` is false and the safe tier was closed to it |

`pushed` no longer gates the safe tier — once the work has landed, every commit has an equivalent in the default branch, so an unpushed tip is nothing left to lose. And a landed branch now says so **first** in the row summary, whatever else is wrong with the directory: leading with `1 file uncommitted` on a merged PR is what made the sweeper look like it had never noticed the merge.

**Removals failed silently.** Every removal was wrapped in `try?`. Git's refusal went nowhere, the sheet closed on a click it had not carried out, and the row came back on reopen with nothing said. The sheet now stays up until the removals answer, and names what it could not take:

- git refused it (its own words, `hint:` lines stripped)
- a loop claimed the worktree between selection and removal
- it grew uncommitted files since the list was built — forcing is decided on what git says *now*, consent stays the human's, so this is refused out loud instead of failing quietly

## Verified

Against real git, in a repo where a 3-commit branch was squash-merged on the forge, the remote branch deleted, and local `main` never fetched:

| | before | after |
|---|---|---|
| facts | `commitsNotLanded: 3, pushed: false` | `commitsNotLanded: 3, squashLanded: true` |
| tier | look before removing | **safe to remove** |
| summary | `3 commits not in main · not pushed` | `squash-merged into main · clean tree · no loop bound` |

A genuinely unmerged branch stays in the look tier, and so does one that gained a commit *after* its squash merge (the probe hashes the branch's current tree).

On this repository's own 23 worktrees the safe tier goes from 0 to 4; the rest are held out by real untracked build residue, which now at least reads as `merged into main · 1 file uncommitted`.

1054 tests pass. `swiftlint` and `swift format lint` report no new violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVkTUnoYTS6ZpTVCKhj2gG