### PR TITLE
fix: a Copilot time loop opens by running now and arming its own /every

### DIFF
--- a/GraphcodeKit/Sources/Domain/BackendCommand.swift
+++ b/GraphcodeKit/Sources/Domain/BackendCommand.swift
@@ -104,7 +104,7 @@ extension CLISessionBackendKind {
       // and the session reads it as prose: no schedule, one pass, then idle. Passed only
       // for a prompt that actually is one, so an ordinary Copilot session keeps the
       // CLI's own defaults.
-      let experimental = SessionPrompt.firstPass(of: prompt) != nil ? ["--experimental"] : []
+      let experimental = SessionPrompt.mentionsRecurrence(prompt) ? ["--experimental"] : []
       guard let briefingPath else {
         return model + access + experimental + ["--interactive", prompt]
       }

--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -199,6 +199,19 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
       let note = firstInstruction?.trimmingCharacters(in: .whitespaces) ?? ""
       return note.isEmpty ? nil : note
     case .timeBased:
+      // Copilot's `/every` submits its first prompt only after the interval elapses, so
+      // a directive-led opening armed correctly and then sat idle — and the typed
+      // first-pass workaround raced the composer. The reliable channel is the opening
+      // prompt itself, so for Copilot it carries both halves as prose: run the task
+      // now, then arm your own `/every`. The session still owns the cadence; graphcode
+      // holds no timer. Other backends keep the directive verbatim — Claude Code's
+      // `/loop` runs its first iteration itself.
+      if backend == .copilotCLI, heartbeatIntervalSeconds == nil, let prompt = triggerPrompt,
+        let recurrence = SessionPrompt.recurrence(of: prompt)
+      {
+        return "Run this task now: \(recurrence.task) Then schedule it to repeat with: "
+          + "/every \(recurrence.interval) \(recurrence.task)"
+      }
       guard let interval = heartbeatIntervalSeconds, interval > 0, let task = triggerPrompt
       else { return triggerPrompt }
       // The heartbeat counterpart of the /loop directive: the session is told who

--- a/GraphcodeKit/Sources/Domain/SessionPrompt.swift
+++ b/GraphcodeKit/Sources/Domain/SessionPrompt.swift
@@ -51,6 +51,30 @@ public enum SessionPrompt {
     return nil
   }
 
+  /// The recurrence a `/loop <interval> <task>` directive describes — the interval token
+  /// exactly as written and the task behind it — or `nil` for anything else. The token
+  /// stays a string because its consumer repeats it back to the agent verbatim.
+  public static func recurrence(of prompt: String) -> (interval: String, task: String)? {
+    let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+    for directive in recurringDirectives where trimmed.hasPrefix("\(directive) ") {
+      let afterDirective = trimmed.dropFirst(directive.count).drop { $0 == " " }
+      let interval = afterDirective.prefix { $0 != " " }
+      let task = afterDirective.dropFirst(interval.count)
+        .trimmingCharacters(in: .whitespaces)
+      guard !interval.isEmpty, !task.isEmpty else { return nil }
+      return (String(interval), task)
+    }
+    return nil
+  }
+
+  /// Whether the prompt involves a recurring directive at all — leading or mentioned —
+  /// which is what decides Copilot's `--experimental` flag: the session needs `/every`
+  /// available whether the directive opens the message or the message asks the agent to
+  /// arm it.
+  public static func mentionsRecurrence(_ prompt: String) -> Bool {
+    recurringDirectives.contains { prompt.contains($0) }
+  }
+
   /// `prompt` with `preamble` on whichever side keeps a leading directive leading.
   public static func composed(preamble: String, prompt: String) -> String {
     guard opensWithDirective(prompt) else { return "\(preamble) \(prompt)" }

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -162,7 +162,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
     // here rather than by the daemon would arm nothing at all without it — the same
     // parity this whole method exists for, since which path starts a session is a race.
     let opening = initialPrompt ?? ""
-    if backend == .copilotCLI, SessionPrompt.firstPass(of: opening) != nil {
+    if backend == .copilotCLI, SessionPrompt.mentionsRecurrence(opening) {
       parts.append("--experimental")
     }
     // Presence reporting, from the same place the daemon gets it (`PresenceHooks`). It

--- a/graphcode/Tests/SessionBriefingTests.swift
+++ b/graphcode/Tests/SessionBriefingTests.swift
@@ -200,12 +200,14 @@ struct SessionBriefingTests {
       #expect(granted.contains { $0.contains("briefings") })
     }
 
-    // The node polls, so its prompt is a `/loop` directive and the pointer trails it —
-    // see `theLoopDirectiveKeepsTheFrontOfACopilotPrompt`.
+    // A Copilot time loop opens as prose — run now, then arm /every — so the briefing
+    // pointer leads it, and the raw directive never fronts the message.
     let interactive = try #require(arguments.firstIndex(of: "--interactive"))
     let opening = arguments[interactive + 1]
     #expect(opening.contains(".md"))
-    #expect(opening.hasPrefix("/loop 1h Check"))
+    #expect(opening.contains("Run this task now: Check"))
+    #expect(opening.contains("/every 1h Check"))
+    #expect(!opening.hasPrefix("/loop"))
   }
 
   @Test

--- a/graphcode/Tests/SessionPromptTests.swift
+++ b/graphcode/Tests/SessionPromptTests.swift
@@ -121,11 +121,56 @@ struct SessionPromptTests {
         title: "Poll", loopType: type, triggerPrompt: prompt,
         heartbeatIntervalSeconds: heartbeat, backend: backend)
     }
-    #expect(ZmxSessionLauncher.firstPassMessage(for: node()) == "Check")
+    // A directive-shaped prompt now opens as prose that runs the task and arms /every
+    // itself, so the typed kickoff is dormant across the board — kept only as the belt
+    // for a future prompt shape the prose composition doesn't cover.
+    #expect(ZmxSessionLauncher.firstPassMessage(for: node()) == nil)
+    #expect(ZmxSessionLauncher.firstPassMessage(for: node(prompt: "/loop soon Check")) == nil)
     #expect(ZmxSessionLauncher.firstPassMessage(for: node(heartbeat: 900)) == nil)
     #expect(ZmxSessionLauncher.firstPassMessage(for: node(backend: .claudeCode)) == nil)
     #expect(
       ZmxSessionLauncher.firstPassMessage(for: node(type: .sketch, prompt: "poke about")) == nil)
