### PR TITLE
fix: relaunch into the default workspace, and start a Copilot time-based loop now

### DIFF
--- a/GraphcodeKit/Sources/Domain/BackendCommand.swift
+++ b/GraphcodeKit/Sources/Domain/BackendCommand.swift
@@ -99,13 +99,21 @@ extension CLISessionBackendKind {
       // why the directories are granted explicitly rather than trusted to the tool flag.
       let access = settings.copilotPermissions.readableDirectories(
         workspacePaths + [briefingDirectory].compactMap { $0 })
-      guard let briefingPath else { return model + access + ["--interactive", prompt] }
+      // `/loop` — an alias of `/every` — is behind Copilot's experimental flag, so
+      // without this the directive a time-based node opens with is not a command at all
+      // and the session reads it as prose: no schedule, one pass, then idle. Passed only
+      // for a prompt that actually is one, so an ordinary Copilot session keeps the
+      // CLI's own defaults.
+      let experimental = SessionPrompt.firstPass(of: prompt) != nil ? ["--experimental"] : []
+      guard let briefingPath else {
+        return model + access + experimental + ["--interactive", prompt]
+      }
       // And the preamble telling it the briefing is there to read. See
       // `SessionBriefing.pointer` for why the tidier env-var route was abandoned.
       // Ordered by `SessionPrompt`, not concatenated: a time-based node's prompt is the
       // `/loop …` directive itself, and Copilot is the one backend that both hosts that
       // loop type and receives its briefing as a preamble (issue #179).
-      return model + access
+      return model + access + experimental
         + [
           "--interactive",
           SessionPrompt.composed(

--- a/GraphcodeKit/Sources/Domain/SessionPrompt.swift
+++ b/GraphcodeKit/Sources/Domain/SessionPrompt.swift
@@ -27,6 +27,30 @@ public enum SessionPrompt {
     prompt.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("/")
   }
 
+  /// The recurring directives a session's own scheduler understands. Copilot's `/loop`
+  /// is an alias of `/every`; both take an interval and then the prompt to submit.
+  static let recurringDirectives = ["/loop", "/every"]
+
+  /// The task inside a `/loop <interval> …` directive — everything the schedule will
+  /// submit, without the directive that schedules it. `nil` when the prompt is not one.
+  ///
+  /// What it is for: `/every` submits its prompt *after* the first interval elapses, so
+  /// arming an hourly loop does nothing at all for an hour. Sending this text as an
+  /// ordinary message gives the session the pass now that the schedule will not give
+  /// until later (`ZmxSessionLauncher`).
+  public static func firstPass(of prompt: String) -> String? {
+    let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+    for directive in recurringDirectives where trimmed.hasPrefix("\(directive) ") {
+      let afterDirective = trimmed.dropFirst(directive.count).drop { $0 == " " }
+      // The interval is one token; everything past it is the prompt the schedule carries.
+      guard let interval = afterDirective.firstIndex(of: " ") else { return nil }
+      let task = afterDirective[afterDirective.index(after: interval)...]
+        .trimmingCharacters(in: .whitespaces)
+      return task.isEmpty ? nil : task
+    }
+    return nil
+  }
+
   /// `prompt` with `preamble` on whichever side keeps a leading directive leading.
   public static func composed(preamble: String, prompt: String) -> String {
     guard opensWithDirective(prompt) else { return "\(preamble) \(prompt)" }

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -1234,10 +1234,86 @@ public enum ZmxSessionLauncher {
       DialLog.record(session: name, dial: "ensure", event: "resume-dead")
       SessionIDStore.remove(forNodeID: node.id)
     }
+    // Noted *before* the launch: the first pass below waits for a Copilot session
+    // directory that was not already there, which is how it tells a session it just
+    // started from one this ensure found already running.
+    let copilotSessionBefore =
+      firstPassMessage(for: node) != nil
+      ? CopilotSessionLog.directory(forSessionNamed: name)?.lastPathComponent : nil
     await atomicCheckOrRun(
       checkArguments: checkArgs, runArguments: runArgs,
       zmxPath: zmxPath, workingDirectory: wd,
       logFragment: DialLog.fragment(session: name, dial: "ensure", event: "fresh"))
+    await kickOffFirstPass(
+      of: node, sessionNamed: name, projectPath: projectPath, after: copilotSessionBefore)
+  }
+
+  /// The message that gives a Copilot time-based loop the pass its schedule will not give
+  /// it for another whole interval, or `nil` for a node that needs no such thing.
+  ///
+  /// `/loop` is an alias of Copilot's `/every`, and `/every` submits its prompt *after*
+  /// the interval has elapsed — documented behaviour, not a bug in it. So an hourly loop
+  /// arms correctly and then does nothing for an hour, which from the outside is
+  /// indistinguishable from a loop that never started. The directive stays the thing the
+  /// session opens with (it must lead its message to be a command at all, see
+  /// `SessionPrompt`); this types the same task in afterwards as ordinary input.
+  ///
+  /// Nothing to do for a heartbeat node — the daemon holds that timer and drives the
+  /// first beat itself — or for any backend whose recurrence is not a scheduler.
+  static func firstPassMessage(for node: LoopNode) -> String? {
+    guard node.backend == .copilotCLI, node.loopType == .timeBased,
+      node.heartbeatIntervalSeconds == nil, let prompt = node.sessionPrompt
+    else { return nil }
+    return SessionPrompt.firstPass(of: prompt)
+  }
+
+  /// Types that first pass in, once the session it belongs to is actually there to
+  /// receive it.
+  ///
+  /// Gated on a *new* Copilot session directory rather than on the launch returning: an
+  /// ensure whose session already existed launched nothing, and typing the task into a
+  /// loop already running it is a second pass nobody asked for. Waiting for the directory
+  /// is also what keeps the keystrokes out of a CLI that has not drawn its composer yet,
+  /// where they are simply lost.
+  ///
+  /// Detached because the wait is seconds long and `start` is on the ensure path, which
+  /// has other nodes to get to.
+  private static func kickOffFirstPass(
+    of node: LoopNode, sessionNamed name: String, projectPath: String?, after previous: String?
+  ) async {
+    guard let message = firstPassMessage(for: node) else { return }
+    Task {
+      guard await FirstPassTickets.shared.claim(node.id) else { return }
+      defer { Task { await FirstPassTickets.shared.release(node.id) } }
+      let deadline = Date().addingTimeInterval(firstPassWaitSeconds)
+      while Date() < deadline {
+        let current = CopilotSessionLog.directory(forSessionNamed: name)?.lastPathComponent
+        if let current, current != previous {
+          // The directory appears as Copilot opens its session, a moment before its
+          // composer can take input. The settle is the same forgiveness `resume` gets.
+          try? await Task.sleep(for: .seconds(firstPassSettleSeconds))
+          _ = await send(message, to: node, projectPath: projectPath)
+          return
+        }
+        try? await Task.sleep(for: .seconds(firstPassPollSeconds))
+      }
+    }
+  }
+
+  /// How long to wait for a launched Copilot session to appear before giving up on its
+  /// first pass. Generous: the loop is still correctly armed either way, so the cost of
+  /// waiting too long is nothing and the cost of giving up early is an idle hour.
+  static let firstPassWaitSeconds: TimeInterval = 90
+  static let firstPassPollSeconds: TimeInterval = 0.5
+  static let firstPassSettleSeconds: TimeInterval = 3
+
+  /// One first-pass message per node at a time. Two ensure ticks that both see a fresh
+  /// session would otherwise type the task in twice.
+  private actor FirstPassTickets {
+    static let shared = FirstPassTickets()
+    private var claimed: Set<UUID> = []
+    func claim(_ id: UUID) -> Bool { claimed.insert(id).inserted }
+    func release(_ id: UUID) { claimed.remove(id) }
   }
 
   /// How long a resumed session has to still be there before its launch counts as taken.

--- a/graphcode/Sources/Clients/UpdateInstallClient.swift
+++ b/graphcode/Sources/Clients/UpdateInstallClient.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Dependencies
 import Foundation
+import GraphcodeKit
 
 /// Downloads a release DMG, verifies what it carries, and swaps it into /Applications —
 /// the drag the browser flow asks the human to do, done by the app on its own behalf.
@@ -62,10 +63,44 @@ extension UpdateInstallClient: DependencyKey {
       // there is never a moment with two instances competing to be the zmx leader.
       let reopen = Process()
       reopen.executableURL = URL(fileURLWithPath: "/bin/sh")
-      reopen.arguments = ["-c", "sleep 1; /usr/bin/open \"\(installedApp.path)\""]
+      reopen.arguments = [
+        "-c",
+        relaunchScript(
+          pid: ProcessInfo.processInfo.processIdentifier, appPath: installedApp.path,
+          workspace: .current),
+      ]
       try? reopen.run()
       await MainActor.run { NSApplication.shared.terminate(nil) }
     })
+
+  /// The detached shell that brings the app back once this process is gone.
+  ///
+  /// Both halves are there for a failure the obvious one-liner had. `open` without `-n`
+  /// *activates* an instance that is already running rather than starting one (`man
+  /// open`), and after an install there is very often one: a second workspace the human
+  /// kept open with "Install Anyway", or this very process, still shutting down. Either
+  /// swallowed the relaunch — whatever window was alive came forward, the default
+  /// workspace never came back, and Relaunch Now read as a button that did nothing.
+  ///
+  /// And the wait was a flat `sleep 1`, which is a race against however long termination
+  /// actually takes rather than a wait for it. Polling the pid ends the moment the
+  /// process is gone and gives up after ten seconds, because a relaunch that never fires
+  /// is worse than one that fires a beat early.
+  ///
+  /// The workspace is named explicitly rather than left to whatever the launched app
+  /// inherits. Only the default workspace installs updates (`WorkspacesState
+  /// .managesUpdates`), so today this always resolves to `env -u` — but a relaunch that
+  /// silently depends on that gating is one edit away from reopening someone's named
+  /// workspace as the default one, which reads as the update having thrown their
+  /// projects away.
+  static func relaunchScript(pid: Int32, appPath: String, workspace: Workspace) -> String {
+    let key = SupportDirectory.environmentKey
+    let named = workspace.isDefault ? "" : " --env \"\(key)=\(workspace.url.path)\""
+    return """
+      for _ in $(seq 1 100); do kill -0 \(pid) 2>/dev/null || break; sleep 0.1; done
+      env -u \(key) /usr/bin/open -n\(named) "\(appPath)"
+      """
+  }
 
   /// Tests never touch the network or /Applications — override with a fixture.
   static let testValue = UpdateInstallClient(

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -158,6 +158,13 @@ struct GhosttyTerminalView: NSViewRepresentable {
   ) -> [String]? {
     guard var parts = launchPrefix(settings: settings) else { return nil }
     let prompt = initialPrompt == nil ? "" : "\"$\(Self.promptVariable)\""
+    // `/loop` lives behind Copilot's experimental flag, so a time-based node opened from
+    // here rather than by the daemon would arm nothing at all without it — the same
+    // parity this whole method exists for, since which path starts a session is a race.
+    let opening = initialPrompt ?? ""
+    if backend == .copilotCLI, SessionPrompt.firstPass(of: opening) != nil {
+      parts.append("--experimental")
+    }
     // Presence reporting, from the same place the daemon gets it (`PresenceHooks`). It
     // matters most here: a turn-based loop's session only ever starts from this view, so
     // without it the one loop type a human watches most closely would be the one that

--- a/graphcode/Tests/SessionPromptTests.swift
+++ b/graphcode/Tests/SessionPromptTests.swift
@@ -65,4 +65,66 @@ struct SessionPromptTests {
       SessionPrompt.composed(preamble: "Read the file.", prompt: "/loop 1h Triage.")
         == "/loop 1h Triage. Read the file.")
   }
+
+  /// Copilot's `/loop` is an alias of `/every`, which submits its prompt only *after* the
+  /// interval has elapsed. An hourly loop therefore arms correctly and then does nothing
+  /// for an hour, which reads as a loop that never started — so the same task is typed in
+  /// as an ordinary message to give it the pass the schedule will not.
+  @Test
+  func theFirstPassIsTheTaskWithoutTheDirectiveThatSchedulesIt() {
+    #expect(
+      SessionPrompt.firstPass(of: "/loop 1h Triage new issues") == "Triage new issues")
+    #expect(
+      SessionPrompt.firstPass(of: "/every 30m Check the queue") == "Check the queue")
+    // Everything past the interval, pointers included: the first pass reads the same
+    // briefing and memory every scheduled pass will.
+    #expect(
+      SessionPrompt.firstPass(of: "/loop 1h Triage. Read the briefing at /tmp/a/AGENTS.md.")
+        == "Triage. Read the briefing at /tmp/a/AGENTS.md.")
+  }
+
+  @Test
+  func aPromptThatIsNotADirectiveHasNoFirstPass() {
+    #expect(SessionPrompt.firstPass(of: "fix the failing test") == nil)
+    // A prompt opening with a path is not a command to be unwrapped.
+    #expect(SessionPrompt.firstPass(of: "/tmp/x is broken") == nil)
+    // An interval with no task behind it schedules nothing worth repeating.
+    #expect(SessionPrompt.firstPass(of: "/loop 1h") == nil)
+    #expect(SessionPrompt.firstPass(of: "/loop 1h   ") == nil)
+  }
+
+  /// `/loop` is behind Copilot's experimental flag. Without it the directive is not a
+  /// command at all and the session reads it as prose — the same silence issue #179
+  /// produced by a different route.
+  @Test
+  func aCopilotLoopDirectiveAsksForTheExperimentalCommands() {
+    let looping = CLISessionBackendKind.copilotCLI.launchArguments(
+      prompt: "/loop 1h Check the queue", tier: .standard)
+    #expect(looping.contains("--experimental"))
+
+    // An ordinary session keeps the CLI's own defaults.
+    let ordinary = CLISessionBackendKind.copilotCLI.launchArguments(
+      prompt: "fix the failing test", tier: .standard)
+    #expect(!ordinary.contains("--experimental"))
+  }
+
+  /// The first pass belongs only to a node whose *session* holds the timer. A heartbeat
+  /// node's daemon drives every pass including the first, and typing a task in as well
+  /// would double it.
+  @Test
+  func onlyASchedulingCopilotNodeGetsAFirstPass() {
+    func node(
+      backend: CLISessionBackendKind = .copilotCLI, type: LoopType = .timeBased,
+      prompt: String = "/loop 1h Check", heartbeat: Double? = nil
+    ) -> LoopNode {
+      LoopNode(
+        title: "Poll", loopType: type, triggerPrompt: prompt,
+        heartbeatIntervalSeconds: heartbeat, backend: backend)
+    }
+    #expect(ZmxSessionLauncher.firstPassMessage(for: node()) == "Check")
+    #expect(ZmxSessionLauncher.firstPassMessage(for: node(heartbeat: 900)) == nil)
+    #expect(ZmxSessionLauncher.firstPassMessage(for: node(backend: .claudeCode)) == nil)
+    #expect(
+      ZmxSessionLauncher.firstPassMessage(for: node(type: .sketch, prompt: "poke about")) == nil)
+  }
 }

