### PR TITLE
feat: keep the Mac awake while loops run, behind an off-by-default setting

### DIFF
--- a/GraphcodeKit/Sources/AwakeAssertion.swift
+++ b/GraphcodeKit/Sources/AwakeAssertion.swift
@@ -1,0 +1,63 @@
+import Foundation
+import IOKit.pwr_mgt
+
+/// Keeps the Mac from falling asleep while loops are actually running — the power
+/// assertion `caffeinate -i` takes, held by the daemon rather than by a person at a
+/// terminal.
+///
+/// It lives in `graphcoded` because that is the process that knows. A loop's session
+/// outlives every window (`ZmxSessionLauncher`), so the app is not running when this
+/// matters most: the lid comes down on a machine with six loops mid-turn and the work
+/// stops until someone wakes it. The app cannot hold an assertion for work it is not
+/// present for.
+///
+/// Deliberately the *idle* assertion and nothing stronger. It stops the system sleeping
+/// on its own while there is work in flight; it does not keep the display awake, does not
+/// override a lid close, and does not survive a human choosing Sleep from the menu. An
+/// idle machine with no loops running still sleeps exactly as it always did — the
+/// assertion is dropped the moment the last loop stops, not held for the daemon's
+/// lifetime.
+///
+/// Behind `GraphcodeSettings.keepsMacAwakeWhileLoopsRun`, off by default: a background
+/// process that quietly stops a laptop sleeping is not something to switch on for
+/// somebody.
+public actor AwakeAssertion {
+  public static let shared = AwakeAssertion()
+
+  private var held: IOPMAssertionID?
+
+  /// Whether the machine should be kept awake right now. Pure, and separate from the
+  /// IOKit call, because the interesting part is the decision: a setting that is off
+  /// beats any number of running loops, and no running loops beats the setting.
+  public static func shouldStayAwake(runningLoops: Int, enabled: Bool) -> Bool {
+    enabled && runningLoops > 0
+  }
+
+  /// Takes or drops the assertion to match `shouldHold`. Idempotent: holding while held
+  /// and releasing while released both do nothing, so the caller can simply state the
+  /// current answer on every graph change without tracking edges itself.
+  public func apply(shouldHold: Bool, runningLoops: Int) {
+    if shouldHold {
+      guard held == nil else { return }
+      var identifier = IOPMAssertionID(0)
+      let reason =
+        runningLoops == 1
+        ? "a GraphCode loop is running" : "\(runningLoops) GraphCode loops are running"
+      let result = IOPMAssertionCreateWithName(
+        kIOPMAssertionTypePreventUserIdleSystemSleep as CFString,
+        IOPMAssertionLevel(kIOPMAssertionLevelOn), reason as CFString, &identifier)
+      // A refused assertion is not worth failing anything over: the machine sleeps as it
+      // did before this existed, which is the behaviour every release until now had.
+      guard result == kIOReturnSuccess else { return }
+      held = identifier
+    } else {
+      guard let identifier = held else { return }
+      held = nil
+      IOPMAssertionRelease(identifier)
+    }
+  }
+
+  /// Whether an assertion is currently held — for the daemon's own logging and for a test
+  /// that wants to know without reading `pmset`.
+  public var isHolding: Bool { held != nil }
+}

--- a/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
+++ b/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
@@ -347,6 +347,13 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
   /// heartbeat loops immediately without restarting anything.
   public var daemonHeartbeatEnabled: Bool
 
+  /// Whether `graphcoded` keeps the Mac awake while any loop is running
+  /// (`AwakeAssertion`). Off by default and deliberately so: a background process that
+  /// quietly stops a machine sleeping is a thing to opt into, not to inherit from an
+  /// update. Read fresh whenever the answer is recomputed, so switching it off drops the
+  /// assertion without restarting anything.
+  public var keepsMacAwakeWhileLoopsRun: Bool
+
   // There is deliberately no window-opacity setting here any more. graphcode used to own
   // one and apply it as `NSWindow.alphaValue`, which fades the whole window — terminal
   // text included — rather than only the background behind it. Ghostty already has
@@ -367,6 +374,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     summarisesLoops: Bool = false,
     summaryUsesModel: Bool = false,
     daemonHeartbeatEnabled: Bool = false,
