### PR TITLE
fix: relaunch through LaunchServices, and notice a bundle swapped underneath a window

### DIFF
--- a/GraphcodeKit/Sources/DaemonBootstrap.swift
+++ b/GraphcodeKit/Sources/DaemonBootstrap.swift
@@ -81,6 +81,27 @@ public enum DaemonBootstrap {
     }
   }
 
+  /// The bundle's helper stamp when it no longer matches the one this workspace
+  /// installed from it — a bundle replaced underneath a running app, which is what a
+  /// `brew upgrade`, a DMG dragged over /Applications, or an install whose relaunch was
+  /// declined all leave behind. `nil` when they agree, or when there is nothing packaged
+  /// to compare.
+  ///
+  /// Deliberately only the three `stat`s the stamp is made of: no launchctl probe, no
+  /// copy, no daemon reload. This is asked every time a window comes forward, and none of
+  /// `installIfNeeded`'s work is work to repeat on activation — nor would it be *correct*
+  /// there. Installing the new helpers under an app whose own code was swapped on disk
+  /// leaves a new daemon serving an old window, which is a worse pairing than the stale
+  /// one it replaced. The answer belongs to the human as a relaunch prompt; the relaunch
+  /// is what runs the bootstrap, on both halves at once.
+  public static func changedBundleStamp() -> String? {
+    guard let bundled = bundledHelperDirectory() else { return nil }
+    let expected = stamp(forHelpersIn: bundled)
+    guard !expected.isEmpty else { return nil }
+    let installed = try? String(contentsOf: stampURL, encoding: .utf8)
+    return expected == installed ? nil : expected
+  }
+
   @discardableResult
   public static func installIfNeeded() -> Outcome {
     guard let bundled = bundledHelperDirectory() else { return .notPackaged }

--- a/graphcode/Sources/Clients/UpdateClient.swift
+++ b/graphcode/Sources/Clients/UpdateClient.swift
@@ -1,5 +1,6 @@
 import Dependencies
 import Foundation
+import GraphcodeKit
 
 /// Asks GitHub what releases exist, and answers what this build is and which channel it
 /// follows. All of it lives here rather than in the reducer so a test can hand the check
@@ -13,6 +14,11 @@ struct UpdateClient: Sendable {
   /// prereleases, "stable" pins a beta build to stables. Interpreting it (including
   /// ignoring garbage) is `UpdateChannel.channel(for:override:)`'s job.
   var channelOverride: @Sendable () -> String?
+  /// The helper stamp of a bundle that has been replaced underneath this running app —
+  /// a `brew upgrade`, a DMG dragged over /Applications, an install whose relaunch was
+  /// declined. `nil` while the app and its installed helpers still come from the same
+  /// bundle. See `DaemonBootstrap.changedBundleStamp`.
+  var swappedBundleStamp: @Sendable () -> String?
 }
 
 enum UpdateCheckFailure: Error, LocalizedError, Equatable {
@@ -44,7 +50,8 @@ extension UpdateClient: DependencyKey {
     },
     channelOverride: {
       UserDefaults.standard.string(forKey: "updateChannel")
-    })
+    },
+    swappedBundleStamp: { DaemonBootstrap.changedBundleStamp() })
 
   private static func fetch<Value: Decodable>(_ path: String) async throws -> Value {
     guard let url = URL(string: "https://api.github.com/repos/scgopi/GraphCode/\(path)")
@@ -65,7 +72,8 @@ extension UpdateClient: DependencyKey {
     latestRelease: { throw UpdateCheckFailure.requestFailed(status: 0) },
     allReleases: { throw UpdateCheckFailure.requestFailed(status: 0) },
     currentVersion: { "0.0.0" },
-    channelOverride: { nil })
+    channelOverride: { nil },
+    swappedBundleStamp: { nil })
 }
 
 extension DependencyValues {

--- a/graphcode/Sources/Clients/UpdateInstallClient.swift
+++ b/graphcode/Sources/Clients/UpdateInstallClient.swift
@@ -59,21 +59,62 @@ extension UpdateInstallClient: DependencyKey {
       try? await run("/usr/bin/hdiutil", ["detach", mountPoint.path, "-force"])
     },
     relaunch: {
-      // A detached shell outlives this process and reopens the app *after* it exits, so
-      // there is never a moment with two instances competing to be the zmx leader.
-      let reopen = Process()
-      reopen.executableURL = URL(fileURLWithPath: "/bin/sh")
-      reopen.arguments = [
-        "-c",
-        relaunchScript(
-          pid: ProcessInfo.processInfo.processIdentifier, appPath: installedApp.path,
-          workspace: .current),
-      ]
-      try? reopen.run()
+      // Started through LaunchServices rather than as a child of this process, and that
+      // is the whole point. A GUI app launched by LaunchServices runs inside its own
+      // RunningBoard job, and the processes it spawns belong to that job: when the app
+      // goes, they are killed with it. The relaunch used to be a `/bin/sh` child holding
+      // a `sleep` — exactly the thing that gets reaped — so the app quit and nothing came
+      // back. (It is why Sparkle ships a separate helper *app* for this rather than
+      // forking one.) LaunchServices spawns the successor under launchd instead, where
+      // this process dying cannot reach it.
+      //
+      // `createsNewApplicationInstance` because `open` semantics apply here too: without
+      // it a second workspace's window is merely activated and no new instance starts.
+      let configuration = NSWorkspace.OpenConfiguration()
+      configuration.createsNewApplicationInstance = true
+      configuration.activates = true
+      // The workspace this window belongs to, named rather than inherited — the default
+      // one is the absence of the variable, so it is set only for a named workspace,
+      // matching how `WorkspaceClient.open` starts one.
+      let workspace = Workspace.current
+      if !workspace.isDefault {
+        configuration.environment = [SupportDirectory.environmentKey: workspace.url.path]
+      }
+      // Dropped before the successor starts, not on the way out: `claim` declines while
+      // a live process still holds the file, so a successor that launches first would
+      // never record itself and the workspace would read as free with a window open on
+      // it. The `willTerminate` release still runs and is a no-op by then — it only
+      // deletes a claim that still names this process.
+      WorkspaceLock.release()
+      let launched = await withCheckedContinuation { continuation in
+        NSWorkspace.shared.openApplication(at: installedApp, configuration: configuration) {
+          application, _ in
+          continuation.resume(returning: application != nil)
+        }
+      }
+      // Only once the successor is actually running: terminating first would race the
+      // launch request against this process's own death.
+      if !launched {
+        // Nothing to lose by trying the old way if LaunchServices refused outright.
+        let reopen = Process()
+        reopen.executableURL = URL(fileURLWithPath: "/bin/sh")
+        reopen.arguments = [
+          "-c",
+          relaunchScript(
+            pid: ProcessInfo.processInfo.processIdentifier, appPath: installedApp.path,
+            workspace: workspace),
+        ]
+        try? reopen.run()
+      }
       await MainActor.run { NSApplication.shared.terminate(nil) }
     })
 
