### PR TITLE
fix: keep a /loop directive at the front of the prompt it rides in

### DIFF
--- a/GraphcodeKit/Sources/Domain/BackendCommand.swift
+++ b/GraphcodeKit/Sources/Domain/BackendCommand.swift
@@ -102,9 +102,14 @@ extension CLISessionBackendKind {
       guard let briefingPath else { return model + access + ["--interactive", prompt] }
       // And the preamble telling it the briefing is there to read. See
       // `SessionBriefing.pointer` for why the tidier env-var route was abandoned.
+      // Ordered by `SessionPrompt`, not concatenated: a time-based node's prompt is the
+      // `/loop …` directive itself, and Copilot is the one backend that both hosts that
+      // loop type and receives its briefing as a preamble (issue #179).
       return model + access
         + [
-          "--interactive", "\(SessionBriefing.pointer(toBriefingAt: briefingPath)) \(prompt)",
+          "--interactive",
+          SessionPrompt.composed(
+            preamble: SessionBriefing.pointer(toBriefingAt: briefingPath), prompt: prompt),
         ]
     case .codex:
       // Same shape as Claude Code — an interactive TUI taking its prompt positionally —
@@ -113,14 +118,21 @@ extension CLISessionBackendKind {
       let access = settings.codexApprovals.writableDirectories(workspacePaths)
       guard let briefingPath, let briefingDirectory else { return model + access + [prompt] }
       return model + access + ["--add-dir", briefingDirectory]
-        + ["\(SessionBriefing.pointer(toBriefingAt: briefingPath)) \(prompt)"]
+        + [
+          SessionPrompt.composed(
+            preamble: SessionBriefing.pointer(toBriefingAt: briefingPath), prompt: prompt)
+        ]
     case .openCode:
       // The prompt is the value of `--prompt`, the briefing a pointer inside it. No
       // directory grant: OpenCode's `read` permission defaults to allow, and `--auto`
       // approves everything not explicitly denied, so the briefing is readable as is.
       guard let briefingPath else { return model + ["--prompt", prompt] }
       return model
-        + ["--prompt", "\(SessionBriefing.pointer(toBriefingAt: briefingPath)) \(prompt)"]
+        + [
+          "--prompt",
+          SessionPrompt.composed(
+            preamble: SessionBriefing.pointer(toBriefingAt: briefingPath), prompt: prompt),
+        ]
     }
   }
 

