### PR TITLE
fix: Copilot time loops deliver like goal loops — typed passes on a daemon timer

### DIFF
--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -199,15 +199,19 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
       let note = firstInstruction?.trimmingCharacters(in: .whitespaces) ?? ""
       return note.isEmpty ? nil : note
     case .timeBased:
-      guard let interval = heartbeatIntervalSeconds, interval > 0, let task = triggerPrompt
-      else { return triggerPrompt }
+      guard let interval = effectiveHeartbeatInterval, interval > 0 else {
+        return triggerPrompt
+      }
+      let task = heartbeatTask ?? ""
       // The heartbeat counterpart of the /loop directive: the session is told who
       // holds the timer, so it neither schedules its own cadence (double-driving)
-      // nor exits believing one pass was the whole job.
-      return "Every \(Int(interval))s you will receive a [graphcode] heartbeat message. "
-        + "Each one is your cue to run one pass of this task, then wait for the next: "
-        + "\(task) Do not schedule your own /loop, wakeup, or cron for it — the "
-        + "orchestrator holds the timer. Stay in the session between heartbeats."
+      // nor exits believing one pass was the whole job. It opens by *doing* rather
+      // than waiting — a fresh loop's first pass belongs to creation, exactly as a
+      // goal-based loop's does, not to the far end of the first interval.
+      return "Run one pass of this task now: \(task) Then stay in the session — every "
+        + "\(Int(interval))s you will receive a [graphcode] heartbeat message, and each "
+        + "one is your cue to run the next pass. Do not schedule your own /loop, wakeup, "
+        + "or cron for it — the orchestrator holds the timer."
     case .goalBased: return goal?.sessionPrompt
     case .turnBased:
       return Self.turnBasedPrompt(
@@ -245,6 +249,37 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     parts.append(pause)
     if !criterion.isEmpty { parts.append("Each turn is verified against this: \(criterion)") }
     return parts.isEmpty ? nil : parts.joined(separator: " ")
+  }
+
+  /// The cadence the daemon drives this loop on, or `nil` when the session owns it.
+  ///
+  /// The stored `heartbeatIntervalSeconds` — the experiment's explicit opt-in — wins
+  /// where present. What the derivation adds is Copilot: its in-session `/loop` never
+  /// worked as a cadence (the directive's scheduled prompts arrive as system-shaped
+  /// messages the agent does not treat as work, where a *typed* message — the goal-based
+  /// delivery — demonstrably does), so a Copilot time loop's interval is read out of the
+  /// directive it was created with and the daemon holds the timer. Derived rather than
+  /// migrated, so every existing Copilot time loop heals on update with its graph
+  /// untouched.
+  public var effectiveHeartbeatInterval: Double? {
+    if let interval = heartbeatIntervalSeconds, interval > 0 { return interval }
+    guard backend == .copilotCLI, loopType == .timeBased, let prompt = triggerPrompt
+    else { return nil }
+    return SessionPrompt.interval(of: prompt)
+  }
+
+  /// Whether the daemon's timer for this node is the Copilot derivation above rather
+  /// than the experiment's opt-in — the one cadence that must keep beating with the
+  /// experiment toggle off, because for Copilot it is not an experiment but the only
+  /// delivery that works.
+  public var hasDerivedHeartbeat: Bool {
+    heartbeatIntervalSeconds == nil && effectiveHeartbeatInterval != nil
+  }
+
+  /// The bare task a heartbeat pass runs: the prompt with its `/loop` directive
+  /// unwrapped when it carries one, verbatim otherwise.
+  public var heartbeatTask: String? {
+    triggerPrompt.map { SessionPrompt.firstPass(of: $0) ?? $0 }
   }
 
   /// The tier this node actually runs on: the human's pin if there is one, otherwise

--- a/GraphcodeKit/Sources/Domain/SessionPrompt.swift
+++ b/GraphcodeKit/Sources/Domain/SessionPrompt.swift
@@ -51,6 +51,40 @@ public enum SessionPrompt {
     return nil
   }
 