-  /// The detached shell that brings the app back once this process is gone.
+  /// The fallback relauncher, for the case where LaunchServices refuses the open
+  /// outright: a detached shell that brings the app back once this process is gone.
+  ///
+  /// Second choice, not first — a child process is exactly what a terminating app's
+  /// RunningBoard job takes with it, which is the failure the LaunchServices path above
+  /// exists to avoid. Kept because a refused open leaves nothing else to try.
   ///
   /// Both halves are there for a failure the obvious one-liner had. `open` without `-n`
   /// *activates* an instance that is already running rather than starting one (`man

--- a/graphcode/Sources/Features/App/AppFeature+Updates.swift
+++ b/graphcode/Sources/Features/App/AppFeature+Updates.swift
@@ -15,6 +15,27 @@ import Foundation
 /// read `offeredUpdate` (kept until the next check) rather than `availableUpdate` (the
 /// presentation, already nil by then). That was #35 — shipped builds whose Download
 /// button did nothing.
+/// A copy of GraphCode in /Applications that has changed since this window opened —
+/// `brew upgrade`, a DMG dragged over it, an install whose relaunch was declined.
+///
+/// It matters past cosmetics because the helpers are installed and the daemon reloaded by
+/// `DaemonBootstrap.installIfNeeded()` at *launch*: until this window is relaunched it
+/// runs an old build over an old `graphcoded`, silently. The stamp is kept rather than a
+/// flag so declining answers for that swap and not for every activation after it.
+struct BundleSwap: Equatable {
+  var pending: String?
+  var acknowledged: String?
+
+  @CasePathable
+  enum Action: Equatable {
+    /// Sent whenever the window comes forward. Three `stat`s and no daemon work — see
+    /// `DaemonBootstrap.changedBundleStamp` for why this is not `installIfNeeded`.
+    case checkRequested
+    case checked(String?)
+    case relaunchDismissed
+  }
+}
+
 extension AppFeature {
   /// A completed check's one-sentence outcome, for the alert that reports it. Only the
   /// "nothing to do" outcomes land here — an actual update gets the richer alert driven
@@ -243,8 +264,31 @@ extension AppFeature {
         state.updateInstallFailure = nil
         return .none
 
+      case .bundleSwap(.checkRequested):
+        // Nothing to ask while an install is mid-flight or a relaunch is already being
+        // offered — both end in the relaunch this would be asking for.
+        guard state.updateInstallProgress == nil, !state.isUpdateReadyToRelaunch,
+          state.bundleSwap.pending == nil
+        else { return .none }
+        return .run { send in
+          await send(.bundleSwap(.checked(updateClient.swappedBundleStamp())))
+        }
+
+      case .bundleSwap(.checked(let stamp)):
+        // Only a swap this window has not already been told about: "Later" answers for
+        // that bundle, not for every time the app is brought forward afterwards.
+        guard let stamp, stamp != state.bundleSwap.acknowledged else { return .none }
+        state.bundleSwap.pending = stamp
+        return .none
+
+      case .bundleSwap(.relaunchDismissed):
+        state.bundleSwap.acknowledged = state.bundleSwap.pending
+        state.bundleSwap.pending = nil
+        return .none
+
       case .updateRelaunchTapped:
         state.isUpdateReadyToRelaunch = false
+        state.bundleSwap.pending = nil
         return .run { _ in await updateInstallClient.relaunch() }
 
       case .updateRelaunchDismissed:

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -116,6 +116,9 @@ struct AppFeature {
     var updateInstallProgress: Double?
     var updateInstallFailure: String?
     var isUpdateReadyToRelaunch = false
+    /// A bundle replaced underneath this running app — see `BundleSwap` in
+    /// `AppFeature+Updates.swift`.
+    var bundleSwap = BundleSwap()
 
     /// State changes seen since launch, for the activity strip — see
     /// `AppFeature+Activity.swift`. Bounded, and deliberately not persisted.
@@ -227,6 +230,9 @@ struct AppFeature {
     /// The sidebar update banner — re-presents the offer alert the banner stands for.
     case updateBannerTapped
     case updateCheckCompleted(Result<AvailableUpdate?, any Error>)
+    /// A bundle replaced underneath this running window — asked on activation, answered
+    /// with a relaunch prompt. See `BundleSwap.Action`.
+    case bundleSwap(BundleSwap.Action)
     case updateDownloadTapped
     case updateReleaseNotesTapped
     case updateAlertDismissed
@@ -486,6 +492,7 @@ struct AppFeature {
       // `AppFeature+Updates.swift` — listed here only so this switch stays exhaustive.
       case .checkForUpdatesTapped, .checkForUpdatesInBackground, .updateFoundInBackground,
         .updateBannerTapped, .updateCheckCompleted, .updateDownloadTapped,
+        .bundleSwap,
         .updateReleaseNotesTapped, .updateAlertDismissed, .updateNoticeDismissed,
         .updateInstallTapped, .updateInstallConfirmed, .updateInstallResolved,
         .updateInstallProgressed,

--- a/graphcode/Sources/Features/App/UpdateDialogs.swift
+++ b/graphcode/Sources/Features/App/UpdateDialogs.swift
@@ -47,6 +47,7 @@ struct UpdateDialogs: ViewModifier {
       } message: {
         Text(store.updateNotice?.message ?? "")
       }
+      .modifier(SwappedBundleDialog(store: store))
       .alert(
         "Update installed",
         isPresented: Binding(
@@ -116,6 +117,46 @@ struct UpdateDialogs: ViewModifier {
           .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
           .padding(12)
         }
+      }
+  }
+}
+
+/// The relaunch prompt for a bundle that changed underneath a running window, kept apart
+/// from `UpdateDialogs` because it is not an update this app performed: nothing was
+/// downloaded, nobody was asked, and the first this window hears of it is the copy in
+/// /Applications no longer matching the helpers it installed at launch.
+struct SwappedBundleDialog: ViewModifier {
+  let store: StoreOf<AppFeature>
+
+  func body(content: Content) -> some View {
+    content
+      // A bundle can also change without this app having installed anything — `brew
+      // upgrade`, a DMG dragged over /Applications, an earlier install whose relaunch
+      // was declined. The window keeps running code that is no longer on disk and, more
+      // to the point, its `graphcoded` stays the old one: the bootstrap that installs
+      // the helpers and reloads the daemon runs at launch, so only a relaunch applies
+      // it. Asked on activation rather than fixed silently — installing new helpers
+      // under an old window would leave a new daemon serving it.
+      .onReceive(
+        NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+      ) { _ in
+        store.send(.bundleSwap(.checkRequested))
+      }
+      .alert(
+        "A newer GraphCode is installed",
+        isPresented: Binding(
+          get: { store.bundleSwap.pending != nil },
+          set: { if !$0 { store.send(.bundleSwap(.relaunchDismissed)) } }
+        )
+      ) {
+        Button("Relaunch Now") { store.send(.updateRelaunchTapped) }
+        Button("Later", role: .cancel) { store.send(.bundleSwap(.relaunchDismissed)) }
+      } message: {
+        Text(
+          "The copy in Applications has changed since this window opened, so this one "
+            + "is still running the old build and its background helper. Relaunching "
+            + "picks up both. Sessions keep running through it — the daemon holds them, "
+            + "not the window.")
       }
   }
 }

--- a/graphcode/Tests/SwappedBundleTests.swift
+++ b/graphcode/Tests/SwappedBundleTests.swift
@@ -1,0 +1,100 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// The bundle in /Applications can be replaced while a window is open — `brew upgrade`,
+/// a DMG dragged over it, an install whose relaunch was declined. The app then keeps
+/// running code that is no longer on disk, and its `graphcoded` stays the old one: the
+/// bootstrap that installs the helpers and reloads the daemon runs at launch, so nothing
+/// applies until a relaunch. This is the window noticing and saying so.
+@Suite
+@MainActor
+struct SwappedBundleTests {
+  @Test
+  func aSwappedBundleRaisesTheRelaunchPrompt() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateClient.swappedBundleStamp = { "graphcoded:1:2" }
+    }
+    await store.send(.bundleSwap(.checkRequested))
+    await store.receive(\.bundleSwap.checked) { $0.bundleSwap.pending = "graphcoded:1:2" }
+  }
+
+  @Test
+  func anUnchangedBundleSaysNothing() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateClient.swappedBundleStamp = { nil }
+    }
+    await store.send(.bundleSwap(.checkRequested))
+    await store.receive(\.bundleSwap.checked)
+  }
+
+  /// "Later" answers for *that* swap. Without the acknowledgement the prompt would come
+  /// back every time the window was brought forward, which is nagging rather than news.
+  @Test
+  func laterDeclinesThisSwapAndNotEveryActivationAfterIt() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateClient.swappedBundleStamp = { "graphcoded:1:2" }
+    }
+    await store.send(.bundleSwap(.checkRequested))
+    await store.receive(\.bundleSwap.checked) { $0.bundleSwap.pending = "graphcoded:1:2" }
+    await store.send(.bundleSwap(.relaunchDismissed)) {
+      $0.bundleSwap.acknowledged = "graphcoded:1:2"
+      $0.bundleSwap.pending = nil
+    }
+
+    await store.send(.bundleSwap(.checkRequested))
+    await store.receive(\.bundleSwap.checked)
+  }
+
+  /// A *second* swap after the first was declined is news again — the helpers on disk
+  /// moved on, so the stale window is staler than the one that was waved away.
+  @Test
+  func aSecondSwapIsNewsAgain() async {
+    let store = TestStore(
+      initialState: AppFeature.State(bundleSwap: BundleSwap(acknowledged: "graphcoded:1:2"))
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateClient.swappedBundleStamp = { "graphcoded:1:3" }
+    }
+    await store.send(.bundleSwap(.checkRequested))
+    await store.receive(\.bundleSwap.checked) { $0.bundleSwap.pending = "graphcoded:1:3" }
+  }
+
+  /// Nothing is asked while an install is running or a relaunch is already on offer:
+  /// both end in the relaunch this prompt exists to ask for.
+  @Test
+  func anInstallInFlightIsNotInterrupted() async {
+    let store = TestStore(initialState: AppFeature.State(updateInstallProgress: 0.4)) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateClient.swappedBundleStamp = { "graphcoded:1:2" }
+    }
+    await store.send(.bundleSwap(.checkRequested))
+
+    let offered = TestStore(initialState: AppFeature.State(isUpdateReadyToRelaunch: true)) {
+      AppFeature()
+    } withDependencies: {
+      $0.updateClient.swappedBundleStamp = { "graphcoded:1:2" }
+    }
+    await offered.send(.bundleSwap(.checkRequested))
+  }
+
+  /// The probe is three `stat`s and nothing else. Repeating `installIfNeeded` on every
+  /// activation would shell out to launchctl on the main thread and, worse, install new
+  /// helpers under a window whose own code was replaced — a new daemon serving an old
+  /// app, which is a worse pairing than the stale one it replaced.
+  @Test
+  func anUnpackagedBuildHasNothingToCompare() {
+    #expect(DaemonBootstrap.changedBundleStamp() == nil)
+  }
+}