--- a/graphcode/Tests/UpdateInstallTests.swift
+++ b/graphcode/Tests/UpdateInstallTests.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import GraphcodeKit
 import Testing
 
 @testable import graphcode
@@ -238,5 +239,40 @@ struct UpdateInstallTests {
     #expect(store.state.offeredUpdate?.version == "0.1.16-beta3")
     #expect(store.state.offeredUpdate != offered)
     #expect(store.state.isUpdateReadyToRelaunch)
+  }
+
+  /// The relaunch after an install used `open` with no `-n` and a flat `sleep 1`. `open`
+  /// *activates* an app that is already running rather than starting one (`man open`),
+  /// and after an install there usually is one — a second workspace kept open with
+  /// "Install Anyway", or this very process, still shutting down. Whatever was alive came
+  /// forward, the default workspace never came back, and Relaunch Now read as a button
+  /// that did nothing.
+  @Test
+  func theRelaunchWaitsForThisProcessAndStartsANewInstance() {
+    let script = UpdateInstallClient.relaunchScript(
+      pid: 4242, appPath: "/Applications/graphcode.app", workspace: .default)
+
+    // Waits on the pid rather than guessing how long termination takes.
+    #expect(script.contains("kill -0 4242"))
+    #expect(!script.contains("sleep 1;"))
+    // And asks for an instance of its own, whatever else is running.
+    #expect(script.contains("/usr/bin/open -n \"/Applications/graphcode.app\""))
+  }
+
+  /// Only the default workspace installs updates, so this always resolves to `env -u`
+  /// today — but a relaunch that silently depends on that gating is one edit away from
+  /// reopening someone's named workspace as the default one, which reads as the update
+  /// having thrown their projects away.
+  @Test
+  func theRelaunchNamesTheWorkspaceItIsComingBackTo() {
+    let defaulted = UpdateInstallClient.relaunchScript(
+      pid: 1, appPath: "/Applications/graphcode.app", workspace: .default)
+    #expect(defaulted.contains("env -u GRAPHCODE_SUPPORT_DIR"))
+    #expect(!defaulted.contains("--env"))
+
+    let named = UpdateInstallClient.relaunchScript(
+      pid: 1, appPath: "/Applications/graphcode.app",
+      workspace: Workspace(slug: "work", url: URL(fileURLWithPath: "/Users/x/.graphcode-work")))
+    #expect(named.contains("--env \"GRAPHCODE_SUPPORT_DIR=/Users/x/.graphcode-work\""))
   }
 }