+  /// The interval a `/loop <interval> …` directive names, in seconds — `nil` when the
+  /// prompt is not a directive or its interval token is unreadable. Same vocabulary the
+  /// creation dialog accepts: `90s`, `30m`, `2h`, `3d`, and a bare number is minutes.
+  public static func interval(of prompt: String) -> Double? {
+    let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+    for directive in recurringDirectives where trimmed.hasPrefix("\(directive) ") {
+      let afterDirective = trimmed.dropFirst(directive.count).drop { $0 == " " }
+      let token = afterDirective.prefix { $0 != " " }.lowercased()
+      guard !token.isEmpty else { return nil }
+      let scale: Double
+      let digits: Substring
+      switch token.last {
+      case "s":
+        scale = 1
+        digits = token.dropLast()
+      case "m":
+        scale = 60
+        digits = token.dropLast()
+      case "h":
+        scale = 3600
+        digits = token.dropLast()
+      case "d":
+        scale = 86400
+        digits = token.dropLast()
+      default:
+        scale = 60
+        digits = token[...]
+      }
+      guard let value = Double(digits), value > 0 else { return nil }
+      return value * scale
+    }
+    return nil
+  }
+
   /// `prompt` with `preamble` on whichever side keeps a leading directive leading.
   public static func composed(preamble: String, prompt: String) -> String {
     guard opensWithDirective(prompt) else { return "\(preamble) \(prompt)" }

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -1975,7 +1975,7 @@ public actor GraphStore {
   /// the session on every beat, so the timer itself holds no authority anything else
   /// would need revoking.
   private func armHeartbeat(for node: LoopNode) {
-    guard node.loopType == .timeBased, let interval = node.heartbeatIntervalSeconds,
+    guard node.loopType == .timeBased, let interval = node.effectiveHeartbeatInterval,
       interval > 0, onDeliverMessage != nil
     else { return }
     heartbeatTimers[node.id]?.cancel()
@@ -2002,13 +2002,17 @@ public actor GraphStore {
   /// was the double-driving this experiment must not reintroduce. Skips are silent; a
   /// heartbeat that logged every beat would turn the memory log into a metronome.
   public func deliverHeartbeat(_ nodeID: UUID) async {
-    guard onHeartbeatEnabled?() == true else { return }
     guard let node = graph.nodes[id: nodeID], node.loopType == .timeBased, !node.isResolved,
-      let interval = node.heartbeatIntervalSeconds, interval > 0
+      let interval = node.effectiveHeartbeatInterval, interval > 0
     else {
       cancelHeartbeat(nodeID)
       return
     }
+    // The Settings toggle gates the *experiment* — loops that opted in explicitly. A
+    // derived Copilot cadence beats regardless: for that backend the daemon's typed
+    // message is not an experiment but the only delivery that works, and a toggle
+    // nobody associated with Copilot silencing every Copilot time loop is a trap.
+    guard node.hasDerivedHeartbeat || onHeartbeatEnabled?() == true else { return }
     guard MessageBus.deliverability(to: node) == nil else { return }
     let presence: Presence?
     if let onReadPresence {
@@ -2017,7 +2021,7 @@ public actor GraphStore {
       presence = node.presence?.presence
     }
     guard presence != .busy else { return }
-    let task = node.triggerPrompt ?? ""
+    let task = node.heartbeatTask ?? ""
     _ = await deliverToSession(
       node, "[graphcode] Heartbeat — run one pass of your task now: \(task)")
   }

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -1280,7 +1280,7 @@ public enum ZmxSessionLauncher {
   /// first beat itself — or for any backend whose recurrence is not a scheduler.
   static func firstPassMessage(for node: LoopNode) -> String? {
     guard node.backend == .copilotCLI, node.loopType == .timeBased,
-      node.heartbeatIntervalSeconds == nil, let prompt = node.sessionPrompt
+      node.effectiveHeartbeatInterval == nil, let prompt = node.sessionPrompt
     else { return nil }
     return SessionPrompt.firstPass(of: prompt)
   }

--- a/graphcode/Tests/DaemonHeartbeatTests.swift
+++ b/graphcode/Tests/DaemonHeartbeatTests.swift
@@ -23,6 +23,37 @@ struct DaemonHeartbeatTests {
       ])
   }
 
+  /// The toggle gates the experiment's explicit opt-ins. A Copilot time loop's derived
+  /// cadence beats regardless: for that backend the typed message is not an experiment
+  /// but the only delivery that works, and the toggle was never associated with it.
+  @Test
+  func aDerivedCopilotCadenceBeatsWithTheToggleOff() async {
+    let delivered = LockIsolated<[String]>([])
+    let graph = LoopGraph(
+      project: ProjectRef(path: "/tmp/heartbeat", name: "heartbeat"),
+      nodes: [
+        LoopNode(
+          title: "Poll", loopType: .timeBased, triggerPrompt: "/loop 1h Check the queue",
+          backend: .copilotCLI,
+          presence: PresenceReading(presence: .idle, confidence: .reported),
+          state: .running)
+      ])
+    let store = GraphStore(
+      graph: graph,
+      onDeliverMessage: { _, message, _ in
+        delivered.withValue { $0.append(message) }
+        return true
+      },
+      onHeartbeatEnabled: { false })
+
+    await store.deliverHeartbeat(graph.nodes[0].id)
+
+    #expect(delivered.value.count == 1)
+    // The beat carries the bare task, never the directive that would re-arm /every.
+    #expect(delivered.value.first?.contains("Check the queue") == true)
+    #expect(delivered.value.first?.contains("/loop") == false)
+  }
+
   @Test
   func theToggleOffMeansNoBeatEverFires() async {
     let delivered = LockIsolated(0)

--- a/graphcode/Tests/SessionBriefingTests.swift
+++ b/graphcode/Tests/SessionBriefingTests.swift
@@ -200,12 +200,14 @@ struct SessionBriefingTests {
       #expect(granted.contains { $0.contains("briefings") })
     }
 
-    // The node polls, so its prompt is a `/loop` directive and the pointer trails it —
-    // see `theLoopDirectiveKeepsTheFrontOfACopilotPrompt`.
+    // A Copilot time loop's cadence is daemon-held (`LoopNode.effectiveHeartbeatInterval`),
+    // so its opening is goal-style prose — the pointer leads it, and no `/loop` directive
+    // is typed at a backend whose scheduler delivers system-shaped prompts it won't act on.
     let interactive = try #require(arguments.firstIndex(of: "--interactive"))
     let opening = arguments[interactive + 1]
     #expect(opening.contains(".md"))
-    #expect(opening.hasPrefix("/loop 1h Check"))
+    #expect(opening.contains("Run one pass of this task now: Check"))
+    #expect(!opening.contains("/loop 1h"))
   }
 
   @Test

--- a/graphcode/Tests/SessionPromptTests.swift
+++ b/graphcode/Tests/SessionPromptTests.swift
@@ -121,11 +121,58 @@ struct SessionPromptTests {
         title: "Poll", loopType: type, triggerPrompt: prompt,
         heartbeatIntervalSeconds: heartbeat, backend: backend)
     }
-    #expect(ZmxSessionLauncher.firstPassMessage(for: node()) == "Check")
+    // A parseable interval means the daemon holds the cadence and delivers the first
+    // pass itself — the kickoff exists only for a directive whose interval it cannot
+    // read, where the session is still on its own.
+    #expect(ZmxSessionLauncher.firstPassMessage(for: node()) == nil)
+    #expect(ZmxSessionLauncher.firstPassMessage(for: node(prompt: "/loop soon Check")) == "Check")
     #expect(ZmxSessionLauncher.firstPassMessage(for: node(heartbeat: 900)) == nil)
     #expect(ZmxSessionLauncher.firstPassMessage(for: node(backend: .claudeCode)) == nil)
     #expect(
       ZmxSessionLauncher.firstPassMessage(for: node(type: .sketch, prompt: "poke about")) == nil)
+  }
+
+  /// The user-visible difference this pins: a goal-based loop's task lands as a typed
+  /// user message and Copilot works on it at creation; `/every`'s scheduled prompts
+  /// arrive system-shaped and it does not. So a Copilot time loop's cadence is the
+  /// daemon's — derived from the directive it was created with, no migration — and its
+  /// session opens by doing, not by scheduling.
+  @Test
+  func aCopilotTimeLoopIsDaemonDrivenByDerivation() {
+    let copilot = LoopNode(
+      title: "Poll", loopType: .timeBased, triggerPrompt: "/loop 1h Check the queue",
+      backend: .copilotCLI)
+    #expect(copilot.effectiveHeartbeatInterval == 3600)
+    #expect(copilot.hasDerivedHeartbeat)
+    #expect(copilot.heartbeatTask == "Check the queue")
+    let opening = copilot.sessionPrompt ?? ""
+    #expect(opening.contains("Run one pass of this task now: Check the queue"))
+    #expect(!opening.contains("/loop 1h"))
+
+    // Claude Code's /loop works as a command; its model is untouched.
+    let claude = LoopNode(
+      title: "Poll", loopType: .timeBased, triggerPrompt: "/loop 1h Check the queue",
+      backend: .claudeCode)
+    #expect(claude.effectiveHeartbeatInterval == nil)
+    #expect(claude.sessionPrompt == "/loop 1h Check the queue")
+
+    // The experiment's explicit opt-in still wins over the derivation.
+    let explicit = LoopNode(
+      title: "Poll", loopType: .timeBased, triggerPrompt: "/loop 1h Check",
+      heartbeatIntervalSeconds: 900, backend: .copilotCLI)
+    #expect(explicit.effectiveHeartbeatInterval == 900)
+    #expect(!explicit.hasDerivedHeartbeat)
+  }
+
+  @Test
+  func theDirectiveIntervalVocabularyMatchesTheDialog() {
+    #expect(SessionPrompt.interval(of: "/loop 90s go") == 90)
+    #expect(SessionPrompt.interval(of: "/every 30m go") == 1800)
+    #expect(SessionPrompt.interval(of: "/loop 2h go") == 7200)
+    #expect(SessionPrompt.interval(of: "/loop 3d go") == 259_200)
+    #expect(SessionPrompt.interval(of: "/loop 45 go") == 2700)
+    #expect(SessionPrompt.interval(of: "/loop soon go") == nil)
+    #expect(SessionPrompt.interval(of: "just prose") == nil)
   }
 
   /// The marker is what stops the opening pass repeating, and it records *which* session


### PR DESCRIPTION
The user-visible difference that survived every prior fix: a goal-based loop's task lands as a **typed user message** at creation and Copilot works on it immediately; a time-based loop's `/loop` directive arms `/every`, whose scheduled prompts arrive **system-shaped** — and Copilot does not treat them as work. The loop neither runs at creation nor acts on its schedule.

## The fix

Copilot time-based loops stop using `/every` entirely and deliver the goal-based way:

| Moment | Delivery |
|---|---|
| Creation | The session opens with `"Run one pass of this task now: <task>"` — prose, lands as a user message, works immediately, exactly like a goal-based loop |
| Every interval | The daemon types `[graphcode] Heartbeat — run one pass…` into the session — a real user message |

- `LoopNode.effectiveHeartbeatInterval` **derives** the cadence from the `/loop <interval> …` prompt the node already has (`SessionPrompt.interval(of:)`, same vocabulary as the dialog: `90s/30m/2h/3d`, bare number = minutes). Derived, not migrated — **every existing Copilot time loop heals on update** with its graph untouched.
- The derived cadence beats **regardless of the `daemonHeartbeatEnabled` toggle** — that setting gates the experiment's explicit opt-ins, and stays doing exactly that. For Copilot this is not an experiment; it is the only delivery that works.
- The heartbeat text carries the **bare task** (directive unwrapped), so a beat can never re-arm `/every`.
- `armHeartbeat` already runs at graph load, node creation, and update, so no new arming path was needed.
- The typed first-pass kickoff from beta5/6 goes dormant for any node whose cadence is daemon-held; it remains only for a directive whose interval cannot be parsed.

## No Claude Code regression

`effectiveHeartbeatInterval` derives **only** for `backend == .copilotCLI`; a Claude Code time loop's `sessionPrompt` is byte-identical (`/loop 1h …` positional, works there as a real command — asserted in `aCopilotTimeLoopIsDaemonDrivenByDerivation`). The explicit heartbeat experiment's behaviour is pinned unchanged by the existing `theToggleOffMeansNoBeatEverFires`.

## Verification

1094 tests in 117 suites pass (3 new: derivation + interval vocabulary + derived-beats-with-toggle-off); `make check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyMWkpMbY295brojUPbFRE