--- a/graphcode/Tests/UpdateInstallTests.swift
+++ b/graphcode/Tests/UpdateInstallTests.swift
@@ -241,12 +241,13 @@ struct UpdateInstallTests {
     #expect(store.state.isUpdateReadyToRelaunch)
   }
 
-  /// The relaunch after an install used `open` with no `-n` and a flat `sleep 1`. `open`
+  /// The fallback relauncher, used only when LaunchServices refuses the open outright.
+  /// It still must not repeat the two mistakes the original had: `open` without `-n`
   /// *activates* an app that is already running rather than starting one (`man open`),
-  /// and after an install there usually is one — a second workspace kept open with
-  /// "Install Anyway", or this very process, still shutting down. Whatever was alive came
-  /// forward, the default workspace never came back, and Relaunch Now read as a button
-  /// that did nothing.
+  /// and a flat `sleep 1` is a race against however long termination takes.
+  ///
+  /// The primary path no longer spawns a child at all — a terminating app's RunningBoard
+  /// job takes its children with it, which is why the app quit and nothing came back.
   @Test
   func theRelaunchWaitsForThisProcessAndStartsANewInstance() {
     let script = UpdateInstallClient.relaunchScript(


### PR DESCRIPTION
Two fixes to the same area, both about the app not picking up a new build.

## 1. Relaunch quits the app and nothing comes back

Reported: *"It just gets killed but not comes back."*

The relauncher was a `/bin/sh` child of the app, holding a wait before it ran `open`. A GUI app launched by LaunchServices runs inside its own **RunningBoard job, and the processes it spawns belong to that job** — when the app terminates, they are killed with it. The helper was being reaped along with the app it was waiting for, so the quit landed and the launch never did. This is why Sparkle ships a separate helper *app* rather than forking one.

0.1.50-beta2's `-n` + pid-wait fixed a real, different failure (another instance swallowing the activation), but it could not fix a helper that was no longer alive to run.

The successor is now started through **LaunchServices**, which spawns it under launchd where this process's death cannot reach it, and this process terminates only once the launch has reported an actual application — not before, which would race the request against our own exit.

Kept from beta2: `createsNewApplicationInstance` (the activate-instead-of-launch semantics apply to this API too) and naming the workspace explicitly. New: the workspace claim is dropped *before* the successor starts, so its claim sticks instead of being declined by a pid file this process still holds — otherwise the workspace reads as free with a window open on it.

The shell script stays as a fallback for a refused open, with its tests.

## 2. A bundle swapped underneath a running window goes unnoticed

`DaemonBootstrap.installIfNeeded()` runs once, at launch. So a bundle replaced while the app is open — `brew upgrade`, a DMG dragged over /Applications, an install whose relaunch was declined — leaves that window running an old build over an **old `graphcoded`**, silently. Measured on the dev machine: app bundle 0.1.49 on disk, daemon still the previous day's build.

The window now asks on activation and offers a relaunch. What it deliberately does **not** do is repeat `installIfNeeded()` there:

1. it shells out to `launchctl print` on every activation, synchronously;
2. that probe is the sole input to `reloadDaemon()`, so a transient failure boots the daemon out from under running work;
3. worst, it would install new helpers under a window whose own code was swapped on disk — a new daemon serving an old app, a worse pairing than the stale one it replaces.

The probe is `DaemonBootstrap.changedBundleStamp()`: the three `stat`s the install stamp is made of, no launchctl, no copy, no reload. The relaunch is what runs the bootstrap, on both halves at once.

"Later" answers for *that* swap, not for every activation afterwards; a later swap is news again; nothing is asked while an install is in flight or a relaunch is already on offer.

## Verification

1079 tests in 115 suites pass (6 new); `make check` exit 0.

`AppFeature` was at its 350-line swiftlint cap, so the new state and actions are nested in a `BundleSwap` type in `AppFeature+Updates.swift`, and the prompt lives in its own `SwappedBundleDialog` modifier rather than growing `UpdateDialogs.body` past its 100-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyMWkpMbY295brojUPbFRE