+    keepsMacAwakeWhileLoopsRun: Bool = false,
     worktreePolicies: [String: WorktreeHygienePolicy] = [:]
   ) {
     self.defaultBackend = defaultBackend.isSpiked ? defaultBackend : .claudeCode
@@ -381,6 +389,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     self.summarisesLoops = summarisesLoops
     self.summaryUsesModel = summaryUsesModel
     self.daemonHeartbeatEnabled = daemonHeartbeatEnabled
+    self.keepsMacAwakeWhileLoopsRun = keepsMacAwakeWhileLoopsRun
     self.worktreePolicies = worktreePolicies
   }
 
@@ -429,6 +438,10 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(Bool.self, forKey: .summaryUsesModel) ?? false
     daemonHeartbeatEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .daemonHeartbeatEnabled) ?? false
+    // Absent means nobody has asked for it, which is the default. An update must never
+    // start holding a power assertion on a machine whose owner did not choose that.
+    keepsMacAwakeWhileLoopsRun =
+      try container.decodeIfPresent(Bool.self, forKey: .keepsMacAwakeWhileLoopsRun) ?? false
     worktreePolicies =
       try container.decodeIfPresent(
         [String: WorktreeHygienePolicy].self, forKey: .worktreePolicies) ?? [:]

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -669,6 +669,15 @@ public actor GraphStore {
   /// **Nothing changed, nothing sent.** And when something *has* changed this notifies
   /// clients without going through `broadcast()`, because that persists the graph — a
   /// write per tick, forever, of the one field that is deliberately never restored.
+  /// How many of this graph's loops are running right now, sub-graphs included — what
+  /// `ProjectRegistry` sums to decide whether the machine should be kept awake
+  /// (`AwakeAssertion`). Only `.running`: a loop parked on a human's answer is not work
+  /// in flight, and holding a sleepless machine overnight for one is the opposite of the
+  /// point.
+  public func runningLoopCount() -> Int {
+    graph.nodesAtAnyDepth.count { $0.state == .running }
+  }
+
   public func pollPresence() async {
     guard !connections.isEmpty, onReadPresence != nil else { return }
     // Both, and in this order, because they are one answer to a human: the pill says a

--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -42,6 +42,8 @@ public actor ProjectRegistry {
   private let readPresence: (@Sendable (LoopNode, String?) async -> PresenceReading)?
   /// Non-nil only while at least one client is attached — see `startPresencePolling`.
   private var presencePoller: Task<Void, Never>?
+  /// Runs only while the sleep assertion is held — see `refreshAwakeAssertion`.
+  private var awakeRecheck: Task<Void, Never>?
 
   /// These default to the real `ZmxSessionLauncher`/`ShellPredicateEvaluator` closures —
   /// every `GraphStore` this registry creates gets them, so an unattended node's session
@@ -170,7 +172,10 @@ public actor ProjectRegistry {
   /// The registry outlives the daemon in practice, but a `Task` holding only a weak
   /// `self` would otherwise keep waking every minute after the registry it sweeps for is
   /// gone — the same reason `GraphStore` cancels its goal pollers here.
-  deinit { remoteSweeper?.cancel() }
+  deinit {
+    remoteSweeper?.cancel()
+    awakeRecheck?.cancel()
+  }
 
   /// `ensureSession` is fire-and-forget by contract (`CLISessionBackend.ensureSession`
   /// spawns a detached task), so this returns well before the dials it started finish and
@@ -181,6 +186,41 @@ public actor ProjectRegistry {
     for (path, store) in stores where RemoteProjectLocation.parse(projectPath: path) != nil {
       await store.ensureUnattendedSessionsAlive()
     }
+  }
+
+  /// Takes or drops the sleep assertion to match what is running right now
+  /// (`AwakeAssertion`), across every open project.
+  ///
+  /// Called on every graph change rather than on a timer, because a graph change is
+  /// exactly when the answer can differ. The one thing a graph change cannot notice is
+  /// the *setting* being switched off while loops keep running, which is why holding the
+  /// assertion also starts a slow re-check — and only while it is held, so a daemon with
+  /// this switched off, or with nothing running, still keeps no timer at all.
+  private func refreshAwakeAssertion() async {
+    var running = 0
+    for store in stores.values { running += await store.runningLoopCount() }
+    let enabled = GraphcodeSettingsStore.load().keepsMacAwakeWhileLoopsRun
+    let shouldHold = AwakeAssertion.shouldStayAwake(runningLoops: running, enabled: enabled)
+    await AwakeAssertion.shared.apply(shouldHold: shouldHold, runningLoops: running)
+    if shouldHold { startAwakeRecheck() } else { stopAwakeRecheck() }
+  }
+
+  static let awakeRecheckInterval: Duration = .seconds(60)
+
+  private func startAwakeRecheck() {
+    guard awakeRecheck == nil else { return }
+    awakeRecheck = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(for: Self.awakeRecheckInterval)
+        guard !Task.isCancelled else { return }
+        await self?.refreshAwakeAssertion()
+      }
+    }
+  }
+
+  private func stopAwakeRecheck() {
+    awakeRecheck?.cancel()
+    awakeRecheck = nil
   }
 
   /// Sequential rather than concurrent across projects: each store's poll already spawns
@@ -366,7 +406,12 @@ public actor ProjectRegistry {
     }
     let newStore = GraphStore(
       graph: graph,
-      onGraphChanged: { updatedGraph in persistence.saveGraph(updatedGraph) },
+      onGraphChanged: { [weak self] updatedGraph in
+        persistence.saveGraph(updatedGraph)
+        // Every state change is a chance for the last running loop to have stopped, or
+        // the first to have started — see `refreshAwakeAssertion`.
+        Task { await self?.refreshAwakeAssertion() }
+      },
       onEnsureSession: ensureSession,
       onTerminateSession: terminateSession,
       onEvaluatePredicate: evaluatePredicate,

--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -149,6 +149,19 @@ struct SettingsView: View {
         .fixedSize(horizontal: false, vertical: true)
 
         Toggle(
+          "Keep this Mac awake while loops run (experimental)",
+          isOn: $model.settings.keepsMacAwakeWhileLoopsRun)
+        Text(
+          "The daemon holds the same idle-sleep assertion as `caffeinate -i` while any "
+            + "loop is running, and drops it the moment the last one stops. Unattended "
+            + "loops stop stalling on a machine that went to sleep. It does not keep the "
+            + "display on, and it does not override closing the lid or choosing Sleep."
+        )
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+        Toggle(
           "Export and import loops",
           isOn: $model.settings.sharesLoops)
         Text(

--- a/graphcode/Tests/AwakeAssertionTests.swift
+++ b/graphcode/Tests/AwakeAssertionTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// Keeping the Mac awake while loops run — the assertion `graphcoded` holds so unattended
+/// work does not stall on a machine that went to sleep, and the setting that gates it.
+@Suite
+struct AwakeAssertionTests {
+  @Test
+  func nothingIsHeldWhileTheSettingIsOff() {
+    #expect(!AwakeAssertion.shouldStayAwake(runningLoops: 3, enabled: false))
+    #expect(!AwakeAssertion.shouldStayAwake(runningLoops: 0, enabled: false))
+  }
+
+  /// The assertion follows the work, not the daemon: an enabled machine with nothing
+  /// running sleeps exactly as it did before this existed.
+  @Test
+  func theAssertionFollowsTheRunningLoops() {
+    #expect(!AwakeAssertion.shouldStayAwake(runningLoops: 0, enabled: true))
+    #expect(AwakeAssertion.shouldStayAwake(runningLoops: 1, enabled: true))
+    #expect(AwakeAssertion.shouldStayAwake(runningLoops: 12, enabled: true))
+  }
+
+  /// Off by default. An update must never start holding a power assertion on a machine
+  /// whose owner did not ask for it.
+  @Test
+  func theSettingIsOffUntilSomebodyAsks() {
+    #expect(!GraphcodeSettings().keepsMacAwakeWhileLoopsRun)
+  }
+
+  /// A settings file written before this existed decodes with the feature off rather than
+  /// failing the whole read — the same tolerance every other added key gets.
+  @Test
+  func aSettingsFileFromBeforeTheFeatureKeepsItOff() throws {
+    let older = Data(#"{"defaultBackend":"claudeCode","summarisesLoops":true}"#.utf8)
+    let settings = try JSONDecoder().decode(GraphcodeSettings.self, from: older)
+    #expect(!settings.keepsMacAwakeWhileLoopsRun)
+    #expect(settings.summarisesLoops)
+  }
+
+  @Test
+  func theChoiceSurvivesARoundTrip() throws {
+    var settings = GraphcodeSettings()
+    settings.keepsMacAwakeWhileLoopsRun = true
+    let decoded = try JSONDecoder().decode(
+      GraphcodeSettings.self, from: JSONEncoder().encode(settings))
+    #expect(decoded.keepsMacAwakeWhileLoopsRun)
+  }
+
+  /// Applying is idempotent: the registry states the current answer on every graph change
+  /// rather than tracking edges, so holding while held and releasing while released both
+  /// have to be no-ops.
+  @Test
+  func applyingTheSameAnswerTwiceIsANoOp() async {
+    let assertion = AwakeAssertion()
+    await assertion.apply(shouldHold: false, runningLoops: 0)
+    #expect(!(await assertion.isHolding))
+    await assertion.apply(shouldHold: true, runningLoops: 2)
+    let held = await assertion.isHolding
+    await assertion.apply(shouldHold: true, runningLoops: 3)
+    #expect(await assertion.isHolding == held)
+    await assertion.apply(shouldHold: false, runningLoops: 0)
+    #expect(!(await assertion.isHolding))
+  }
+
+  /// Only `.running` counts. A loop parked on a human's answer is not work in flight, and
+  /// holding a machine sleepless overnight for one is the opposite of the point.
+  @Test
+  func onlyRunningLoopsCount() async {
+    let graph = LoopGraph(
+      scope: LoopGraphScope(projectPath: "/tmp/p", name: "p"),
+      nodes: [
+        LoopNode(title: "a", state: .running),
+        LoopNode(title: "b", state: .awaitingInput),
+        LoopNode(title: "c", state: .idle),
+        LoopNode(title: "d", state: .running),
+        LoopNode(title: "e", state: .stopped),
+      ])
+    let store = GraphStore(graph: graph)
+    #expect(await store.runningLoopCount() == 2)
+  }
+}


### PR DESCRIPTION
An unattended loop's whole promise is that it runs while nobody is watching, and a Mac that idles to sleep breaks it — the session is still there when the machine wakes, having done nothing for however long it slept. Nothing in graphcode held a power assertion; the workaround was a human running `caffeinate` in a terminal.

## What it does

`graphcoded` holds the same idle-sleep assertion `caffeinate -i` takes, for exactly as long as at least one loop is `.running`, and drops it when the last one stops.

| Decision | Why |
|---|---|
| In the **daemon**, not the app | A loop's session outlives every window, so the app is not running when this matters most — lid down on a machine with six loops mid-turn |
| `PreventUserIdleSystemSleep` only | Stops the machine idling to sleep with work in flight. Does **not** keep the display on, override a lid close, or survive someone choosing Sleep |
| Only `.running` counts | A loop parked on a human's answer is not work in flight; holding a machine sleepless overnight for one is the opposite of the point. Sub-graph loops count too, via `nodesAtAnyDepth` |
| **Off by default** | An update must never start holding a power assertion on a machine whose owner never asked. Absent from an older settings file decodes as off |
| Recomputed on graph change | That is when the answer can differ. The slow re-check that catches the setting being switched off mid-run runs **only while the assertion is held**, so a daemon with this off keeps no timer at all |

## Verification

Beyond the suite, the IOKit call itself was checked against real system state — a standalone probe using the identical API:

```
pid 34967(probe): PreventUserIdleSystemSleep named: "2 GraphCode loops are running"
```

and after release, `pmset -g assertions` no longer lists it.

- 1086 tests in 116 suites pass (7 new in `AwakeAssertionTests`); `make check` exit 0
- Covered: the gate (off beats any number of loops), the count (0 running never holds), the default, tolerant decoding of a pre-feature settings file, round-trip, idempotent apply, and that only `.running` is counted

## Setting

Settings → "Keep this Mac awake while loops run (experimental)", alongside the other experimental toggles, with the caveats spelled out under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyMWkpMbY295brojUPbFRE