### PR TITLE
fix: pre-trust the folder locally, and verify the Copilot first pass landed

### DIFF
--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -182,6 +182,18 @@ public enum CopilotSessionLog {
     return lines
   }
 
+  /// Whether the session named `name` has recorded a user message containing `text` —
+  /// how a typed-in first pass proves it actually landed (`ZmxSessionLauncher`). Copilot
+  /// writes a `user.message` event the moment a message is submitted, so absence after a
+  /// sensible wait means the keystrokes went somewhere else: a trust dialog, a composer
+  /// that was not up yet.
+  static func hasUserMessage(containing text: String, inSessionNamed name: String) -> Bool {
+    guard let directory = directory(forSessionNamed: name) else { return false }
+    let needle = text.prefix(80)
+    return tailLines(ofLogAt: directory.appendingPathComponent("events.jsonl"))
+      .contains { $0.contains("\"user.message\"") && $0.contains(needle) }
+  }
+
   /// What this node's Copilot session is doing, or `nil` when nothing says.
   ///
   /// Local only, deliberately. The remote twin of this would have to carry a JSON record

--- a/GraphcodeKit/Sources/Sessions/CopilotTrust.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotTrust.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Seeds Copilot's folder-trust list so an unattended session is never parked at the
+/// trust-this-folder dialog — the local twin of the remote ensure's
+/// `copilotTrustSeedScript`, which learned this first: `--yolo` does not cover folder
+/// trust (measured), and a fresh unattended Copilot boots to an idle screen with its
+/// `--interactive` goal queued behind a dialog nobody is present to answer. Anything
+/// typed into the session while that dialog is up — a time-based loop's opening pass —
+/// is swallowed outright.
+///
+/// Pre-trusting the one directory the loop was pointed at is the same consent the human
+/// gave by creating the loop there. The write is additive and idempotent, and any
+/// failure falls back to today's behaviour: the dialog, answerable by opening the loop.
+///
+/// The file's shape was read off a real "remember this folder" answer, including the
+/// detail the remote script missed: Copilot writes `// …` comment lines above the JSON
+/// ("This file is managed automatically"), so a plain JSON parse fails on a real file.
+/// The header is carried through the rewrite untouched.
+public enum CopilotTrust {
+  public static var configURL: URL {
+    FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent(".copilot/config.json")
+  }
+
+  /// Adds `directory` to `trustedFolders` unless it is already there. Never throws and
+  /// never clobbers: a config it cannot parse is left exactly as found.
+  public static func ensureTrusted(directory: String, configURL: URL = configURL) {
+    guard !directory.isEmpty else { return }
+    let existing = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+    let lines = existing.components(separatedBy: "\n")
+    let header = lines.prefix { $0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+    let body = lines.dropFirst(header.count).joined(separator: "\n")
+    var config: [String: Any] = [:]
+    if !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      guard let parsed = try? JSONSerialization.jsonObject(with: Data(body.utf8)),
+        let dictionary = parsed as? [String: Any]
+      else { return }
+      config = dictionary
+    }
+    var trusted = config["trustedFolders"] as? [String] ?? []
+    guard !trusted.contains(directory) else { return }
+    trusted.append(directory)
+    config["trustedFolders"] = trusted
+    guard
+      let data = try? JSONSerialization.data(
+        withJSONObject: config, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+    else { return }
+    let text =
+      (header.isEmpty ? "" : header.joined(separator: "\n") + "\n")
+      + String(decoding: data, as: UTF8.self) + "\n"
+    try? FileManager.default.createDirectory(
+      at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try? Data(text.utf8).write(to: configURL, options: .atomic)
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -1003,11 +1003,18 @@ public enum ZmxSessionLauncher {
   /// cannot become Python syntax; the whole command is neutered with `|| true` because
   /// a failed seed must never block the launch it precedes.
   static func copilotTrustSeedScript(forRemotePath remotePath: String) -> String {
+    // Real config files open with `// …` comment lines Copilot writes above the JSON, so
+    // a plain `json.load` fails — and, `|| true`d, failed silently for as long as this
+    // script existed. The comment header is stripped for parsing and restored on write.
     let program =
       "import json,os,sys; p=os.path.expanduser('~/.copilot/config.json'); "
-      + "c=json.load(open(p)) if os.path.exists(p) else {}; "
+      + "r=open(p).read() if os.path.exists(p) else ''; "
+      + "h=[l for l in r.splitlines() if l.strip().startswith('//')]; "
+      + "b='\\n'.join(l for l in r.splitlines() if not l.strip().startswith('//')); "
+      + "c=json.loads(b) if b.strip() else {}; "
       + "f=c.get('trustedFolders') or []; t=sys.argv[1]; "
-      + "(t in f) or (f.append(t), c.update(trustedFolders=f), json.dump(c, open(p,'w')))"
+      + "(t in f) or (f.append(t), c.update(trustedFolders=f), "
+      + "open(p,'w').write('\\n'.join(h+[json.dumps(c)])+'\\n'))"
     return quotedCommand(["python3", "-c", program, remotePath]) + " 2>/dev/null || true"
   }
 
@@ -1239,6 +1246,12 @@ public enum ZmxSessionLauncher {
       DialLog.record(session: name, dial: "ensure", event: "resume-dead")
       SessionIDStore.remove(forNodeID: node.id)
     }
+    // The local half of the trust seed the remote ensure has always done: without it a
+    // fresh unattended Copilot parks its opening prompt behind the folder-trust dialog
+    // and swallows anything typed at it — the first pass included (`CopilotTrust`).
+    if node.backend == .copilotCLI, let directory = wd {
+      CopilotTrust.ensureTrusted(directory: directory)
+    }
     // Noted *before* the launch: the first pass below waits for a Copilot session
     // directory that was not already there, which is how it tells a session it just
     // started from one this ensure found already running.
@@ -1324,15 +1337,37 @@ public enum ZmxSessionLauncher {
         DialLog.record(session: name, dial: "first-pass", event: "no-session")
         return
       }
-      let delivered = await send(message, to: node, projectPath: projectPath)
-      if delivered {
+      // Sent, then *verified*: a `zmx send` reports only that the keystrokes reached
+      // the PTY, and a Copilot mid-boot — or parked at a dialog the trust seed could
+      // not prevent — swallows them whole. The `user.message` event Copilot writes on
+      // submission is the proof the pass became a turn; absent, the send is repeated.
+      var attempt = 0
+      var confirmed = false
+      while attempt < firstPassAttempts, !confirmed {
+        attempt += 1
+        guard await send(message, to: node, projectPath: projectPath) else { break }
+        let verifyDeadline = Date().addingTimeInterval(firstPassVerifySeconds)
+        while Date() < verifyDeadline, !confirmed {
+          confirmed = CopilotSessionLog.hasUserMessage(containing: message, inSessionNamed: name)
+          if !confirmed { try? await Task.sleep(for: .seconds(firstPassPollSeconds)) }
+        }
+      }
+      if confirmed {
         NodeMemory.recordFirstPass(session, projectPath: projectPath, nodeID: node.id)
       }
       DialLog.record(
         session: name, dial: "first-pass",
-        event: delivered ? (observed == nil ? "sent-unobserved" : "sent") : "undelivered")
+        event: confirmed
+          ? (attempt > 1 ? "sent-after-retry" : "sent")
+          : (attempt > 0 ? "undelivered" : "send-failed"))
     }
   }
+
+  /// The verification window per attempt is generous next to the instant write Copilot
+  /// actually does, and the attempt count is small: three swallowed sends in a row means
+  /// something structural, not something a fourth send fixes.
+  static let firstPassAttempts = 3
+  static let firstPassVerifySeconds: TimeInterval = 10
 
   /// Long enough for a cold `copilot` to open its session, short enough that a pass sent
   /// without ever seeing one is still early in the interval it is standing in for.

--- a/graphcode/Tests/CopilotTrustTests.swift
+++ b/graphcode/Tests/CopilotTrustTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// Seeding Copilot's folder trust so an unattended session never parks at the dialog
+/// that swallows its opening prompt and anything typed after it.
+@Suite
+struct CopilotTrustTests {
+  private func temporaryConfig(_ contents: String?) -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathComponent("config.json")
+    if let contents {
+      try? FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try? Data(contents.utf8).write(to: url)
+    }
+    return url
+  }
+
+  /// The detail the remote seed missed for as long as it existed: real config files open
+  /// with `// …` lines Copilot writes above the JSON, and a plain parse fails on them.
+  @Test
+  func aRealConfigWithCommentHeaderIsParsedAndTheHeaderKept() throws {
+    let url = temporaryConfig(
+      """
+      // User settings belong in settings.json.
+      // This file is managed automatically.
+      {"firstLaunchAt":"2026-07-28","trustedFolders":["/tmp/existing"]}
+      """)
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    CopilotTrust.ensureTrusted(directory: "/tmp/project", configURL: url)
+
+    let written = try String(contentsOf: url, encoding: .utf8)
+    #expect(written.hasPrefix("// User settings belong in settings.json."))
+    #expect(written.contains("/tmp/existing"))
+    #expect(written.contains("/tmp/project"))
+    // The unrelated key survives the rewrite.
+    #expect(written.contains("firstLaunchAt"))
+  }
+
+  @Test
+  func aMissingConfigIsCreated() throws {
+    let url = temporaryConfig(nil)
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    CopilotTrust.ensureTrusted(directory: "/tmp/project", configURL: url)
+    #expect(try String(contentsOf: url, encoding: .utf8).contains("/tmp/project"))
+  }
+
+  /// Additive and idempotent: a directory already trusted changes nothing, so the seed
+  /// can run on every launch without churning the file.
+  @Test
+  func anAlreadyTrustedDirectoryLeavesTheFileUntouched() throws {
+    let url = temporaryConfig(#"{"trustedFolders":["/tmp/project"]}"#)
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    let before = try Data(contentsOf: url)
+    CopilotTrust.ensureTrusted(directory: "/tmp/project", configURL: url)
+    #expect(try Data(contentsOf: url) == before)
+  }
+
+  /// A config it cannot parse is left exactly as found — the dialog is a recoverable
+  /// failure, a clobbered Copilot config is not.
+  @Test
+  func garbageIsLeftExactlyAsFound() throws {
+    let url = temporaryConfig("{not json at all")
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    CopilotTrust.ensureTrusted(directory: "/tmp/project", configURL: url)
+    #expect(try String(contentsOf: url, encoding: .utf8) == "{not json at all")
+  }
+}


### PR DESCRIPTION
The Copilot time-based first pass was still not arriving. Probed against a real Copilot 1.0.80 under zmx, three measurements:

| Probe | Result |
|---|---|
| `/loop 2m …` as the opening prompt | ✅ arms — "Scheduled #1 every 2m" |
| `zmx send` + `\r` into an idle session | ✅ lands as a user message and is answered |
| The same send while the **folder-trust dialog** is up | ❌ swallowed completely — and `--yolo` does not skip that dialog |

## Root cause

The **remote** ensure has known this for some time — `copilotTrustSeedScript`'s comment says it outright: "an unattended Copilot queues its `--interactive` goal behind a per-session folder-trust dialog that nobody is present to answer… `--yolo` does not cover folder trust — measured." It pre-trusts the folder in `~/.copilot/config.json` before launching. **The local launch path never got the same treatment.** So locally: the dialog queues the `/loop` directive (scheduling eventually shows, matching the report) and silently eats the first-pass message the kickoff types.

## The fix, three parts

1. **`CopilotTrust.ensureTrusted`** — the local twin of the remote seed. Adds the working directory to `trustedFolders` before a Copilot node's session launches; additive, idempotent, and it refuses to touch a file it cannot parse. Run only for `.copilotCLI` nodes.
2. **The remote seed had a latent bug**: real config files open with `// …` comment lines Copilot writes above the JSON, so its `json.load` failed — and, `|| true`'d, failed *silently* for as long as the script has existed. Both seeds now strip the header for parsing and preserve it on write. Verified against a fixture with the real header.
3. **The first pass is verified, not assumed.** `zmx send` only proves keystrokes reached the PTY. Copilot writes a `user.message` event to `events.jsonl` the moment a message is actually submitted (measured), so the kickoff now confirms that event appeared and re-sends up to 3 times if it didn't. Dial log gains `sent-after-retry` and `send-failed`.

## No Claude Code regression

Every new behaviour is gated on `.copilotCLI`: the trust seed (`node.backend == .copilotCLI` at the launch site), the kickoff (`firstPassMessage` guards backend + loop type + no heartbeat), and `--experimental` (inside the `case .copilotCLI` branch only). Claude Code's argv is byte-identical to before this branch; the full 1091-test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyMWkpMbY295brojUPbFRE