+  }
+
+  /// The user-shaped fix: `/every` submits its first prompt only after the interval, so
+  /// the opening message — the one channel that always lands — carries both halves as
+  /// prose. Run now, then arm your own recurrence. The session still owns the cadence.
+  @Test
+  func aCopilotTimeLoopOpensByRunningNowAndArmingItsOwnEvery() {
+    let copilot = LoopNode(
+      title: "Poll", loopType: .timeBased, triggerPrompt: "/loop 15m say hi",
+      backend: .copilotCLI)
+    #expect(
+      copilot.sessionPrompt
+        == "Run this task now: say hi Then schedule it to repeat with: /every 15m say hi")
+
+    // Claude Code's /loop runs its first iteration itself; its directive is untouched.
+    let claude = LoopNode(
+      title: "Poll", loopType: .timeBased, triggerPrompt: "/loop 15m say hi",
+      backend: .claudeCode)
+    #expect(claude.sessionPrompt == "/loop 15m say hi")
+
+    // The token is repeated back verbatim, whatever it is — a bad one still runs its
+    // first pass, and the agent surfaces the bad /every where a silent directive never
+    // surfaced anything.
+    let odd = LoopNode(
+      title: "Poll", loopType: .timeBased, triggerPrompt: "/loop soon say hi",
+      backend: .copilotCLI)
+    #expect(
+      odd.sessionPrompt
+        == "Run this task now: say hi Then schedule it to repeat with: /every soon say hi")
+  }
+
+  @Test
+  func recurrenceExtractionKeepsTheTokenVerbatim() {
+    let parsed = SessionPrompt.recurrence(of: "/every 30m check the queue")
+    #expect(parsed?.interval == "30m")
+    #expect(parsed?.task == "check the queue")
+    #expect(SessionPrompt.recurrence(of: "/loop 1h") == nil)
+    #expect(SessionPrompt.recurrence(of: "plain prose") == nil)
+    // The experimental flag follows any mention, prose included.
+    #expect(SessionPrompt.mentionsRecurrence("Run now. Then: /every 15m say hi"))
+    #expect(!SessionPrompt.mentionsRecurrence("fix the failing test"))
   }
 
   /// The marker is what stops the opening pass repeating, and it records *which* session


### PR DESCRIPTION
The user-shaped fix for the last of the first-pass flakiness, replacing the typed kickoff for the normal case.

## The shape

`/every` submits its first prompt only after the interval elapses, and the typed first-pass workaround raced Copilot's booting composer. The one channel that always lands is the opening prompt itself — so for Copilot a time loop's opening is now two sentences of prose:

> Run this task now: say hi Then schedule it to repeat with: /every 15m say hi

- **First pass is deterministic** — it rides the launch argv like a goal-based prompt, landing as a user message the moment boot completes. No typed second message, no readiness poll, no verification, no retries.
- **Cadence stays session-owned** — the *session* arms its own `/every`; graphcode holds no timer, honoring the architecture contract.
- The interval token is repeated back verbatim; a bad one still runs its first pass and surfaces the bad `/every` visibly, where the silent directive surfaced nothing.
- `--experimental` now keys on any `/every`//`/loop` mention (prose included), so the armed command exists.
- The kickoff machinery from beta5–0.1.51-beta1 goes fully dormant (asserted) — kept as the belt for a prompt shape the prose composition doesn't cover.

## The trade, named

The directive-led opening armed the schedule deterministically and flaked on the first pass; this makes the first pass deterministic and hands arming to an instructed agent. A missed arm is *visible* (the loop goes quiet after a good first pass, `/every` list is empty) where a missed first pass looked identical to a dead loop — the right side of the trade.

## Scope

Copilot only: Claude Code's `/loop` runs its first iteration itself and its prompt is untouched (asserted); heartbeat-mode and all other loop types unchanged.

1095 tests in 117 suites pass (3 new/reshaped); `make check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyMWkpMbY295brojUPbFRE