### PR TITLE
fix: send the Copilot opening pass even when nothing was observed

### DIFF
--- a/GraphcodeKit/Sources/Sessions/NodeMemory.swift
+++ b/GraphcodeKit/Sources/Sessions/NodeMemory.swift
@@ -329,6 +329,44 @@ public enum NodeMemory {
     "Read your loop memory at \(path) before starting."
   }
 
+  static let firstPassFileName = "FIRST-PASS.txt"
+
+  /// Which of this node's sessions has already been given its opening pass
+  /// (`ZmxSessionLauncher.kickOffFirstPass`), identified by the Copilot session directory
+  /// it was typed into.
+  ///
+  /// Persisted rather than held in memory because the thing it must not do is repeat: the
+  /// daemon restarts, ensure ticks run again, and a task typed twice is a loop that did
+  /// its work twice. A *new* Copilot session has a new directory and so is never mistaken
+  /// for one already served.
+  public static func firstPassMarker(
+    projectPath: String, nodeID: UUID, baseURL: URL = SupportDirectory.url
+  ) -> String? {
+    let url = directory(forProjectPath: projectPath, nodeID: nodeID, baseURL: baseURL)
+      .appendingPathComponent(firstPassFileName)
+    return (try? String(contentsOf: url, encoding: .utf8))?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  public static func recordFirstPass(
+    _ marker: String, projectPath: String, nodeID: UUID, baseURL: URL = SupportDirectory.url
+  ) {
+    let directory = directory(forProjectPath: projectPath, nodeID: nodeID, baseURL: baseURL)
+    try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try? Data(marker.utf8).write(
+      to: directory.appendingPathComponent(firstPassFileName), options: .atomic)
+  }
+
+  /// Forgotten when the session is torn down: the next one is a new session and has had
+  /// no pass of its own.
+  public static func clearFirstPass(
+    projectPath: String, nodeID: UUID, baseURL: URL = SupportDirectory.url
+  ) {
+    try? FileManager.default.removeItem(
+      at: directory(forProjectPath: projectPath, nodeID: nodeID, baseURL: baseURL)
+        .appendingPathComponent(firstPassFileName))
+  }
+
   /// Removes a node's memory directory — called when the node itself is deleted, the
   /// same moment its session is torn down. A log for a loop that no longer exists is
   /// not history, it's litter.

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -419,6 +419,11 @@ public enum ZmxSessionLauncher {
       return
     }
     SessionIDStore.remove(forNodeID: node.id)
+    // The next session is a new one and has had no opening pass of its own
+    // (`kickOffFirstPass`).
+    if let projectPath {
+      NodeMemory.clearFirstPass(projectPath: projectPath, nodeID: node.id)
+    }
     guard ZmxLocator.isInstalled else { return }
     guard
       let session = try? PTYProcessSession(
@@ -1267,43 +1272,71 @@ public enum ZmxSessionLauncher {
     return SessionPrompt.firstPass(of: prompt)
   }
 
-  /// Types that first pass in, once the session it belongs to is actually there to
-  /// receive it.
+  /// Types that first pass in, once the session it belongs to is there to receive it.
   ///
-  /// Gated on a *new* Copilot session directory rather than on the launch returning: an
-  /// ensure whose session already existed launched nothing, and typing the task into a
-  /// loop already running it is a second pass nobody asked for. Waiting for the directory
-  /// is also what keeps the keystrokes out of a CLI that has not drawn its composer yet,
-  /// where they are simply lost.
+  /// Two things had to change after the first attempt shipped and the pass still did not
+  /// arrive. It waited for a *new* Copilot session directory and did nothing at all if
+  /// none appeared — but which process launches a node's session is a race (the daemon if
+  /// it got there first, the app's terminal view if the node was opened before it did,
+  /// `GhosttyTerminalView.agentCommand`), and a session the ensure found already running
+  /// produces no new directory. And a probe that finds nothing must still send: the loop
+  /// is armed either way, so the cost of not sending is an idle interval and the cost of
+  /// sending is one pass — which is the pass being asked for.
   ///
-  /// Detached because the wait is seconds long and `start` is on the ensure path, which
-  /// has other nodes to get to.
+  /// What stops it repeating is the marker (`NodeMemory.firstPassMarker`), which records
+  /// the session that was served rather than the fact of serving: a new Copilot session
+  /// has a new directory and is never mistaken for one already given its pass, and a
+  /// daemon restart over the same session sends nothing.
+  ///
+  /// Every branch is written to the dial log, because the failure this replaces was
+  /// invisible from outside — the loop simply sat there, and nothing said whether the
+  /// message had been skipped, timed out, or refused.
   private static func kickOffFirstPass(
     of node: LoopNode, sessionNamed name: String, projectPath: String?, after previous: String?
   ) async {
-    guard let message = firstPassMessage(for: node) else { return }
+    guard let message = firstPassMessage(for: node), let projectPath else { return }
     Task {
       guard await FirstPassTickets.shared.claim(node.id) else { return }
       defer { Task { await FirstPassTickets.shared.release(node.id) } }
       let deadline = Date().addingTimeInterval(firstPassWaitSeconds)
-      while Date() < deadline {
+      var observed: String?
+      while Date() < deadline, observed == nil {
         let current = CopilotSessionLog.directory(forSessionNamed: name)?.lastPathComponent
         if let current, current != previous {
-          // The directory appears as Copilot opens its session, a moment before its
-          // composer can take input. The settle is the same forgiveness `resume` gets.
-          try? await Task.sleep(for: .seconds(firstPassSettleSeconds))
-          _ = await send(message, to: node, projectPath: projectPath)
-          return
+          observed = current
+        } else {
+          try? await Task.sleep(for: .seconds(firstPassPollSeconds))
         }
-        try? await Task.sleep(for: .seconds(firstPassPollSeconds))
       }
+      // The session this pass would belong to: the one that just appeared, the one that
+      // was already running when the ensure found it, or — when Copilot's own state
+      // directory tells us nothing — the node itself, served once.
+      let session = observed ?? previous ?? "unknown"
+      guard NodeMemory.firstPassMarker(projectPath: projectPath, nodeID: node.id) != session
+      else {
+        DialLog.record(session: name, dial: "first-pass", event: "already-served")
+        return
+      }
+      // The directory appears as Copilot opens its session, a moment before its composer
+      // can take input. The settle is the same forgiveness `resume` gets.
+      try? await Task.sleep(for: .seconds(firstPassSettleSeconds))
+      guard await sessionExists(node) else {
+        DialLog.record(session: name, dial: "first-pass", event: "no-session")
+        return
+      }
+      let delivered = await send(message, to: node, projectPath: projectPath)
+      if delivered {
+        NodeMemory.recordFirstPass(session, projectPath: projectPath, nodeID: node.id)
+      }
+      DialLog.record(
+        session: name, dial: "first-pass",
+        event: delivered ? (observed == nil ? "sent-unobserved" : "sent") : "undelivered")
     }
   }
 
-  /// How long to wait for a launched Copilot session to appear before giving up on its
-  /// first pass. Generous: the loop is still correctly armed either way, so the cost of
-  /// waiting too long is nothing and the cost of giving up early is an idle hour.
-  static let firstPassWaitSeconds: TimeInterval = 90
+  /// Long enough for a cold `copilot` to open its session, short enough that a pass sent
+  /// without ever seeing one is still early in the interval it is standing in for.
+  static let firstPassWaitSeconds: TimeInterval = 45
   static let firstPassPollSeconds: TimeInterval = 0.5
   static let firstPassSettleSeconds: TimeInterval = 3
 

--- a/graphcode/Tests/SessionPromptTests.swift
+++ b/graphcode/Tests/SessionPromptTests.swift
@@ -127,4 +127,25 @@ struct SessionPromptTests {
     #expect(
       ZmxSessionLauncher.firstPassMessage(for: node(type: .sketch, prompt: "poke about")) == nil)
   }
+
+  /// The marker is what stops the opening pass repeating, and it records *which* session
+  /// was served rather than the fact of serving: a daemon restart over the same Copilot
+  /// session must send nothing, while a new session — a new directory — is always owed
+  /// its own pass.
+  @Test
+  func theFirstPassMarkerIsPerSessionAndForgottenWithIt() throws {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: base) }
+    let node = UUID()
+
+    #expect(NodeMemory.firstPassMarker(projectPath: "/tmp/p", nodeID: node, baseURL: base) == nil)
+    NodeMemory.recordFirstPass("session-a", projectPath: "/tmp/p", nodeID: node, baseURL: base)
+    #expect(
+      NodeMemory.firstPassMarker(projectPath: "/tmp/p", nodeID: node, baseURL: base)
+        == "session-a")
+
+    NodeMemory.clearFirstPass(projectPath: "/tmp/p", nodeID: node, baseURL: base)
+    #expect(NodeMemory.firstPassMarker(projectPath: "/tmp/p", nodeID: node, baseURL: base) == nil)
+  }
 }