### PR DESCRIPTION
Two reports, both of which read as "the button did nothing".

## 1. Relaunch Now doesn't come back in the Default workspace

The post-install relaunch was:

```sh
sleep 1; /usr/bin/open "/Applications/graphcode.app"
```

`open` without `-n` **activates** an app that is already running rather than starting one (`man open`: "-n Open a new instance of the application(s) even if one is already running"). After an install there usually *is* one — a second workspace the human kept open with "Install Anyway", or this very process, still shutting down past the flat one-second wait. Whatever instance was alive came forward, and the default workspace never came back.

Now: wait on the pid until this process is actually gone (bounded at 10s), ask for an instance of our own with `-n`, and name the workspace explicitly rather than leaving it to whatever the launched app inherits.

A knock-on this also fixes: when the new instance started while the old one still held `app.pid`, `WorkspaceLock.claim()` returned false and the old instance's `release()` then deleted the file — leaving a running default workspace with no claim, so opening it from the switcher would launch a *second* app over the same graphs.

## 2. A Copilot time-based loop schedules but never runs its first pass

Not a graphcode bug so much as Copilot semantics we had not accounted for. Per [GitHub's docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/automate-copilot-cli/schedule-prompts):

> `/loop` is an alias of `/every`.

and `/every` submits its prompt **after the interval you specified has elapsed**. So 0.1.50-beta1 armed the schedule correctly — and then did nothing for a full hour, which from the outside is indistinguishable from a loop that never started.

The directive still opens the session (it must lead its message to be a command at all — issue #179). The same task is now typed in afterwards as ordinary input, giving the pass the schedule will not give until later. It is sent only when a **new** Copilot session directory appears, so an ensure that found the session already running never adds a second pass, and a per-node ticket keeps two ensure ticks from typing it twice.

Also: `/every` and `/loop` are experimental commands, available only under `/experimental on` or `--experimental`. Without the flag the directive is not a command at all. `--experimental` now rides along whenever the opening prompt is a loop directive — on both the daemon's launch path and the app's attached-surface path, which race each other to start a session.

Untouched: the daemon-heartbeat route (`heartbeatIntervalSeconds`), which drives its own first beat and needs none of this.

## Verification

- 1073 tests in 114 suites pass (6 new); `make check` exit 0, no new warnings
- Relaunch script asserted for the pid wait, `-n`, and the workspace naming in both the default and named cases
- `SessionPrompt.firstPass` covered for `/loop`, `/every`, trailing pointers, a bare path, and an interval with no task
- `firstPassMessage` covered for heartbeat nodes, non-Copilot backends, and non-time-based types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyMWkpMbY295brojUPbFRE