--- a/GraphcodeKit/Sources/Domain/SessionPrompt.swift
+++ b/GraphcodeKit/Sources/Domain/SessionPrompt.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// How an opening prompt and the preambles graphcode wraps around it are ordered.
+///
+/// Every backend graphcode drives reads a leading `/` as a slash command and anything
+/// else as prose, and the prompts graphcode composes are not just the human's text: a
+/// session is told where its briefing is (`SessionBriefing.pointer`) and where its wake
+/// digest is (`NodeMemory`), both by preamble on the same message. Concatenating those
+/// in front is what a preamble usually means, and for prose it is right.
+///
+/// It is wrong for exactly one prompt shape, and that shape is a whole loop type. A
+/// time-based node's prompt *is* a slash command — `/loop 1h …`, the directive that makes
+/// the session re-trigger itself, since graphcode holds no timer of its own
+/// (`ZmxSessionLauncher`). Buried mid-message it is literal text: no schedule is created,
+/// the loop runs exactly one pass and sits `idle` forever. Copilot hosts time-based loops
+/// and receives its briefing as a preamble, so it got both halves of that and never armed
+/// recurrence at all (issue #179).
+///
+/// So the preamble trails a prompt that opens with a directive and leads one that doesn't.
+/// Trailing costs nothing: `/loop <interval> <task>` takes the rest of the line as the
+/// task, so the pointer travels into every scheduled pass rather than only the first.
+public enum SessionPrompt {
+  /// Whether `prompt` opens with something its backend will read as a command rather than
+  /// prose. A leading `/` is the whole test — a prompt that opens with an absolute path
+  /// matches too, and trailing the preamble there is merely a different word order.
+  public static func opensWithDirective(_ prompt: String) -> Bool {
+    prompt.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("/")
+  }
+
+  /// `prompt` with `preamble` on whichever side keeps a leading directive leading.
+  public static func composed(preamble: String, prompt: String) -> String {
+    guard opensWithDirective(prompt) else { return "\(preamble) \(prompt)" }
+    let directive = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+    // A sentence boundary the human's task text can't be relied on to bring: without it
+    // "…check the queue Before anything else, read…" reads as one run-on instruction.
+    let separator = directive.last.map { ".!?".contains($0) } == true ? " " : ". "
+    return "\(directive)\(separator)\(preamble)"
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/NodeMemory.swift
+++ b/GraphcodeKit/Sources/Sessions/NodeMemory.swift
@@ -321,6 +321,14 @@ public enum NodeMemory {
       + "carry out everything it says."
   }
 
+  /// What points a waking session at its own digest. Self-contained rather than a
+  /// "…, then:" joiner, because `SessionPrompt` may put it on either side of the prompt:
+  /// a time-based node's prompt is the `/loop …` directive, which stops being a command
+  /// the moment anything precedes it (issue #179).
+  public static func wakePointer(toDigestAt path: String) -> String {
+    "Read your loop memory at \(path) before starting."
+  }
+
   /// Removes a node's memory directory — called when the node itself is deleted, the
   /// same moment its session is torn down. A log for a loop that no longer exists is
   /// not history, it's litter.

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -503,8 +503,9 @@ public enum ZmxSessionLauncher {
       wakePath = wakeFile?.path
     }
     let promptWithMemory =
-      wakePath.map { "Read your loop memory at \($0) before starting. Then: \(singleLine)" }
-      ?? singleLine
+      wakePath.map {
+        SessionPrompt.composed(preamble: NodeMemory.wakePointer(toDigestAt: $0), prompt: singleLine)
+      } ?? singleLine
     // Both the executable and the shape of its arguments come from the node's backend —
     // `claude` takes its prompt positionally and its briefing via `--append-system-prompt`,
     // `copilot` takes both together as `--interactive <prompt>`. Model tier is applied
@@ -586,8 +587,9 @@ public enum ZmxSessionLauncher {
       // The file carries the *unflattened* prompt — a file has no newline hazard, so a
       // pasted multi-line goal survives verbatim where the typed line had to collapse it.
       let filePrompt =
-        wakePath.map { "Read your loop memory at \($0) before starting. Then: \(prompt)" }
-        ?? prompt
+        wakePath.map {
+          SessionPrompt.composed(preamble: NodeMemory.wakePointer(toDigestAt: $0), prompt: prompt)
+        } ?? prompt
       guard let projectPath,
         let promptFile = NodeMemory.writePrompt(
           filePrompt, projectPath: projectPath, nodeID: node.id)

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -260,8 +260,9 @@ struct GhosttyTerminalView: NSViewRepresentable {
     remoteLocation == nil ? workingDirectory : nil
   }
 
-  /// What rides into the session through the environment: the opening prompt, prefixed
-  /// for Copilot and Codex with the pointer at the briefing file. In the env var rather
+  /// What rides into the session through the environment: the opening prompt, carrying
+  /// for Copilot and Codex the pointer at the briefing file — on whichever side keeps a
+  /// leading `/loop` directive leading (`SessionPrompt`). In the env var rather
   /// than on the command line because the pointer is prose — inside `"$VAR"` it needs no
   /// quoting and cannot break the shell string the command is joined into. Claude's
   /// prompt stays untouched: its briefing arrives via `--append-system-prompt-file`.
@@ -269,7 +270,8 @@ struct GhosttyTerminalView: NSViewRepresentable {
     var environment = backend.presenceEnvironment(hooksFile: hooksFile)
     guard var prompt = initialPrompt else { return environment }
     if backend != .claudeCode, let briefingPath {
-      prompt = "\(SessionBriefing.pointer(toBriefingAt: briefingPath)) \(prompt)"
+      prompt = SessionPrompt.composed(
+        preamble: SessionBriefing.pointer(toBriefingAt: briefingPath), prompt: prompt)
     }
     environment[Self.promptVariable] = prompt
     return environment

--- a/graphcode/Tests/SessionBriefingTests.swift
+++ b/graphcode/Tests/SessionBriefingTests.swift
@@ -200,10 +200,12 @@ struct SessionBriefingTests {
       #expect(granted.contains { $0.contains("briefings") })
     }
 
+    // The node polls, so its prompt is a `/loop` directive and the pointer trails it —
+    // see `theLoopDirectiveKeepsTheFrontOfACopilotPrompt`.
     let interactive = try #require(arguments.firstIndex(of: "--interactive"))
     let opening = arguments[interactive + 1]
     #expect(opening.contains(".md"))
-    #expect(opening.hasSuffix("/loop 1h Check"))
+    #expect(opening.hasPrefix("/loop 1h Check"))
   }
 
   @Test

--- a/graphcode/Tests/SessionPromptTests.swift
+++ b/graphcode/Tests/SessionPromptTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// Where the preambles graphcode wraps around a session's opening prompt are allowed to
+/// sit. Every backend reads a leading `/` as a command and anything else as prose, and a
+/// time-based node's prompt *is* a command — the `/loop …` directive that makes the
+/// session re-trigger itself, since graphcode holds no timer of its own. A preamble in
+/// front of it is not a preamble, it is a silently disabled loop type (issue #179).
+@Suite
+struct SessionPromptTests {
+  /// Copilot is the backend that both hosts time-based loops and takes its briefing as a
+  /// preamble, so the briefing pushed the directive mid-message, Copilot read it as
+  /// literal text, no schedule was ever created, and the loop ran one pass and sat
+  /// `idle` forever.
+  @Test
+  func theLoopDirectiveKeepsTheFrontOfACopilotPrompt() throws {
+    let arguments = CLISessionBackendKind.copilotCLI.launchArguments(
+      prompt: "/loop 1h Check the queue", tier: .standard,
+      briefingPath: "/tmp/briefings/x/AGENTS.md")
+
+    let interactive = try #require(arguments.firstIndex(of: "--interactive"))
+    let opening = arguments[interactive + 1]
+    #expect(opening.hasPrefix("/loop 1h Check the queue"))
+    // Trailing, not dropped: `/loop <interval> <task>` takes the rest of the line as the
+    // task, so the briefing reaches every scheduled pass rather than none of them.
+    #expect(opening.contains("/tmp/briefings/x/AGENTS.md"))
+  }
+
+  /// The other half of the same rule, and the one issue #2 bought: an ordinary prose
+  /// prompt still opens with the pointer, because a session that reads its briefing after
+  /// the work is a session that never fanned out.
+  @Test
+  func anOrdinaryPromptStillOpensWithTheBriefingPointer() throws {
+    let arguments = CLISessionBackendKind.copilotCLI.launchArguments(
+      prompt: "fix the failing test", tier: .standard,
+      briefingPath: "/tmp/briefings/x/AGENTS.md")
+
+    let interactive = try #require(arguments.firstIndex(of: "--interactive"))
+    #expect(arguments[interactive + 1].hasPrefix("Before anything else"))
+    #expect(arguments[interactive + 1].hasSuffix("fix the failing test"))
+  }
+
+  /// The wake digest is the second preamble a launched session carries (`NodeMemory`),
+  /// and it buried the directive on every relaunch after the first pass — including on
+  /// Claude Code, whose briefing rides a flag and so looked immune.
+  @Test
+  func theWakeDigestPointerTrailsADirectiveToo() {
+    let composed = SessionPrompt.composed(
+      preamble: NodeMemory.wakePointer(toDigestAt: "/tmp/m/WAKE.md"),
+      prompt: "/loop 30m Triage new issues")
+    #expect(composed.hasPrefix("/loop 30m Triage new issues"))
+    #expect(composed.contains("/tmp/m/WAKE.md"))
+  }
+
+  @Test
+  func aTrailingPreambleGetsItsOwnSentence() {
+    // Without the boundary the task and the preamble run together into one instruction:
+    // "...Triage new issues Read your loop memory at...".
+    #expect(
+      SessionPrompt.composed(preamble: "Read the file.", prompt: "/loop 1h Triage")
+        == "/loop 1h Triage. Read the file.")
+    #expect(
+      SessionPrompt.composed(preamble: "Read the file.", prompt: "/loop 1h Triage.")
+        == "/loop 1h Triage. Read the file.")
+  }
+}


### PR DESCRIPTION
Fixes #179.

## What was wrong

A `timeBased` node's prompt **is** a slash command — `/loop <interval> …`, the directive that makes the session re-trigger itself, since graphcode holds no timer of its own. Every backend reads a leading `/` as a command and anything else as prose.

graphcode wraps two preambles around that prompt, both concatenated in **front**:

| Preamble | Site | Backends |
|---|---|---|
| Briefing pointer | `BackendCommand.launchArguments` | Copilot, Codex, OpenCode |
| Briefing pointer | `GhosttyTerminalView.sessionEnvironment` | Copilot, Codex, OpenCode |
| Wake digest pointer | `ZmxSessionLauncher` | **all four, Claude Code included** |

Copilot had both halves — the only backend that both hosts `timeBased` loops and takes its briefing as a preamble — so its recurrence has never armed since the capability was enabled in `7721be3`. `manage_schedule list` reports no scheduled prompts while the node shows `idle timeBased`.

The wake digest row is the part the issue didn't cover: `"Read your loop memory at … Then: /loop 1h …"` buries the directive on **every relaunch after the first pass**, on Claude Code too. Fixing only the briefing would have left Copilot `timeBased` still broken on relaunch.

## The fix

`SessionPrompt.composed(preamble:prompt:)` decides the side: a preamble leads a prose prompt and trails one that opens with a directive, with a sentence boundary inserted so the two don't run together. Trailing costs nothing — `/loop <interval> <task>` takes the rest of the line as the task, so the pointer reaches every scheduled pass rather than only the first.

## Not in this change

The daemon-heartbeat route (`heartbeatIntervalSeconds` + `daemonHeartbeatEnabled`) is **untouched** — zero heartbeat lines in the diff. It's being tested separately.

## Verification

- `xcodebuild … test` — 1067 tests in 114 suites, all pass
- `make check` — exit 0, no new warnings in the touched files
- New `SessionPromptTests`: directive keeps the front, prose prompts still open with the pointer, wake digest trails a directive, sentence boundary is inserted
- `copilotIsBothToldToReadTheBriefingAndAllowedTo` previously asserted `opening.hasSuffix("/loop 1h Check")` — it pinned the broken ordering, and now asserts `hasPrefix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyMWkpMbY295brojUPbFRE