### PR DESCRIPTION
Reported still broken after 0.1.50-beta2: a Copilot time-based loop schedules but does not run its first pass.

## Why beta2's kickoff didn't fire

It waited for a **new** Copilot session directory to appear and, if none did, did nothing at all. Two problems:

1. **The launch is a race.** The daemon starts a node's session if it gets there first; the app's terminal view does if the node was opened before it did (`GhosttyTerminalView.agentCommand` — the comment there says so explicitly). A session the daemon's ensure found *already running* produces no new Copilot directory, so the probe never fired.
2. **An empty probe still has to send.** The schedule is armed either way. Not sending costs a whole idle interval; sending costs one pass — which is precisely the pass being asked for. Giving up silently was the wrong default.

## What changed

- The pass is sent whether or not a new session directory was observed, after a bounded wait (45s, down from 90)
- Repetition is prevented by a marker recording **which** session was served (`NodeMemory.firstPassMarker`), not the fact of serving — a new Copilot session has a new directory and is always owed its own pass; a daemon restart over the same session sends nothing; killing the session forgets the marker
- Every branch is written to `~/.graphcode/dials.log`: `already-served`, `no-session`, `sent`, `sent-unobserved`, `undelivered`

That last point matters as much as the fix. The failure was invisible from outside — the loop simply sat there, with nothing to say whether the message had been skipped, timed out, or refused. Next time there is a line to read.

## Field note on Copilot versions

This machine has Copilot CLI **1.0.78**, and `/loop` and `/every` do not exist in it — `copilot help commands` and `copilot --experimental help commands` are byte-identical and list neither. [GitHub's docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/automate-copilot-cli/schedule-prompts) document both as experimental commands, so they arrived in a later build than this one.

Worth knowing because it changes what "scheduling is happening" means: on a CLI without `/loop`, the directive is prose, and an agent that reads "/loop 1h check X" may schedule it via its own `manage_schedule` tool and consider the turn done — scheduled, no first pass, exactly the reported symptom, by a different route than `/every`'s documented after-the-interval semantics. The kickoff fixes both, since it does not care why the first pass is missing.

## Verification

1087 tests in 116 suites pass (1 new); `make check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyMWkpMbY295brojUPbFRE