### PR TITLE
fix: report the real number of unlanded commits, not a clamped 1

### DIFF
--- a/GraphcodeKit/Sources/Domain/WorktreeLanding.swift
+++ b/GraphcodeKit/Sources/Domain/WorktreeLanding.swift
@@ -50,16 +50,20 @@ public enum WorktreeLanding {
   public static func reading(
     tip: String, bases: [String], git: Git
   ) async -> WorktreeLandedReading {
-    var best = WorktreeLandedReading(commitsNotLanded: 1, squashLanded: false)
+    // Optional, not a seeded 1: seeding the accumulator with the failure value made
+    // `min` clamp every real count down to it, so a four-commit branch reported "1
+    // commit not in main". The fallback belongs to a read that failed, not to a read
+    // that succeeded and returned four.
+    var fewest: Int?
     for base in bases {
       let notLanded = notLandedCount(await git(["cherry", base, tip]))
       if notLanded == 0 { return WorktreeLandedReading(commitsNotLanded: 0, squashLanded: false) }
       if await isSquashLanded(tip: tip, base: base, git: git) {
         return WorktreeLandedReading(commitsNotLanded: notLanded, squashLanded: true)
       }
-      best.commitsNotLanded = min(best.commitsNotLanded, notLanded)
+      fewest = min(fewest ?? notLanded, notLanded)
     }
-    return best
+    return WorktreeLandedReading(commitsNotLanded: fewest ?? 1, squashLanded: false)
   }
 
   /// A failed or missing `cherry` counts as one commit not landed: every read here

--- a/graphcode/Tests/WorktreeLandingTests.swift
+++ b/graphcode/Tests/WorktreeLandingTests.swift
@@ -78,6 +78,46 @@ struct WorktreeLandingTests {
   }
 
   @Test
+  func theCountOfUnlandedCommitsIsReportedAsMeasured() async {
+    // The row says how much is at stake, so the number has to be the real one — a
+    // clamped count read "1 commit not in main" on a branch with four.
+    let (result, _) = await reading([
+      "cherry main refs/heads/feat": "+ a\n+ b\n+ c\n+ d",
+      "merge-base main refs/heads/feat": "base0",
+      "rev-parse refs/heads/feat": "tip0",
+      "rev-parse refs/heads/feat^{tree}": "tree0",
+      "commit-tree tree0 -p base0 -m graphcode-landed-probe": "probe0",
+      "cherry main probe0": "+ probe0",
+    ])
+
+    #expect(result.commitsNotLanded == 4)
+    #expect(!result.landed)
+  }
+
+  @Test
+  func theNearerOfTwoBasesIsTheOneReported() async {
+    // Local `main` is behind, so it sees more outstanding than `origin/main` does.
+    // Neither says landed; the honest number is the smaller one.
+    let (result, _) = await reading(
+      bases: ["main", "refs/remotes/origin/main"],
+      [
+        "cherry main refs/heads/feat": "+ a\n+ b\n+ c",
+        "merge-base main refs/heads/feat": "base0",
+        "rev-parse refs/heads/feat": "tip0",
+        "rev-parse refs/heads/feat^{tree}": "tree0",
+        "commit-tree tree0 -p base0 -m graphcode-landed-probe": "probe0",
+        "cherry main probe0": "+ probe0",
+        "cherry refs/remotes/origin/main refs/heads/feat": "+ c",
+        "merge-base refs/remotes/origin/main refs/heads/feat": "base1",
+        "commit-tree tree0 -p base1 -m graphcode-landed-probe": "probe1",
+        "cherry refs/remotes/origin/main probe1": "+ probe1",
+      ])
+
+    #expect(result.commitsNotLanded == 1)
+    #expect(!result.landed)
+  }
+
+  @Test
   func aStaleLocalDefaultBranchIsNotTheLastWord() async {
     // The PR merged on the forge an hour ago; nobody has fetched since. Local `main`
     // says unmerged, `origin/main` says merged, and merged is the truth.


### PR DESCRIPTION
Regression from #177, caught reading the sweeper's own output.

`WorktreeLanding.reading` seeds the "fewest outstanding across the bases" accumulator with `1` — the value a *failed* `git cherry` falls back to. `min` then clamps every real count down to it:

| Branch | True count | Reported before | Reported after |
|---|---|---|---|
| 4 commits outstanding | 4 | `1 commit not in main` | `4 commits not in main` |
| 40 commits outstanding | 40 | `1 commit not in main` | `40 commits not in main` |

Reachable with a single base, so it affected every unmerged worktree in every repo. The landed/not-landed verdict was never wrong — only the number, which is exactly what that line exists to tell you.

The fallback now applies only when the read actually failed. Two tests: a four-commit branch reports four, and with two bases the nearer (smaller) count wins.