### PR TITLE
Visualise a finished pass as a diagram (experimental, off by default)

### DIFF
--- a/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
+++ b/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
@@ -329,6 +329,27 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
   /// the derived beat exactly as it was — see `SummaryModelWriter`.
   public var summaryUsesModel: Bool
 
+  /// Whether a small model draws each finished pass — the summary rail's *picture*.
+  ///
+  /// **Off by default, experimental, and meaningless with `summarisesLoops` off.** The rail
+  /// above it says what a loop is doing in a sentence; this says it in a shape, when the
+  /// work had one. On, the end of a pass sends that pass's beats to the fast tier and asks
+  /// for a Mermaid flowchart or a Markdown table, which graphcode parses and draws natively
+  /// (`MermaidBoardParser`) rather than through a web view it does not ship.
+  ///
+  /// Its own switch rather than a mode of `summaryUsesModel`, and the reason is what the two
+  /// buy. That one spends a call to improve a sentence already on screen — the failure mode
+  /// is a worse sentence. This one spends a call to draw a claim about the *shape* of a run,
+  /// which is a larger claim than a sentence makes and is wrong in a way that looks
+  /// authoritative: a flowchart of work that had no flow reads as fact. So it is opt-in on
+  /// its own terms, the composer is told to answer `NONE` and expected to (most passes are),
+  /// and the Mermaid it produced is always one click from being read as text.
+  ///
+  /// One call per *finished pass* of a working loop, at most `SummaryBoardComposer.maxPerTick`
+  /// loops a tick — not one per beat, which is what `summaryUsesModel` costs and what makes
+  /// this the cheaper of the two on a busy graph.
+  public var visualisesSummaries: Bool
+
   /// Whether the daemon may drive time-based loops on its own timer — the experiment
   /// that tests the *opposite* of this project's founding cadence decision.
   ///
@@ -373,6 +394,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     sharesLoops: Bool = true,
     summarisesLoops: Bool = false,
     summaryUsesModel: Bool = false,
+    visualisesSummaries: Bool = false,
     daemonHeartbeatEnabled: Bool = false,
     keepsMacAwakeWhileLoopsRun: Bool = false,
     worktreePolicies: [String: WorktreeHygienePolicy] = [:]
@@ -388,6 +410,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     self.sharesLoops = sharesLoops
     self.summarisesLoops = summarisesLoops
     self.summaryUsesModel = summaryUsesModel
+    self.visualisesSummaries = visualisesSummaries
     self.daemonHeartbeatEnabled = daemonHeartbeatEnabled
     self.keepsMacAwakeWhileLoopsRun = keepsMacAwakeWhileLoopsRun
     self.worktreePolicies = worktreePolicies
@@ -436,6 +459,11 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     // money on a machine whose owner only asked to see what their loops were doing.
     summaryUsesModel =
       try container.decodeIfPresent(Bool.self, forKey: .summaryUsesModel) ?? false
+    // Absent means nobody has opted in. Never inferred from either switch above it: the
+    // reading is free, the rewrite is a sentence, and this draws a shape — three different
+    // prices, so three different answers.
+    visualisesSummaries =
+      try container.decodeIfPresent(Bool.self, forKey: .visualisesSummaries) ?? false
     daemonHeartbeatEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .daemonHeartbeatEnabled) ?? false
     // Absent means nobody has asked for it, which is the default. An update must never

--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -94,6 +94,17 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
   /// `nil` until the summary producer is switched on in Settings, which is where it stays
   /// for anyone who never turns the experiment on.
   public var summary: LoopSummary?
+  /// The same run, drawn — a Mermaid flowchart or a table, composed once per finished pass
+  /// and rendered natively by the rail (`SummaryBoard`).
+  ///
+  /// Beside `summary` rather than inside it because the two are produced by different
+  /// things at different prices: a beat is read off the transcript for nothing, every poll;
+  /// a board is a model call, at a pass boundary, only if someone switched that on. Folding
+  /// them together would mean a summary that costs money to merge.
+  ///
+  /// `nil` for anyone who never turns the experiment on, and cleared within a poll of it
+  /// being turned off.
+  public var board: SummaryBoard?
   /// What the session is doing right now, as last read off its own label store
   /// (`PresenceHooks` writes it, `ZmxSessionLauncher.presence` reads it).
   ///
@@ -144,6 +155,7 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     usage: UsageSample? = nil,
     activity: String? = nil,
     summary: LoopSummary? = nil,
+    board: SummaryBoard? = nil,
     presence: PresenceReading? = nil,
     metricHistory: [MetricSample] = [],
     createdBy: UUID? = nil,
@@ -167,6 +179,7 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     self.usage = usage
     self.activity = activity
     self.summary = summary
+    self.board = board
     self.presence = presence
     self.metricHistory = metricHistory
     self.createdBy = createdBy
@@ -333,7 +346,7 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     case id, title, loopType, checkDescription, triggerPrompt, goal, backend, modelTier
     case worktreeBinding, subGraph, pilotState, usage, metricHistory, createdBy
     case state, createdAt, activity, presence, firstInstruction, pausesBeforeWritesOnly
-    case summary, heartbeatIntervalSeconds
+    case summary, board, heartbeatIntervalSeconds
   }
 
   /// Hand-written for the same reason `LoopEdge`'s is: `ProjectPersistence.loadGraph`
@@ -366,6 +379,9 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     // account of a run, and a resolved loop's is the thing worth reading after the fact.
     // It is bounded by construction, so a graph file cannot grow on it.
     summary = try container.decodeIfPresent(LoopSummary.self, forKey: .summary)
+    // Survives a reload for the reason above, and one more: it cost a model call, and a
+    // picture that has to be paid for again on every relaunch is a picture nobody keeps.
+    board = try container.decodeIfPresent(SummaryBoard.self, forKey: .board)
     presence = try container.decodeIfPresent(PresenceReading.self, forKey: .presence)
     metricHistory =
       try container.decodeIfPresent([MetricSample].self, forKey: .metricHistory) ?? []

--- a/GraphcodeKit/Sources/Domain/SummaryBoard.swift
+++ b/GraphcodeKit/Sources/Domain/SummaryBoard.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+/// What shape a run turned out to have — the one judgement the composer is asked to make.
+///
+/// Deliberately two, not ten. A model given a menu of diagram types will find a reason to
+/// use every one of them, and a run rendered as a sequence diagram because the menu had a
+/// sequence diagram on it is a picture that tells you about the menu. Work either has an
+/// order to it or it has facts in columns; anything else is a sentence, which the summary
+/// rail above already draws.
+public enum BoardForm: String, Codable, Sendable, CaseIterable {
+  /// Steps, branches and hand-offs — a plan, a pipeline, a decision the session made.
+  case flow
+  /// Rows and columns — findings, files touched, options weighed, a comparison.
+  case table
+}
+
+/// Which way a flow runs. Mermaid's own two useful answers; `RL`/`BT` are parsed and
+/// normalised to these, because a board that reads bottom-up next to a terminal that reads
+/// top-down is a board nobody reads twice.
+public enum BoardDirection: String, Codable, Sendable {
+  case topDown
+  case leftRight
+}
+
+/// A box on a flow board. The shapes are Mermaid's, narrowed to the four that survive
+/// being drawn at 90 points wide.
+public enum BoardNodeShape: String, Codable, Sendable {
+  /// `[text]` — a step.
+  case box
+  /// `(text)` — a state, something the run is in rather than does.
+  case rounded
+  /// `{text}` — a branch. The only shape that earns its geometry: a diamond is how you
+  /// see there was a choice without reading the label.
+  case decision
+  /// `([text])` — where the flow starts or stops.
+  case terminal
+}
+
+public struct BoardNode: Codable, Equatable, Sendable, Identifiable {
+  /// Mermaid's own identifier, kept rather than reissued: the edges name it, and a board
+  /// re-parsed from its own `source` has to come out the same both times.
+  public let id: String
+  public let text: String
+  public let shape: BoardNodeShape
+
+  public init(id: String, text: String, shape: BoardNodeShape = .box) {
+    self.id = id
+    self.text = text
+    self.shape = shape
+  }
+}
+
+public enum BoardEdgeStyle: String, Codable, Sendable {
+  case solid
+  /// `-.->` — a path taken conditionally, or a hand-off that hasn't happened.
+  case dashed
+  /// `==>` — the spine of the run, when the composer marks one.
+  case thick
+}
+
+public struct BoardEdge: Codable, Equatable, Sendable, Identifiable {
+  public let from: String
+  public let to: String
+  /// `-->|yes|` — the condition, when there is one. Never invented: an unlabelled arrow
+  /// stays unlabelled rather than being given "then".
+  public let label: String?
+  public let style: BoardEdgeStyle
+
+  public var id: String { "\(from)→\(to)#\(label ?? "")" }
+
+  public init(from: String, to: String, label: String? = nil, style: BoardEdgeStyle = .solid) {
+    self.from = from
+    self.to = to
+    self.label = label
+    self.style = style
+  }
+}
+
+public struct BoardTable: Codable, Equatable, Sendable {
+  public let headers: [String]
+  public let rows: [[String]]
+
+  public init(headers: [String], rows: [[String]]) {
+    self.headers = headers
+    self.rows = rows
+  }
+
+  /// Rows padded and clipped to the header count, so the renderer can index a row by
+  /// column without checking. A model writing Markdown by hand drops a cell often enough
+  /// that the alternative is a crash on a table that looked fine.
+  public var normalisedRows: [[String]] {
+    rows.map { row in
+      row.count == headers.count
+        ? row
+        : Array((row + Array(repeating: "", count: headers.count)).prefix(headers.count))
+    }
+  }
+}
+
+/// A run, drawn — the visual counterpart to `LoopSummary`, produced once per finished pass
+/// and bounded the same way.
+///
+/// **The Mermaid is the source and the drawing is derived, not the other way round.** The
+/// composer's whole output is `source`; everything else on this type is what
+/// `MermaidBoardParser` made of it. That ordering is what makes the board portable — the
+/// text pastes into a pull request, a GitHub comment or anywhere else that speaks Mermaid,
+/// and graphcode renders it natively rather than being the only place it exists. It also
+/// means a board that fails to re-parse is still a board: the source is shown as code and
+/// nothing is lost, which is the honest outcome for a diagram type this build cannot draw.
+///
+/// Bounded by construction, like the summary it sits under: a board is capped at
+/// `maxNodes`/`maxEdges` or `maxRows` and re-composed rather than accumulated, so a
+/// six-hour loop and a six-minute one cost the same bytes in the graph file.
+public struct SummaryBoard: Codable, Equatable, Sendable {
+  /// Past this a flow stops being a picture and becomes a diagram of a diagram. Chosen
+  /// against the rail's expanded width rather than a round number: 24 boxes is roughly six
+  /// layers of four, which is what fits at a readable font before anything has to scroll.
+  public static let maxNodes = 24
+  public static let maxEdges = 40
+  public static let maxRows = 12
+  /// Five columns at the expanded rail's ~520 points of content is about 100 points each —
+  /// the point at which a heading stops fitting on one line.
+  public static let maxColumns = 5
+
+  public let form: BoardForm
+  /// The board's own heading, when the composer gave one. Not the loop's title: the loop
+  /// is named twice on screen already.
+  public let title: String?
+  public let direction: BoardDirection
+  public let nodes: [BoardNode]
+  public let edges: [BoardEdge]
+  public let table: BoardTable?
+  /// The composer's reply, verbatim and unrepaired. Copyable, and the fallback the view
+  /// shows when this build cannot draw what it describes.
+  public let source: String
+  /// Which pass this describes — `LoopSummary.currentPass` at the moment it was composed.
+  ///
+  /// The whole of the dedupe. A board whose pass equals the summary's is a board already
+  /// paid for, and `GraphStore` will not spend a second call on it however many times the
+  /// poll comes round.
+  public let pass: Int
+  public let composedAt: Date
+
+  public init(
+    form: BoardForm, title: String? = nil, direction: BoardDirection = .topDown,
+    nodes: [BoardNode] = [], edges: [BoardEdge] = [], table: BoardTable? = nil,
+    source: String, pass: Int, composedAt: Date = Date()
+  ) {
+    self.form = form
+    self.title = title
+    self.direction = direction
+    self.nodes = Array(nodes.prefix(Self.maxNodes))
+    let known = Set(self.nodes.map(\.id))
+    // Edges are filtered against the nodes that survived the cap, not merely counted: an
+    // arrow into a box that was trimmed away draws as a line to nowhere, and the layout
+    // would place a phantom layer to hold the box it points at.
+    self.edges = Array(
+      edges.filter { known.contains($0.from) && known.contains($0.to) }
+        .prefix(Self.maxEdges))
+    self.table = table.map {
+      BoardTable(
+        headers: Array($0.headers.prefix(Self.maxColumns)),
+        rows: Array($0.rows.prefix(Self.maxRows)).map { row in
+          Array(row.prefix(Self.maxColumns))
+        })
+    }
+    self.source = source
+    self.pass = pass
+    self.composedAt = composedAt
+  }
+
+  /// Whether there is anything worth giving the rail's space to. A single box with no
+  /// arrows is a sentence drawn as a rectangle — the summary above already said it better.
+  public var isDrawable: Bool {
+    switch form {
+    case .flow: return nodes.count >= 2 && !edges.isEmpty
+    case .table: return (table?.rows.isEmpty == false) && (table?.headers.isEmpty == false)
+    }
+  }
+
+  /// Hand-written for the reason `LoopSummary`'s is: a graph file that fails to decode is
+  /// a graph the app reports as having no loops in it. Every field is optional on the way
+  /// in, so a board written by a build before this one — or after the next one — still
+  /// loads, and an unreadable one degrades to its source text rather than to nothing.
+  private enum CodingKeys: String, CodingKey {
+    case form, title, direction, nodes, edges, table, source, pass, composedAt
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    form = try container.decodeIfPresent(BoardForm.self, forKey: .form) ?? .flow
+    title = try container.decodeIfPresent(String.self, forKey: .title)
+    direction = try container.decodeIfPresent(BoardDirection.self, forKey: .direction) ?? .topDown
+    nodes = try container.decodeIfPresent([BoardNode].self, forKey: .nodes) ?? []
+    edges = try container.decodeIfPresent([BoardEdge].self, forKey: .edges) ?? []
+    table = try container.decodeIfPresent(BoardTable.self, forKey: .table)
+    source = try container.decodeIfPresent(String.self, forKey: .source) ?? ""
+    pass = try container.decodeIfPresent(Int.self, forKey: .pass) ?? 0
+    composedAt = try container.decodeIfPresent(Date.self, forKey: .composedAt) ?? Date()
+  }
+}

--- a/GraphcodeKit/Sources/Domain/SummaryBoard.swift
+++ b/GraphcodeKit/Sources/Domain/SummaryBoard.swift
@@ -76,13 +76,57 @@ public struct BoardEdge: Codable, Equatable, Sendable, Identifiable {
   }
 }
 
+/// Which way a column's cells sit, taken from the separator row's colons — `|---:|` is
+/// right, `|:---:|` is centre, `|---|` says nothing.
+///
+/// Markdown has carried this since the syntax existed and the parser has always read it;
+/// until boards learned to draw a table properly it read it only to check the row was a
+/// separator, and threw the answer away. A number column that the author right-aligned and
+/// the renderer left-aligned is the author being overruled by an oversight.
+public enum BoardColumnAlignment: String, Codable, Sendable {
+  case unspecified
+  case leading
+  case center
+  case trailing
+}
+
 public struct BoardTable: Codable, Equatable, Sendable {
   public let headers: [String]
   public let rows: [[String]]
+  /// One per header. Short or missing lists are padded with `.unspecified` on read, so a
+  /// board written before this existed still draws.
+  public let alignments: [BoardColumnAlignment]
 
-  public init(headers: [String], rows: [[String]]) {
+  public init(
+    headers: [String], rows: [[String]], alignments: [BoardColumnAlignment] = []
+  ) {
     self.headers = headers
     self.rows = rows
+    self.alignments =
+      alignments.count == headers.count
+      ? alignments
+      : Array(
+        (alignments + Array(repeating: .unspecified, count: headers.count))
+          .prefix(headers.count))
+  }
+
+  /// A hand-written decoder for the reason every other one here is hand-written: a graph
+  /// file that fails to decode is a graph the app reports as having no loops in it.
+  private enum CodingKeys: String, CodingKey {
+    case headers, rows, alignments
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let headers = try container.decodeIfPresent([String].self, forKey: .headers) ?? []
+    let rows = try container.decodeIfPresent([[String]].self, forKey: .rows) ?? []
+    let alignments =
+      try container.decodeIfPresent([BoardColumnAlignment].self, forKey: .alignments) ?? []
+    self.init(headers: headers, rows: rows, alignments: alignments)
+  }
+
+  public func alignment(ofColumn index: Int) -> BoardColumnAlignment {
+    index < alignments.count ? alignments[index] : .unspecified
   }
 
   /// Rows padded and clipped to the header count, so the renderer can index a row by
@@ -162,7 +206,8 @@ public struct SummaryBoard: Codable, Equatable, Sendable {
         headers: Array($0.headers.prefix(Self.maxColumns)),
         rows: Array($0.rows.prefix(Self.maxRows)).map { row in
           Array(row.prefix(Self.maxColumns))
-        })
+        },
+        alignments: Array($0.alignments.prefix(Self.maxColumns)))
     }
     self.source = source
     self.pass = pass

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -89,7 +89,11 @@ public actor GraphStore {
   /// In memory rather than in the graph file, deliberately: it is a record of what was
   /// *spent*, not of what a loop is, and re-drawing one pass after a daemon restart is a
   /// far better failure than persisting a refusal for ever.
-  private var boardAttempts: [UUID: Int] = [:]
+  ///
+  /// Pruned to the graph's own nodes on every sweep. A deleted loop's entry would otherwise
+  /// outlive it, and `graphcoded` runs for weeks — which is precisely how the PTY leak this
+  /// path already had turned "one descriptor" into an exhausted host.
+  private(set) var boardAttempts: [UUID: Int] = [:]
   /// How many composites deep this store sits: 0 at the project root, 1 inside the
   /// first composite, and so on — see `runInSubGraph`, which increments it.
   ///
@@ -676,6 +680,10 @@ public actor GraphStore {
       return cleared
     }
     let path = graph.project.path
+    // Before anything else, so a graph that has lost half its loops does not keep paying
+    // for them in memory.
+    let living = Set(graph.nodes.map(\.id))
+    boardAttempts = boardAttempts.filter { living.contains($0.key) }
     let candidates =
       graph.nodes
       .compactMap { node -> (node: LoopNode, summary: LoopSummary, behind: Int)? in

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -71,6 +71,25 @@ public actor GraphStore {
   /// that don't care, and any client that never wires it) means off, which is the
   /// experiment's default.
   private let onHeartbeatEnabled: (@Sendable () -> Bool)?
+  /// Draws one finished pass (`SummaryBoardComposer`). `nil` when nothing composes boards,
+  /// which is every test that did not ask for one.
+  private let onComposeBoard: (@Sendable (LoopNode, LoopSummary, String?) async -> SummaryBoard?)?
+  /// Whether the human has the picture switched on, asked fresh at every tick — so
+  /// switching it off empties the boards on the next poll without restarting anything, the
+  /// same contract `onHeartbeatEnabled` has.
+  private let onBoardsEnabled: (@Sendable () -> Bool)?
+  /// The newest pass each node has already been *asked* about, drawn or not.
+  ///
+  /// Without this, `NONE` — the answer the composer is told to give for a thin pass, and
+  /// the answer most passes get — would leave the node's board stamped with an older pass
+  /// and make it a candidate again on the very next tick. One declined pass would become a
+  /// model call every fifteen seconds for as long as the loop stayed on it, which is the
+  /// one cost this whole path promises to bound.
+  ///
+  /// In memory rather than in the graph file, deliberately: it is a record of what was
+  /// *spent*, not of what a loop is, and re-drawing one pass after a daemon restart is a
+  /// far better failure than persisting a refusal for ever.
+  private var boardAttempts: [UUID: Int] = [:]
   /// How many composites deep this store sits: 0 at the project root, 1 inside the
   /// first composite, and so on — see `runInSubGraph`, which increments it.
   ///
@@ -162,6 +181,10 @@ public actor GraphStore {
     onRefinePlaybook: (@Sendable (UUID, String) -> Bool)? = nil,
     onRollbackPlaybook: (@Sendable (UUID) -> Bool)? = nil,
     onHeartbeatEnabled: (@Sendable () -> Bool)? = nil,
+    onComposeBoard: (
+      @Sendable (LoopNode, LoopSummary, String?) async -> SummaryBoard?
+    )? = nil,
+    onBoardsEnabled: (@Sendable () -> Bool)? = nil,
     subGraphDepth: Int = 0
   ) {
     self.graph = graph
@@ -183,6 +206,8 @@ public actor GraphStore {
     self.onRefinePlaybook = onRefinePlaybook
     self.onRollbackPlaybook = onRollbackPlaybook
     self.onHeartbeatEnabled = onHeartbeatEnabled
+    self.onComposeBoard = onComposeBoard
+    self.onBoardsEnabled = onBoardsEnabled
   }
 
   private func recordMemory(_ nodeID: UUID, _ entry: String) {
@@ -375,6 +400,9 @@ public actor GraphStore {
       await refreshPresence()
       await refreshActivity()
       await refreshSummary()
+      // After the summary, never beside it: a board is drawn *from* the merged summary, so
+      // a pass that ended this tick has to be counted before it can be drawn.
+      await refreshBoards()
     }
 
     // Guarded re-fires need an `until` predicate answered first, which means a
@@ -614,6 +642,76 @@ public actor GraphStore {
     return changed
   }
 
+  /// Draws the passes that have ended since the last tick — the only reading here that
+  /// costs money, and the only one that is allowed to skip work it could do.
+  ///
+  /// Three rules, and they are the whole of the bounding:
+  ///
+  /// 1. **Off means empty.** Asked fresh every tick, so switching the experiment off drops
+  ///    every board within a poll rather than leaving pictures on nodes for a feature
+  ///    nobody has switched on — the same clearing `refreshSummary` does for beats.
+  /// 2. **A pass is drawn once.** `SummaryBoard.pass` records which pass a board describes,
+  ///    and a node whose summary has not moved past it is not a candidate. This is what
+  ///    turns "once per pass" from an intention into a property.
+  /// 3. **At most `maxPerTick` a tick.** These are subprocesses with timeouts on them, run
+  ///    concurrently, and a graph where ten loops finish together must not put ten CLI
+  ///    processes on one poll — the poll every state dot in the app rides on. The rest are
+  ///    drawn next tick; the candidate list is sorted by how far behind each board is, so
+  ///    nothing waits indefinitely behind a loop that keeps finishing passes.
+  ///
+  /// A loop with no finished pass is never a candidate. A board is an account of work that
+  /// happened, and a session thirty seconds into its first pass has none to account for.
+  @discardableResult
+  private func refreshBoards() async -> Bool {
+    guard let onComposeBoard else { return false }
+    guard onBoardsEnabled?() != false else {
+      var cleared = false
+      for node in graph.nodes where node.board != nil {
+        graph.nodes[id: node.id]?.board = nil
+        cleared = true
+      }
+      // Forgotten along with the boards, so switching the experiment back on draws the
+      // current pass rather than waiting for the next one.
+      boardAttempts.removeAll()
+      return cleared
+    }
+    let path = graph.project.path
+    let candidates =
+      graph.nodes
+      .compactMap { node -> (node: LoopNode, summary: LoopSummary, behind: Int)? in
+        guard let summary = node.summary, !summary.passes.isEmpty else { return nil }
+        let settled = max(node.board?.pass ?? 0, boardAttempts[node.id] ?? 0)
+        let behind = summary.currentPass - settled
+        guard behind > 0 else { return nil }
+        return (node, summary, behind)
+      }
+      .sorted { ($0.behind, $0.node.id.uuidString) > ($1.behind, $1.node.id.uuidString) }
+      .prefix(SummaryBoardComposer.maxPerTick)
+    guard !candidates.isEmpty else { return false }
+    for candidate in candidates { boardAttempts[candidate.node.id] = candidate.summary.currentPass }
+
+    let drawn = await withTaskGroup(of: (UUID, SummaryBoard?).self) { group in
+      for candidate in candidates {
+        group.addTask {
+          (candidate.node.id, await onComposeBoard(candidate.node, candidate.summary, path))
+        }
+      }
+      var collected: [UUID: SummaryBoard] = [:]
+      for await (id, board) in group {
+        guard let board else { continue }
+        collected[id] = board
+      }
+      return collected
+    }
+    var changed = false
+    for (id, board) in drawn {
+      guard graph.nodes[id: id]?.board != board else { continue }
+      graph.nodes[id: id]?.board = board
+      changed = true
+    }
+    return changed
+  }
+
   /// Asks each session what it is doing, the third reading on the same channel and the
   /// same trip as the other two.
   ///
@@ -687,6 +785,9 @@ public actor GraphStore {
     var changed = await refreshPresence()
     if await refreshActivity() { changed = true }
     if await refreshSummary() { changed = true }
+    // After the summary and never beside it: a board is drawn *from* the merged summary,
+    // so a pass that ended on this tick has to be counted before it can be drawn.
+    if await refreshBoards() { changed = true }
     // The poll that just learned a target went idle is the natural moment to hand it
     // what was waiting on exactly that.
     await drainPendingFollowUps()

--- a/GraphcodeKit/Sources/ProjectRegistry.swift
+++ b/GraphcodeKit/Sources/ProjectRegistry.swift
@@ -40,6 +40,7 @@ public actor ProjectRegistry {
   private let readActivity: (@Sendable (LoopNode, String?) async -> String?)?
   private let readSummary: (@Sendable (LoopNode, String?) async -> SummaryReading?)?
   private let readPresence: (@Sendable (LoopNode, String?) async -> PresenceReading)?
+  private let composeBoard: (@Sendable (LoopNode, LoopSummary, String?) async -> SummaryBoard?)?
   /// Non-nil only while at least one client is attached — see `startPresencePolling`.
   private var presencePoller: Task<Void, Never>?
   /// Runs only while the sleep assertion is held — see `refreshAwakeAssertion`.
@@ -69,7 +70,9 @@ public actor ProjectRegistry {
     readSummary: (@Sendable (LoopNode, String?) async -> SummaryReading?)? =
       CLISessionBackend.readSummary,
     readPresence: (@Sendable (LoopNode, String?) async -> PresenceReading)? =
-      CLISessionBackend.readPresence
+      CLISessionBackend.readPresence,
+    composeBoard: (@Sendable (LoopNode, LoopSummary, String?) async -> SummaryBoard?)? =
+      CLISessionBackend.composeBoard
   ) {
     persistence = ProjectPersistence(baseDirectory: persistenceDirectory)
     self.ensureSession = ensureSession
@@ -82,6 +85,7 @@ public actor ProjectRegistry {
     self.readActivity = readActivity
     self.readSummary = readSummary
     self.readPresence = readPresence
+    self.composeBoard = composeBoard
   }
 
   // MARK: - Connections
@@ -438,7 +442,15 @@ public actor ProjectRegistry {
       onRollbackPlaybook: { nodeID in
         NodeMemory.rollbackPlaybook(projectPath: path, nodeID: nodeID)
       },
-      onHeartbeatEnabled: { GraphcodeSettingsStore.load().daemonHeartbeatEnabled })
+      onHeartbeatEnabled: { GraphcodeSettingsStore.load().daemonHeartbeatEnabled },
+      onComposeBoard: composeBoard,
+      onBoardsEnabled: {
+        let settings = GraphcodeSettingsStore.load()
+        // Both, and in this order: a board is drawn from the summary, so the picture is
+        // meaningless without the reading that feeds it. Switching the rail off takes the
+        // boards with it rather than leaving pictures of a run nothing is narrating.
+        return settings.summarisesLoops && settings.visualisesSummaries
+      })
     stores[path] = newStore
     // Only on first load of this project — a time-based node's session outlives the app
     // but not a reboot, so something has to restart it, and this is the moment the

--- a/GraphcodeKit/Sources/Sessions/CLISessionBackend.swift
+++ b/GraphcodeKit/Sources/Sessions/CLISessionBackend.swift
@@ -259,4 +259,16 @@ extension CLISessionBackend {
     node, path in
     await backend(for: node).presence(node, path)
   }
+
+  /// The board-composing hook `GraphStore` is wired with.
+  ///
+  /// Not on `CLISessionBackend` itself, unlike every reading beside it, and the reason is
+  /// what it reads: a board is composed from `LoopSummary` — a value the store already
+  /// holds — rather than from anything in the session's own transcript. The backend matters
+  /// only for *which CLI is invoked to write it*, which `SummaryBoardComposer` takes off the
+  /// node. An adapter method here would be four identical implementations.
+  public static let composeBoard:
+    @Sendable (LoopNode, LoopSummary, String?) async -> SummaryBoard? = { node, summary, path in
+      await SummaryBoardComposer.compose(node: node, summary: summary, projectPath: path)
+    }
 }

--- a/GraphcodeKit/Sources/Sessions/MermaidBoardParser.swift
+++ b/GraphcodeKit/Sources/Sessions/MermaidBoardParser.swift
@@ -312,8 +312,10 @@ public enum MermaidBoardParser {
     }
     guard !body.isEmpty else { return nil }
     let board = SummaryBoard(
-      form: .table, table: BoardTable(headers: headers, rows: body), source: block,
-      pass: pass, composedAt: now)
+      form: .table,
+      table: BoardTable(
+        headers: headers, rows: body, alignments: alignments(ofSeparator: rows[1])),
+      source: block, pass: pass, composedAt: now)
     return board.isDrawable ? board : nil
   }
 
@@ -323,6 +325,22 @@ public enum MermaidBoardParser {
     if text.hasSuffix("|") { text = String(text.dropLast()) }
     return text.components(separatedBy: "|").map {
       $0.trimmingCharacters(in: .whitespaces)
+    }
+  }
+
+  /// `|---|---:|:--:|` — what the author asked for, per column.
+  ///
+  /// A leading colon means left, a trailing one means right, both mean centre, neither
+  /// means the author did not say and the renderer should decide from the content.
+  static func alignments(ofSeparator row: String) -> [BoardColumnAlignment] {
+    cells(of: row).map { cell in
+      let rule = cell.trimmingCharacters(in: .whitespaces)
+      switch (rule.hasPrefix(":"), rule.hasSuffix(":")) {
+      case (true, true): return .center
+      case (false, true): return .trailing
+      case (true, false): return .leading
+      case (false, false): return .unspecified
+      }
     }
   }
 

--- a/GraphcodeKit/Sources/Sessions/MermaidBoardParser.swift
+++ b/GraphcodeKit/Sources/Sessions/MermaidBoardParser.swift
@@ -1,0 +1,336 @@
+import Foundation
+
+/// Turns the composer's reply into something `SummaryBoardView` can draw, or into nothing.
+///
+/// **A deliberately small subset of Mermaid, and it says so.** Mermaid has a dozen diagram
+/// types and a syntax that grows every release; this understands flowcharts and Markdown
+/// tables, which are the two forms `SummaryBoardComposer` asks for. Anything else parses to
+/// `nil`, the board keeps its source text, and the view shows that text as code — the
+/// honest outcome, and the reason `SummaryBoard.source` is the field the composer actually
+/// produces.
+///
+/// The reason for parsing at all rather than embedding a renderer: the canvas and the rail
+/// both redraw at pointer-event rate inside a `scaleEffect`, and the app has no WebKit
+/// dependency to give one. A parsed board is a few dozen structs that lay out in
+/// microseconds and draw as SwiftUI shapes.
+///
+/// What is understood, in full:
+///
+/// - `flowchart TD|TB|LR|RL` and `graph …` headers, with `BT`/`RL` normalised
+/// - node shapes `[]`, `()`, `{}`, `([])`, `(())`, `[[]]`, `[()]`, `{{}}`, `>]`
+/// - links `-->`, `---`, `-.->`, `-.-`, `==>`, `===`, chained (`A --> B --> C`)
+/// - edge labels in both spellings: `-->|yes|` and `-- yes -->`
+/// - `%% title: …`, and `%%` comments otherwise dropped
+/// - GitHub-flavoured Markdown tables
+///
+/// What is dropped without complaint, because a board that refuses to draw over a styling
+/// directive is worse than one that draws unstyled: `subgraph`/`end`, `classDef`, `class`,
+/// `style`, `linkStyle`, `click`.
+public enum MermaidBoardParser {
+  /// The composer's whole reply in, a board or nothing out.
+  ///
+  /// `pass` is stamped rather than parsed — it is the store's number, and nothing a model
+  /// writes is allowed to set it.
+  public static func board(fromReply reply: String, pass: Int, now: Date = Date())
+    -> SummaryBoard?
+  {
+    guard let block = lastBlock(in: reply) else { return nil }
+    if let flow = flow(from: block, pass: pass, now: now) { return flow }
+    return table(from: block, pass: pass, now: now)
+  }
+
+  // MARK: - Fences
+
+  /// The last fenced block in the reply, or the whole reply when there are no fences.
+  ///
+  /// **Last, not first.** A CLI in print mode prefixes banners, and a model asked for one
+  /// diagram sometimes shows its working first — in both cases the answer is at the end.
+  /// The same reasoning `SummaryModelWriter.accepted` takes the last line for.
+  static func lastBlock(in reply: String) -> String? {
+    let lines = reply.components(separatedBy: .newlines)
+    var blocks: [[String]] = []
+    var current: [String]?
+    for line in lines {
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+        if let open = current {
+          blocks.append(open)
+          current = nil
+        } else {
+          current = []
+        }
+        continue
+      }
+      current?.append(line)
+    }
+    // An unterminated fence is still an answer: a model that opened a block and ran out of
+    // budget has usually written the whole diagram and only lost the closing ticks.
+    if let open = current, !open.isEmpty { blocks.append(open) }
+    let block = blocks.last?.joined(separator: "\n") ?? reply
+    let trimmed = block.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  // MARK: - Flowcharts
+
+  static func flow(from block: String, pass: Int, now: Date) -> SummaryBoard? {
+    var lines = block.components(separatedBy: .newlines)
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+    var title: String?
+
+    for line in lines where line.hasPrefix("%%") {
+      let comment = line.dropFirst(2).trimmingCharacters(in: .whitespaces)
+      guard comment.lowercased().hasPrefix("title:") else { continue }
+      let text = comment.dropFirst("title:".count).trimmingCharacters(in: .whitespaces)
+      if !text.isEmpty { title = text }
+    }
+
+    guard let headerIndex = lines.firstIndex(where: { isHeader($0) }) else { return nil }
+    let direction = direction(ofHeader: lines[headerIndex])
+    lines = Array(lines[(headerIndex + 1)...])
+
+    var nodes: [String: BoardNode] = [:]
+    var order: [String] = []
+    var edges: [BoardEdge] = []
+
+    func remember(_ node: BoardNode) {
+      // First declaration wins. Mermaid lets a node be named again later with no shape
+      // (`B --> C` after `A --> B[Read it]`), and taking the later one would blank the
+      // label the diagram was written to carry.
+      if let existing = nodes[node.id] {
+        guard existing.text == existing.id, node.text != node.id else { return }
+      } else {
+        order.append(node.id)
+      }
+      nodes[node.id] = node
+    }
+
+    for line in lines where !isIgnorable(line) {
+      let (lineNodes, lineEdges) = parseFlowLine(line)
+      lineNodes.forEach(remember)
+      edges.append(contentsOf: lineEdges)
+    }
+
+    let ordered = order.compactMap { nodes[$0] }
+    let board = SummaryBoard(
+      form: .flow, title: title, direction: direction, nodes: ordered,
+      edges: edges, source: block, pass: pass, composedAt: now)
+    return board.isDrawable ? board : nil
+  }
+
+  static func isHeader(_ line: String) -> Bool {
+    let lower = line.lowercased()
+    return lower.hasPrefix("flowchart") || lower.hasPrefix("graph ") || lower == "graph"
+  }
+
+  static func direction(ofHeader line: String) -> BoardDirection {
+    let token = line.split(separator: " ").dropFirst().first.map { $0.uppercased() } ?? "TD"
+    // `RL` and `BT` are drawn as their mirrors rather than honoured. A board reads beside a
+    // terminal whose newest line is at the bottom; one that ran the other way would have
+    // the same run going two directions on one screen — the argument `LoopSummary.receding`
+    // already settled for the rows above it.
+    return token.hasPrefix("LR") || token.hasPrefix("RL") ? .leftRight : .topDown
+  }
+
+  static func isIgnorable(_ line: String) -> Bool {
+    if line.isEmpty || line.hasPrefix("%%") { return true }
+    let head = line.split(separator: " ").first.map { $0.lowercased() } ?? ""
+    return ["subgraph", "end", "classdef", "class", "style", "linkstyle", "click", "direction"]
+      .contains(head)
+  }
+
+  /// One line of a flowchart: the node tokens it declares and the edges between them.
+  ///
+  /// Chains are handled by construction — `A --> B --> C` is two edges — because splitting
+  /// on links and pairing the survivors is the same work either way.
+  static func parseFlowLine(_ line: String) -> ([BoardNode], [BoardEdge]) {
+    let text = line.hasSuffix(";") ? String(line.dropLast()) : line
+    let links = linkMatches(in: text)
+    guard !links.isEmpty else {
+      // A bare declaration — `A[Start]` on its own line. Legal Mermaid, and the only way a
+      // one-box diagram is written; kept so the node has its label when an edge names it.
+      guard let node = parseNodeToken(text) else { return ([], []) }
+      return ([node], [])
+    }
+
+    var nodes: [BoardNode] = []
+    var edges: [BoardEdge] = []
+    var cursor = text.startIndex
+    var previous: BoardNode?
+    /// The link whose right-hand node has not been read yet. An edge can only be emitted
+    /// once *both* its ends are known, and the link that joins them is the one before the
+    /// node being read — not the one the loop is currently on.
+    var pending: LinkMatch?
+
+    func close(with node: BoardNode) {
+      nodes.append(node)
+      if let from = previous, let pending {
+        edges.append(
+          BoardEdge(from: from.id, to: node.id, label: pending.label, style: pending.style))
+      }
+      previous = node
+    }
+
+    for link in links {
+      // A segment that holds no identifier breaks the chain rather than silently joining
+      // the boxes either side of it.
+      if let node = parseNodeToken(String(text[cursor..<link.range.lowerBound])) {
+        close(with: node)
+      } else {
+        previous = nil
+      }
+      pending = link
+      cursor = link.range.upperBound
+    }
+    if let tail = parseNodeToken(String(text[cursor...])) { close(with: tail) }
+    return (nodes, edges)
+  }
+
+  struct LinkMatch {
+    let range: Range<String.Index>
+    let label: String?
+    let style: BoardEdgeStyle
+  }
+
+  /// Every link on the line, in order.
+  ///
+  /// The alternation is ordered longest-first on purpose: `-- no -->` has to be tried
+  /// before `-->`, or the label is left stranded as part of a node token.
+  static func linkMatches(in line: String) -> [LinkMatch] {
+    guard let regex = linkRegex else { return [] }
+    let range = NSRange(line.startIndex..<line.endIndex, in: line)
+    return regex.matches(in: line, range: range).compactMap { match in
+      guard let full = Range(match.range, in: line) else { return nil }
+      let inline = [1, 2, 3].lazy
+        .compactMap { Range(match.range(at: $0), in: line) }
+        .first
+        .map { String(line[$0]).trimmingCharacters(in: .whitespaces) }
+      let piped = Range(match.range(at: 4), in: line)
+        .map { String(line[$0]).trimmingCharacters(in: .whitespaces) }
+      let label = [piped, inline].compactMap { $0 }.first { !$0.isEmpty }
+      let text = String(line[full])
+      let style: BoardEdgeStyle =
+        text.contains(".") ? .dashed : (text.contains("=") ? .thick : .solid)
+      return LinkMatch(range: full, label: unquoted(label), style: style)
+    }
+  }
+
+  private static let linkRegex: NSRegularExpression? = {
+    let pattern = [
+      "--\\s*([^>|\\n]*?)\\s*-{2,}>",  // -- label -->
+      "-\\.\\s*([^>|\\n]*?)\\s*\\.-+>",  // -. label .->
+      "==\\s*([^>|\\n]*?)\\s*={2,}>",  // == label ==>
+      "-\\.-+>?",  // -.-> / -.-
+      "={2,}>?",  // ==> / ===
+      "-{2,}>?",  // --> / ---
+    ]
+    let alternation = "(?:" + pattern.joined(separator: "|") + ")"
+    return try? NSRegularExpression(pattern: alternation + "(?:\\s*\\|([^|\\n]*)\\|)?")
+  }()
+
+  /// `B{Ready?}` → the node. `nil` when the segment holds no identifier, which is how a
+  /// malformed line loses one edge instead of the whole board.
+  static func parseNodeToken(_ segment: String) -> BoardNode? {
+    let text = segment.trimmingCharacters(in: .whitespaces)
+    guard !text.isEmpty else { return nil }
+    guard let open = text.firstIndex(where: { "[({>".contains($0) }) else {
+      let id = sanitisedIdentifier(text)
+      return id.isEmpty ? nil : BoardNode(id: id, text: id, shape: .box)
+    }
+    let id = sanitisedIdentifier(String(text[text.startIndex..<open]))
+    guard !id.isEmpty else { return nil }
+    let body = String(text[open...])
+    let (label, shape) = shapedLabel(body)
+    let cleaned = unquoted(label.trimmingCharacters(in: .whitespaces)) ?? id
+    return BoardNode(id: id, text: cleaned.isEmpty ? id : cleaned, shape: shape)
+  }
+
+  /// The delimiters, longest first — `([` has to be tested before `(`, or a stadium node
+  /// parses as a rounded one whose label starts with a bracket.
+  private static let delimiters: [(open: String, close: String, shape: BoardNodeShape)] = [
+    ("([", "])", .terminal),
+    ("((", "))", .terminal),
+    ("[[", "]]", .box),
+    ("[(", ")]", .box),
+    ("{{", "}}", .decision),
+    ("[", "]", .box),
+    ("(", ")", .rounded),
+    ("{", "}", .decision),
+    (">", "]", .box),
+  ]
+
+  static func shapedLabel(_ body: String) -> (String, BoardNodeShape) {
+    for delimiter in delimiters where body.hasPrefix(delimiter.open) {
+      let inner = body.dropFirst(delimiter.open.count)
+      guard let end = inner.range(of: delimiter.close, options: .backwards) else {
+        return (String(inner), delimiter.shape)
+      }
+      return (String(inner[inner.startIndex..<end.lowerBound]), delimiter.shape)
+    }
+    return (body, .box)
+  }
+
+  /// Mermaid ids are alphanumerics and underscores; anything else on the left of a shape is
+  /// a typo or a stray operator, and dropping it beats inventing a node called `-`.
+  static func sanitisedIdentifier(_ raw: String) -> String {
+    String(raw.unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) || $0 == "_" })
+  }
+
+  /// Mermaid quotes any label containing punctuation, and writes line breaks as `<br/>`.
+  /// Both are the diagram's syntax rather than the label's content.
+  static func unquoted(_ raw: String?) -> String? {
+    guard var text = raw else { return nil }
+    if text.hasPrefix("\""), text.hasSuffix("\""), text.count > 1 {
+      text = String(text.dropFirst().dropLast())
+    }
+    for token in ["<br/>", "<br>", "<br />"] {
+      text = text.replacingOccurrences(of: token, with: " ")
+    }
+    text = text.replacingOccurrences(of: "&nbsp;", with: " ")
+    return text.trimmingCharacters(in: .whitespaces)
+  }
+
+  // MARK: - Tables
+
+  /// A GitHub-flavoured Markdown table, which is what the composer emits for `.table`.
+  ///
+  /// The separator row is required rather than inferred. Without it a flowchart line
+  /// containing a pipe — legal, if rare — parses as a one-row table, and a board that
+  /// draws the wrong form is worse than one that draws nothing.
+  static func table(from block: String, pass: Int, now: Date) -> SummaryBoard? {
+    let rows =
+      block
+      .components(separatedBy: .newlines)
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { $0.hasPrefix("|") }
+    guard rows.count >= 3 else { return nil }
+    let headers = cells(of: rows[0])
+    guard !headers.isEmpty, isSeparator(rows[1]), cells(of: rows[1]).count == headers.count
+    else { return nil }
+    let body = rows.dropFirst(2).map { cells(of: $0) }.filter { row in
+      row.contains { !$0.isEmpty }
+    }
+    guard !body.isEmpty else { return nil }
+    let board = SummaryBoard(
+      form: .table, table: BoardTable(headers: headers, rows: body), source: block,
+      pass: pass, composedAt: now)
+    return board.isDrawable ? board : nil
+  }
+
+  static func cells(of row: String) -> [String] {
+    var text = row
+    if text.hasPrefix("|") { text = String(text.dropFirst()) }
+    if text.hasSuffix("|") { text = String(text.dropLast()) }
+    return text.components(separatedBy: "|").map {
+      $0.trimmingCharacters(in: .whitespaces)
+    }
+  }
+
+  static func isSeparator(_ row: String) -> Bool {
+    let parts = cells(of: row)
+    guard !parts.isEmpty else { return false }
+    return parts.allSatisfy { cell in
+      !cell.isEmpty && cell.allSatisfy { "-: ".contains($0) } && cell.contains("-")
+    }
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/SummaryBoardComposer.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryBoardComposer.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/// Draws the run — one model call per finished pass, over the summary the rail already
+/// holds, producing the Mermaid that `SummaryBoard` carries and the rail renders natively.
+///
+/// **The counterpart to `SummaryModelWriter`, and priced the same way.** That one buys a
+/// better sentence; this buys a picture, and neither is free, so both sit behind their own
+/// switch and neither is allowed to cost more than the work it describes. Five things keep
+/// this bounded:
+///
+/// 1. **A summary, not a transcript.** The prompt carries what `LoopSummary` already holds
+///    — twelve short beats and six pass lines at the absolute most, bounded by
+///    construction whatever the session's scrollback has grown to.
+/// 2. **Once per finished pass.** Not per beat and not per poll. `SummaryBoard.pass`
+///    records which pass a board describes, and `GraphStore.refreshBoards` will not spend a
+///    second call on a pass it has already drawn. A loop that narrates forty beats inside
+///    one pass costs exactly one call.
+/// 3. **At most `maxPerTick` loops a tick.** A graph where ten loops finish a pass together
+///    draws two of them now and the rest next tick, rather than holding the poll — the same
+///    poll every state dot in the app rides on.
+/// 4. **The fast tier**, and its own process, so nothing here lands on the loop's own
+///    token count.
+/// 5. **Nothing, quite often.** `NONE` is an answer the prompt asks for by name: most passes
+///    are one sentence of work, and a rectangle around a sentence is not a diagram.
+public enum SummaryBoardComposer {
+  /// How long a composition may take before the pass goes undrawn.
+  ///
+  /// Longer than `SummaryModelWriter.timeout` because a diagram is more to write than a
+  /// line, and still inside `ProjectRegistry.presencePollInterval`: this runs on the poll,
+  /// and a call that outlives the tick it started in would delay the next one.
+  static let timeout: Duration = .seconds(14)
+
+  /// How many loops may be drawn in one tick — see the header. Two rather than one so a
+  /// pair of loops finishing together are both current within a tick, and rather than four
+  /// because these run concurrently and each holds a CLI process.
+  public static let maxPerTick = 2
+
+  /// The instruction, which is mostly a list of refusals.
+  ///
+  /// **The judgement is asked for before either format is shown, and that ordering was
+  /// measured rather than reasoned.** The first version described the flowchart first, with
+  /// the only worked example, and offered `NONE` third: against real summaries at the fast
+  /// tier it produced a flowchart every single time — for a two-line version bump, and for
+  /// four findings that were plainly a table. A model shown one vivid format and asked to
+  /// choose will choose it, so the choice now happens above the formats, as three tests
+  /// applied in order, with `NONE` named as the default and the close call.
+  ///
+  /// The line that does the most work is the one denying that a pass list is a flow. Every
+  /// session has passes in order, so "the work had an order to it" is true of everything,
+  /// and it was reading as a licence to draw a chain of boxes that said nothing the pass
+  /// list above it had not already said. A flow now requires a branch, a retry or a fork —
+  /// which real runs do have, and which the diagram is worth drawing for.
+  ///
+  /// The Mermaid subset asked for is exactly the one `MermaidBoardParser` reads. Asking for
+  /// syntax the renderer cannot draw would show as an empty rail, which reads as the
+  /// feature being broken rather than as the model being ambitious.
+  public static func prompt(node: LoopNode, summary: LoopSummary) -> String {
+    var lines = [
+      "You are labelling one coding session for a small status panel. Decide which of",
+      "three answers fits, then write it. Reply with the answer and nothing else — no",
+      "preamble, no explanation, no closing remark.",
+      "",
+      "FIRST decide. Apply these tests in order and stop at the first that passes:",
+      "",
+      "- TABLE — do the facts repeat the same kind of item with the same kind of detail?",
+      "  Four findings that each name a file and a number; five files each with a change;",
+      "  options each with a trade-off; a before and an after. If yes, answer with a table.",
+      "",
+      "- FLOW — did the work itself branch, retry, fork or hand off? A decision that went",
+      "  one way rather than another, a check that sent it back to be redone, a plan with",
+      "  alternatives in it.",
+      "  A list of passes in order is NOT a flow. Every session has passes in order, and",
+      "  drawing them as a chain of boxes says nothing the pass list did not already say.",
+      "  A sequence of steps with no branch and no return is NOT a flow either.",
+      "  If the work genuinely branched, answer with a flowchart.",
+      "",
+      "- NONE — everything else, which is most sessions. \"Read some things, changed some",
+      "  things, ran the tests\" is a sentence, and the panel above this one already prints",
+      "  that sentence. Answer with the single word NONE.",
+      "",
+      "When the choice is close, answer NONE. A wrong diagram is worse than no diagram,",
+      "because it is read as a claim about how the work was structured.",
+      "",
+      "THEN write it, in one of these two forms.",
+      "",
+      "A table — plain GitHub Markdown, header row, --- separator row, no fence:",
+      "",
+      "| Test | Lines | Limit |",
+      "|---|---|---|",
+      "| ThingTests | 438 | 400 |",
+      "| OtherTests | 414 | 400 |",
+      "",
+      "A flowchart — a fenced mermaid block:",
+      "",
+      "```mermaid",
+      "%% title: four words at most",
+      "flowchart TD",
+      "  A([Start]) --> B[Do the thing]",
+      "  B --> C{Did it work?}",
+      "  C -->|yes| D([Done])",
+      "  C -->|no| B",
+      "```",
+      "",
+      "Rules:",
+      "- At most \(SummaryBoard.maxNodes) boxes, at most \(SummaryBoard.maxRows) rows, at",
+      "  most \(SummaryBoard.maxColumns) columns.",
+      "- Labels under six words. They render in a narrow panel and are cut, not wrapped.",
+      "- Mermaid syntax allowed: flowchart TD or LR; shapes [] () {} ([]); links -->",
+      "  --- -.-> ==>; edge labels as -->|yes|. Nothing else — no subgraphs, no classDef,",
+      "  no styling, no other diagram type. Anything else will fail to render.",
+      "- Quote any label containing a bracket, comma, colon or quote mark.",
+      "- Use only the facts below. Invent no step, no file and no outcome.",
+      "",
+      "The session:",
+      "- Loop: \(node.title)",
+    ]
+    if let goal = node.goal?.summary, !goal.isEmpty {
+      lines.append("- Trying to: \(goal)")
+    }
+    if summary.currentPass > 0 {
+      lines.append("- On pass \(summary.currentPass)")
+    }
+    if !summary.passes.isEmpty {
+      lines.append("")
+      lines.append("Passes it has finished:")
+      for pass in summary.passes {
+        let delta = pass.delta.map { " (\($0))" } ?? ""
+        lines.append("- pass \(pass.pass): \(pass.text)\(delta)")
+      }
+    }
+    if !summary.beats.isEmpty {
+      lines.append("")
+      lines.append("What it has done this pass, oldest first:")
+      for beat in summary.beats {
+        let evidence = beat.evidence.map { " [\($0)]" } ?? ""
+        lines.append("- \(beat.kind.rawValue): \(beat.text)\(evidence)")
+      }
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  /// Whether the reply is the composer declining. Checked before parsing rather than left
+  /// to it: a bare `NONE` parses to nothing anyway, but a model that answers
+  /// "NONE — this pass was a single edit" would otherwise be read as a malformed diagram
+  /// and logged as one.
+  static func isDeclined(_ reply: String) -> Bool {
+    let head =
+      reply
+      .components(separatedBy: .newlines)
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .first { !$0.isEmpty } ?? ""
+    return head.uppercased().hasPrefix("NONE")
+  }
+
+  /// The board for this pass, or nothing — which is the common answer and not a failure.
+  ///
+  /// Every path that isn't a drawable diagram returns `nil`, and `nil` leaves whatever the
+  /// node already carries untouched: a pass that could not be drawn must not blank the
+  /// board drawn for the pass before it.
+  public static func compose(
+    node: LoopNode, summary: LoopSummary, projectPath: String?, now: Date = Date()
+  ) async -> SummaryBoard? {
+    let invocation = SummaryModelWriter.invocation(
+      forBackend: node.backend, prompt: prompt(node: node, summary: summary))
+    // Through the launcher's login shell, for the reason `SummaryModelWriter.rewrite`
+    // records: `Process` never searches `PATH`, so a bare `claude` throws at launch and
+    // leaks the PTY it had already opened.
+    let launch = ZmxSessionLauncher.loginShellInvocation(
+      of: invocation[0], arguments: Array(invocation.dropFirst()))
+    guard
+      let session = try? PTYProcessSession(
+        executable: launch[0], arguments: Array(launch.dropFirst()),
+        workingDirectory: ZmxSessionLauncher.workingDirectory(
+          forNode: node, projectPath: projectPath))
+    else { return nil }
+    let outcome = await withTaskGroup(of: (Bool, String)?.self) { group in
+      group.addTask { await session.waitCollectingOutput() }
+      group.addTask {
+        try? await Task.sleep(for: timeout)
+        return nil
+      }
+      let first = await group.next() ?? nil
+      group.cancelAll()
+      return first
+    }
+    // Cancelling the task that was *waiting* does nothing to the process it was waiting on.
+    // A no-op once it has exited.
+    session.terminate()
+    guard let outcome, outcome.0, !isDeclined(outcome.1) else { return nil }
+    return MermaidBoardParser.board(
+      fromReply: outcome.1, pass: summary.currentPass, now: now)
+  }
+}

--- a/graphcode/Sources/Features/LoopWorkspace/BoardExcalidrawExport.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/BoardExcalidrawExport.swift
@@ -1,0 +1,326 @@
+import AppKit
+import Foundation
+import GraphcodeKit
+
+/// A board as an `.excalidraw` file — the same boxes and arrows, somewhere they can be
+/// moved.
+///
+/// **This direction and not the other, and the reason is in the format.** An Excalidraw
+/// element carries `x`, `y`, `width` and `height`: the file has no layout engine, so
+/// positions are baked into it. Asking a model to *write* Excalidraw is therefore asking a
+/// model to do geometry, which is work `BoardLayout` already does correctly and models do
+/// badly. Going the other way costs almost nothing — every coordinate the file needs has
+/// already been computed to draw the board on screen — and it buys the one thing a native
+/// renderer cannot: somewhere to drag a box that ended up in the wrong place.
+///
+/// Mermaid remains the source of truth (`SummaryBoard.source`). This is an export, not a
+/// second representation to keep in step: nothing reads a `.excalidraw` file back in.
+enum BoardExcalidrawExport {
+  static let schemaVersion = 2
+  static let source = "https://graphcode.app"
+
+  /// Excalidraw's own ink on its own white canvas.
+  ///
+  /// Deliberately **not** the rail's palette. A board on screen is near-white strokes on
+  /// #16161a; the same colours in a file that opens on white paper are invisible, and an
+  /// export nobody can see is worse than no export.
+  enum Ink {
+    static let stroke = "#1e1e1e"
+    static let transparent = "transparent"
+    static let decisionStroke = "#1971c2"
+    static let decisionFill = "#a5d8ff"
+    static let terminalStroke = "#1971c2"
+    static let terminalFill = "#d0ebff"
+    static let arrow = "#1e1e1e"
+  }
+
+  /// `roundness: {type: 3}` is Excalidraw's adaptive corner radius, which is what its own
+  /// "round" edge setting writes.
+  static let adaptiveRoundness = 3
+
+  /// The sizes the file is written at — Excalidraw's own defaults, not the rail's.
+  static let boxFontSize: CGFloat = 16
+  static let edgeFontSize: CGFloat = 14
+
+  /// How much bigger the exported drawing is than the one on screen.
+  ///
+  /// **The whole geometry is scaled, rather than the font shrunk to fit.** `BoardLayout`
+  /// sizes each box around its label measured at `BoardLayout.labelFont` — 11.5pt system —
+  /// and the file is written in Excalidraw's own 16pt hand-drawn face, which is wider again
+  /// per point. Exported one-to-one, the longer labels overflow their boxes: verified by
+  /// importing a file and reading `Re-sign helper` off a box that should have said
+  /// `Re-sign helpers`.
+  ///
+  /// Scaling every coordinate by the same factor keeps the drawing internally consistent —
+  /// arrows still meet box edges, layers stay evenly spaced — where shrinking the font to
+  /// fit would have produced a diagram nobody can read and boxes bigger than their contents.
+  /// 1.55 is 16/11.5 with a tenth over for the hand-drawn face being wider than the metric
+  /// one it was measured in.
+  static let exportScale: CGFloat = 1.55
+
+  static func document(
+    for board: SummaryBoard, layout: BoardLayout, now: Date = Date()
+  ) -> [String: Any] {
+    var elements: [[String: Any]] = []
+    let stamp = Int(now.timeIntervalSince1970 * 1000)
+
+    for placed in layout.nodes {
+      let containerID = identifier("box", placed.id)
+      let textID = identifier("text", placed.id)
+      elements.append(
+        shape(placed, id: containerID, textID: textID, stamp: stamp))
+      elements.append(
+        label(placed, id: textID, containerID: containerID, stamp: stamp))
+    }
+    for edge in layout.edges {
+      let arrowID = identifier("edge", edge.id)
+      guard let text = edge.edge.label, !text.isEmpty else {
+        elements.append(arrow(edge, id: arrowID, textID: nil, stamp: stamp))
+        continue
+      }
+      let textID = identifier("edge-text", edge.id)
+      elements.append(arrow(edge, id: arrowID, textID: textID, stamp: stamp))
+      elements.append(
+        edgeLabel(text, id: textID, containerID: arrowID, at: edge.labelPoint, stamp: stamp))
+    }
+
+    return [
+      "type": "excalidraw",
+      "version": schemaVersion,
+      "source": source,
+      "elements": elements,
+      // Only the two keys that change how the file *opens*. Everything else in `appState`
+      // is a preference belonging to whoever opens it, and writing our own would overrule
+      // theirs for the sake of nothing.
+      "appState": ["gridSize": NSNull(), "viewBackgroundColor": "#ffffff"],
+      "files": [String: Any](),
+    ]
+  }
+
+  static func data(
+    for board: SummaryBoard, layout: BoardLayout, now: Date = Date()
+  ) throws -> Data {
+    try JSONSerialization.data(
+      withJSONObject: document(for: board, layout: layout, now: now),
+      options: [.prettyPrinted, .sortedKeys])
+  }
+
+  // MARK: - Elements
+
+  private static func shape(
+    _ placed: BoardLayout.PlacedNode, id: String, textID: String, stamp: Int
+  ) -> [String: Any] {
+    var element = base(
+      id: id, type: excalidrawType(placed.node.shape), frame: scaled(placed.frame),
+      stamp: stamp)
+    element["strokeColor"] = strokeColour(placed.node.shape)
+    element["backgroundColor"] = fillColour(placed.node.shape)
+    element["fillStyle"] = "solid"
+    // A rectangle is the one shape where Excalidraw distinguishes sharp from round, so it
+    // is the one shape that carries the board's own distinction between a step and a state.
+    element["roundness"] =
+      placed.node.shape == .rounded ? ["type": adaptiveRoundness] : NSNull()
+    element["boundElements"] = [["id": textID, "type": "text"]]
+    return element
+  }
+
+  /// A text element bound to its box, rather than a label drawn at the box's centre.
+  ///
+  /// Binding is what makes the export worth having: a bound label moves with its box, wraps
+  /// inside it and stays centred when it is resized. An unbound one is a separate object
+  /// that gets left behind the first time anybody drags anything.
+  private static func label(
+    _ placed: BoardLayout.PlacedNode, id: String, containerID: String, stamp: Int
+  ) -> [String: Any] {
+    var element = base(
+      id: id, type: "text", frame: scaled(placed.frame).insetBy(dx: 6, dy: 6), stamp: stamp)
+    element["strokeColor"] = Ink.stroke
+    element["backgroundColor"] = Ink.transparent
+    element["fillStyle"] = "solid"
+    element["roundness"] = NSNull()
+    element["text"] = placed.node.text
+    element["originalText"] = placed.node.text
+    element["fontSize"] = boxFontSize
+    // 1 is Excalidraw's own hand-drawn face, which is what a file opened there is expected
+    // to look like — the board on screen uses the system font because the rail does.
+    element["fontFamily"] = 1
+    element["textAlign"] = "center"
+    element["verticalAlign"] = "middle"
+    element["containerId"] = containerID
+    element["lineHeight"] = 1.25
+    element["autoResize"] = true
+    return element
+  }
+
+  /// `points` are **local to the arrow**, not to the canvas: the first is always the origin
+  /// and the rest are offsets from it. Absolute coordinates here draw every arrow at twice
+  /// its intended distance from the origin, which is the one mistake this format invites.
+  private static func arrow(
+    _ edge: BoardLayout.PlacedEdge, id: String, textID: String?, stamp: Int
+  ) -> [String: Any] {
+    let path = ([edge.start] + edge.waypoints + [edge.end]).map(scaled)
+    let origin = scaled(edge.start)
+    let points = path.map { [$0.x - origin.x, $0.y - origin.y] }
+    let width = (points.map { $0[0] }.max() ?? 0) - (points.map { $0[0] }.min() ?? 0)
+    let height = (points.map { $0[1] }.max() ?? 0) - (points.map { $0[1] }.min() ?? 0)
+
+    var element = base(
+      id: id,
+      type: "arrow",
+      frame: CGRect(x: origin.x, y: origin.y, width: width, height: height),
+      stamp: stamp)
+    element["strokeColor"] = Ink.arrow
+    element["backgroundColor"] = Ink.transparent
+    element["fillStyle"] = "solid"
+    element["strokeStyle"] = edge.edge.style == .dashed ? "dashed" : "solid"
+    element["strokeWidth"] = edge.edge.style == .thick ? 2 : 1
+    element["roundness"] = ["type": 2]
+    element["points"] = points
+    element["lastCommittedPoint"] = NSNull()
+    element["startBinding"] = NSNull()
+    element["endBinding"] = NSNull()
+    element["startArrowhead"] = NSNull()
+    element["endArrowhead"] = "arrow"
+    element["elbowed"] = false
+    element["boundElements"] = textID.map { [["id": $0, "type": "text"]] } ?? NSNull()
+    return element
+  }
+
+  /// An arrow's own label, and it is a **bound text element** rather than a field on the
+  /// arrow.
+  ///
+  /// `ExcalidrawLinearElement` has no `label` property — an arrow label in Excalidraw is a
+  /// text element whose `containerId` names the arrow, exactly as a box label is. Writing a
+  /// `label` key instead produces a file that opens without complaint and silently has no
+  /// edge labels on it, which for a flowchart of decisions loses the half that says which
+  /// branch is which.
+  private static func edgeLabel(
+    _ text: String, id: String, containerID: String, at point: CGPoint, stamp: Int
+  ) -> [String: Any] {
+    // **Measured, not left at zero.** A bound text element with no width or height is
+    // discarded outright by Excalidraw's `restore` — verified by importing a file written
+    // that way, which came back with every box label intact and every *arrow* label gone.
+    // A flowchart of decisions that loses its yes and no is a flowchart of nothing.
+    let size = textSize(text, fontSize: edgeFontSize)
+    let centre = scaled(point)
+    var element = base(
+      id: id, type: "text",
+      frame: CGRect(
+        x: centre.x - size.width / 2, y: centre.y - size.height / 2,
+        width: size.width, height: size.height), stamp: stamp)
+    element["strokeColor"] = Ink.stroke
+    element["backgroundColor"] = Ink.transparent
+    element["fillStyle"] = "solid"
+    element["roundness"] = NSNull()
+    element["text"] = text
+    element["originalText"] = text
+    element["fontSize"] = edgeFontSize
+    element["fontFamily"] = 1
+    element["textAlign"] = "center"
+    element["verticalAlign"] = "middle"
+    element["containerId"] = containerID
+    element["lineHeight"] = 1.25
+    element["autoResize"] = true
+    return element
+  }
+
+  /// The fields every element carries, whatever it is.
+  private static func base(
+    id: String, type: String, frame: CGRect, stamp: Int
+  ) -> [String: Any] {
+    [
+      "id": id,
+      "type": type,
+      "x": frame.minX,
+      "y": frame.minY,
+      "width": frame.width,
+      "height": frame.height,
+      "angle": 0,
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [String](),
+      "frameId": NSNull(),
+      // Derived from the element's own id rather than drawn at random, so exporting one
+      // board twice produces the same file. Excalidraw uses the seed only to pick which
+      // way its hand-drawn strokes wobble; a random one would make every export a diff.
+      "seed": seed(id),
+      "version": 1,
+      "versionNonce": seed("nonce-" + id),
+      "index": NSNull(),
+      "isDeleted": false,
+      "boundElements": NSNull(),
+      "updated": stamp,
+      "link": NSNull(),
+      "locked": false,
+    ]
+  }
+
+  // MARK: - Naming
+
+  static func excalidrawType(_ shape: BoardNodeShape) -> String {
+    switch shape {
+    case .box, .rounded: return "rectangle"
+    case .decision: return "diamond"
+    // Excalidraw has no stadium, and an ellipse is the shape its own users draw a start or
+    // an end as.
+    case .terminal: return "ellipse"
+    }
+  }
+
+  static func strokeColour(_ shape: BoardNodeShape) -> String {
+    switch shape {
+    case .decision: return Ink.decisionStroke
+    case .terminal: return Ink.terminalStroke
+    default: return Ink.stroke
+    }
+  }
+
+  static func fillColour(_ shape: BoardNodeShape) -> String {
+    switch shape {
+    case .decision: return Ink.decisionFill
+    case .terminal: return Ink.terminalFill
+    default: return Ink.transparent
+    }
+  }
+
+  static func scaled(_ frame: CGRect) -> CGRect {
+    CGRect(
+      x: frame.minX * exportScale, y: frame.minY * exportScale,
+      width: frame.width * exportScale, height: frame.height * exportScale)
+  }
+
+  static func scaled(_ point: CGPoint) -> CGPoint {
+    CGPoint(x: point.x * exportScale, y: point.y * exportScale)
+  }
+
+  /// What a label occupies at the size the file is written at.
+  ///
+  /// Excalidraw re-measures in its own font when the file is opened, so this does not have
+  /// to be exact — it has to be *non-zero*, and close enough that the element's box is not
+  /// visibly wrong before the first re-layout.
+  static func textSize(_ text: String, fontSize: CGFloat) -> CGSize {
+    let bounds = (text as NSString).size(
+      withAttributes: [.font: NSFont.systemFont(ofSize: fontSize)])
+    return CGSize(width: ceil(bounds.width) + 8, height: ceil(bounds.height) + 4)
+  }
+
+  /// Excalidraw ids only have to be unique within the file, so the board's own names do the
+  /// job — and make the file readable, which a nanoid does not.
+  static func identifier(_ kind: String, _ name: String) -> String {
+    let safe = name.unicodeScalars
+      .map { CharacterSet.alphanumerics.contains($0) ? Character($0) : "-" }
+    return "gc-\(kind)-\(String(safe))"
+  }
+
+  /// FNV-1a, for a stable 31-bit seed from a name. Any hash would do; this one is four
+  /// lines and does not vary between processes the way `hashValue` does.
+  static func seed(_ text: String) -> Int {
+    var hash: UInt32 = 2_166_136_261
+    for byte in text.utf8 {
+      hash = (hash ^ UInt32(byte)) &* 16_777_619
+    }
+    return Int(hash & 0x7FFF_FFFF)
+  }
+}

--- a/graphcode/Sources/Features/LoopWorkspace/BoardLayout.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/BoardLayout.swift
@@ -1,0 +1,221 @@
+import AppKit
+import GraphcodeKit
+import SwiftUI
+
+/// Where every box and every arrow of a flow board goes — a layered graph layout, sized
+/// against the text it is actually going to draw.
+///
+/// A value type with no view in it, for the reason `LoopSummaryPresentation` is one: the
+/// layout is the part with the arithmetic, and arithmetic that can only be checked by
+/// looking at a window is arithmetic nobody checks.
+///
+/// The method is the standard layered one, in three passes and no more, because a board is
+/// capped at `SummaryBoard.maxNodes`:
+///
+/// 1. **Layer** — longest path from the roots, with cycles broken by depth-first ordering.
+///    A flow that loops back on itself (`C -->|no| B`, the commonest shape a real run has)
+///    would otherwise have no topological order at all.
+/// 2. **Order** — declaration order, then two barycentre sweeps. Two rather than the usual
+///    dozen: past that the crossings stop falling and the boxes only shuffle, and a diagram
+///    that rearranges itself between two polls of the same run is worse than one with a
+///    crossing in it.
+/// 3. **Place** — each box centred over its parents, then a left-to-right sweep opening any
+///    overlap the centring caused. Alignment is what makes a chain read as a chain; evenly
+///    spacing every layer instead produces a correct diagram that looks like a grid.
+struct BoardLayout: Equatable {
+  struct PlacedNode: Equatable, Identifiable {
+    let node: BoardNode
+    let frame: CGRect
+    var id: String { node.id }
+  }
+
+  struct PlacedEdge: Equatable, Identifiable {
+    let edge: BoardEdge
+    let start: CGPoint
+    let end: CGPoint
+    /// Where the arrow bends. Empty for the common case — one layer straight down.
+    let waypoints: [CGPoint]
+    let labelPoint: CGPoint
+    /// An arrow going back up the flow: a retry, a rejected check, a loop. Routed around
+    /// the outside rather than back through the boxes it would otherwise cross.
+    let isFeedback: Bool
+    /// How far this arrow is bowed off the straight line between its ends.
+    ///
+    /// Zero for all but one case: two arrows joining the *same pair* of boxes, which is
+    /// what `C -->|yes| D` beside `C -->|no| D` produces. Drawn straight, they are one line
+    /// with two labels stacked on the same point — the second is simply invisible.
+    let spread: CGFloat
+    /// Which way the arrow leaves and arrives — down the board or across it.
+    ///
+    /// Carried rather than inferred from the two ends, because it is a fact about how the
+    /// curve is *drawn* and not about where it goes. The control points are offset along
+    /// this axis, so an arrow whose ends are further apart sideways than downwards still
+    /// enters its box from above; a head that took its direction from the chord pointed
+    /// sideways into the top of the box, which is what it did until this was stored.
+    let axis: BoardDirection
+    var id: String { edge.id }
+
+    func offset(by delta: CGPoint) -> PlacedEdge {
+      func moved(_ point: CGPoint) -> CGPoint {
+        CGPoint(x: point.x + delta.x, y: point.y + delta.y)
+      }
+      return PlacedEdge(
+        edge: edge, start: moved(start), end: moved(end),
+        waypoints: waypoints.map(moved), labelPoint: moved(labelPoint),
+        isFeedback: isFeedback, spread: spread, axis: axis)
+    }
+  }
+
+  let nodes: [PlacedNode]
+  let edges: [PlacedEdge]
+  let size: CGSize
+
+  static let empty = BoardLayout(nodes: [], edges: [], size: .zero)
+
+  // MARK: - Metrics
+
+  /// Where a label stops growing sideways and starts wrapping. Six words at 11.5pt is
+  /// around here, which is the budget the composer's prompt hands the model.
+  static let maxLabelWidth: CGFloat = 132
+  static let horizontalPadding: CGFloat = 11
+  static let verticalPadding: CGFloat = 7
+  static let minimumNodeWidth: CGFloat = 58
+  static let minimumNodeHeight: CGFloat = 28
+  /// Between layers. Enough for an edge label to sit in without touching either box.
+  static let layerGap: CGFloat = 34
+  static let siblingGap: CGFloat = 16
+  /// How far outside the widest box a feedback arrow climbs.
+  static let feedbackInset: CGFloat = 18
+  static let labelFont = NSFont.systemFont(ofSize: 11.5)
+  /// What `SummaryBoardView` draws an edge label in. Kept here because the *size* is
+  /// needed here — an arrow label sitting on the outermost lane extends past the last box,
+  /// and a drawing measured without it is a drawing with its own label clipped off.
+  static let edgeLabelFont = NSFont.systemFont(ofSize: 9, weight: .medium)
+  /// The chip's padding around that text, as the view draws it.
+  static let edgeLabelPadding = CGSize(width: 4, height: 2)
+
+  static func edgeLabelSize(_ text: String) -> CGSize {
+    let bounds = (text as NSString).size(withAttributes: [.font: edgeLabelFont])
+    return CGSize(
+      width: ceil(bounds.width) + edgeLabelPadding.width * 2,
+      height: ceil(bounds.height) + edgeLabelPadding.height * 2)
+  }
+
+  /// A diamond wastes its corners: text laid out inside one needs about half as much again
+  /// in each direction before it stops touching the edges.
+  static let decisionScale: CGFloat = 1.45
+
+  static func labelSize(_ text: String) -> CGSize {
+    let bounds = (text as NSString).boundingRect(
+      with: CGSize(width: maxLabelWidth, height: .greatestFiniteMagnitude),
+      options: [.usesLineFragmentOrigin, .usesFontLeading],
+      attributes: [.font: labelFont])
+    return CGSize(width: ceil(bounds.width), height: ceil(bounds.height))
+  }
+
+  static func nodeSize(_ node: BoardNode) -> CGSize {
+    let label = labelSize(node.text)
+    var width = label.width + horizontalPadding * 2
+    var height = label.height + verticalPadding * 2
+    if node.shape == .decision {
+      width *= decisionScale
+      height *= decisionScale
+    }
+    return CGSize(width: max(width, minimumNodeWidth), height: max(height, minimumNodeHeight))
+  }
+
+  // MARK: - Building
+
+  init(nodes: [PlacedNode], edges: [PlacedEdge], size: CGSize) {
+    self.nodes = nodes
+    self.edges = edges
+    self.size = size
+  }
+
+  init(board: SummaryBoard) {
+    guard board.form == .flow, board.nodes.count >= 2 else {
+      self = .empty
+      return
+    }
+    let identifiers = board.nodes.map(\.id)
+    let index = Dictionary(uniqueKeysWithValues: identifiers.enumerated().map { ($1, $0) })
+    let feedback = Self.feedbackEdges(board: board, order: identifiers)
+    let forward = board.edges.filter { !feedback.contains($0.id) }
+    let layers = Self.layers(of: identifiers, edges: forward)
+    let rows = Self.ordered(identifiers: identifiers, layers: layers, edges: forward, index: index)
+
+    let sizes = Dictionary(
+      uniqueKeysWithValues: board.nodes.map { ($0.id, Self.nodeSize($0)) })
+    let frames = Self.place(
+      rows: rows, sizes: sizes, edges: forward, direction: board.direction)
+
+    let placed = board.nodes.compactMap { node in
+      frames[node.id].map { PlacedNode(node: node, frame: $0) }
+    }
+    let bounds = placed.reduce(CGRect.null) { $0.union($1.frame) }
+    guard !bounds.isNull else {
+      self = .empty
+      return
+    }
+    // Shifted so the drawing starts at the origin. A layout that began at negative
+    // coordinates would be clipped by the frame it is drawn in rather than by anything it
+    // chose.
+    let offset = CGPoint(x: -bounds.minX, y: -bounds.minY)
+    let shifted = placed.map {
+      PlacedNode(node: $0.node, frame: $0.frame.offsetBy(dx: offset.x, dy: offset.y))
+    }
+    let routed = Self.routes(
+      of: board, frames: Dictionary(uniqueKeysWithValues: shifted.map { ($0.id, $0.frame) }),
+      feedback: feedback,
+      // Outside the widest box, on the side a feedback arrow climbs.
+      lane: bounds.width + Self.feedbackInset)
+    let drawn = Self.drawnBounds(nodes: shifted, edges: routed)
+    let correction = CGPoint(x: -min(drawn.minX, 0), y: -min(drawn.minY, 0))
+    self.init(
+      nodes: shifted.map {
+        PlacedNode(node: $0.node, frame: $0.frame.offsetBy(dx: correction.x, dy: correction.y))
+      },
+      edges: routed.map { $0.offset(by: correction) },
+      size: CGSize(width: drawn.maxX + correction.x, height: drawn.maxY + correction.y))
+  }
+
+  /// How far each arrow is bowed aside, so two arrows between the same pair of boxes do not
+  /// land on top of one another. Zero for every edge that has the pair to itself, which is
+  /// nearly all of them.
+  static func spreads(of edges: [BoardEdge]) -> [String: CGFloat] {
+    var groups: [String: [BoardEdge]] = [:]
+    for edge in edges { groups["\(edge.from)→\(edge.to)", default: []].append(edge) }
+    var result: [String: CGFloat] = [:]
+    for (_, group) in groups where group.count > 1 {
+      for (offset, edge) in group.enumerated() {
+        result[edge.id] = (CGFloat(offset) - CGFloat(group.count - 1) / 2) * parallelSpread
+      }
+    }
+    return result
+  }
+
+  /// Far enough apart that two labels on the same pair of boxes both fit between them.
+  static let parallelSpread: CGFloat = 34
+
+  /// Everything the drawing occupies — **the arrows included, not only the boxes**.
+  ///
+  /// A feedback arrow leaves the bottom of the last row and climbs a lane outside the widest
+  /// one, and an edge label on that lane reaches further still. A size taken from the node
+  /// frames alone reports a drawing smaller than the one being drawn, and the parts outside
+  /// it are silently clipped by the panel.
+  static func drawnBounds(nodes: [PlacedNode], edges: [PlacedEdge]) -> CGRect {
+    var drawn = nodes.reduce(CGRect.null) { $0.union($1.frame) }
+    for edge in edges {
+      for point in [edge.start, edge.end] + edge.waypoints {
+        drawn = drawn.union(CGRect(origin: point, size: .zero).insetBy(dx: -1, dy: -1))
+      }
+      guard let label = edge.edge.label, !label.isEmpty else { continue }
+      let size = edgeLabelSize(label)
+      drawn = drawn.union(
+        CGRect(
+          x: edge.labelPoint.x - size.width / 2, y: edge.labelPoint.y - size.height / 2,
+          width: size.width, height: size.height))
+    }
+    return drawn
+  }
+}

--- a/graphcode/Sources/Features/LoopWorkspace/BoardPlacement.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/BoardPlacement.swift
@@ -1,0 +1,208 @@
+import AppKit
+import GraphcodeKit
+import SwiftUI
+
+/// Which layer each box belongs to, what order they sit in across it, and where that puts
+/// them — the first three passes of `BoardLayout`, kept apart from the routing that follows
+/// them and the type that hands both a board.
+///
+/// All of it works in two abstract coordinates, *along* the flow and *across* it, and only
+/// turns them into rectangles at the end. That is what lets one routine lay out `TD` and
+/// `LR` boards correctly rather than laying out one and transposing it — see `place`, which
+/// records what transposing got wrong.
+extension BoardLayout {
+  // MARK: - Cycles
+
+  /// The edges that have to be ignored for the graph to have layers at all.
+  ///
+  /// Found by depth-first search from the declaration order: an edge reaching a node still
+  /// on the stack is the one closing the cycle. Declaration order rather than an arbitrary
+  /// start, so the arrow the *author* wrote as the loop-back — which in Mermaid is almost
+  /// always the retry — is the one that gets drawn as one.
+  static func feedbackEdges(board: SummaryBoard, order: [String]) -> Set<String> {
+    var outgoing: [String: [BoardEdge]] = [:]
+    for edge in board.edges { outgoing[edge.from, default: []].append(edge) }
+    var feedback: Set<String> = []
+    var state: [String: Int] = [:]  // 0 unvisited, 1 on stack, 2 done
+
+    func visit(_ id: String) {
+      state[id] = 1
+      for edge in outgoing[id] ?? [] {
+        switch state[edge.to] ?? 0 {
+        case 1: feedback.insert(edge.id)
+        case 0: visit(edge.to)
+        default: break
+        }
+      }
+      state[id] = 2
+    }
+    for id in order where (state[id] ?? 0) == 0 { visit(id) }
+    return feedback
+  }
+
+  // MARK: - Layering
+
+  /// Longest path: a box sits one layer below the lowest thing pointing at it, so a step
+  /// with two prerequisites is drawn under both of them rather than beside one.
+  static func layers(of identifiers: [String], edges: [BoardEdge]) -> [String: Int] {
+    var incoming: [String: [String]] = [:]
+    for edge in edges { incoming[edge.to, default: []].append(edge.from) }
+    var layers: [String: Int] = [:]
+
+    func depth(_ id: String, _ seen: Set<String>) -> Int {
+      if let known = layers[id] { return known }
+      // `seen` is belt and braces: the feedback pass has already made this acyclic, and a
+      // recursion that trusted that and was wrong would not return.
+      guard !seen.contains(id) else { return 0 }
+      let above = (incoming[id] ?? []).map { depth($0, seen.union([id])) }
+      let value = above.isEmpty ? 0 : (above.max() ?? 0) + 1
+      layers[id] = value
+      return value
+    }
+    for id in identifiers { _ = depth(id, []) }
+    return layers
+  }
+
+  /// Which boxes share a layer, in the order they should be drawn across it.
+  static func ordered(
+    identifiers: [String], layers: [String: Int], edges: [BoardEdge], index: [String: Int]
+  ) -> [[String]] {
+    let depth = (layers.values.max() ?? 0) + 1
+    var rows: [[String]] = Array(repeating: [], count: depth)
+    for id in identifiers { rows[layers[id] ?? 0].append(id) }
+
+    var parents: [String: [String]] = [:]
+    for edge in edges { parents[edge.to, default: []].append(edge.from) }
+
+    for _ in 0..<2 {
+      var position: [String: Double] = [:]
+      for row in rows {
+        for (offset, id) in row.enumerated() { position[id] = Double(offset) }
+      }
+      for level in 1..<max(depth, 1) {
+        rows[level].sort { left, right in
+          let first = Self.barycentre(left, parents: parents, position: position, index: index)
+          let second = Self.barycentre(right, parents: parents, position: position, index: index)
+          if first != second { return first < second }
+          // Declaration order breaks every tie, so the layout is a pure function of the
+          // Mermaid and two polls of an unchanged board draw the same picture.
+          return (index[left] ?? 0) < (index[right] ?? 0)
+        }
+      }
+    }
+    return rows
+  }
+
+  static func barycentre(
+    _ id: String, parents: [String: [String]], position: [String: Double], index: [String: Int]
+  ) -> Double {
+    let above = (parents[id] ?? []).compactMap { position[$0] }
+    guard !above.isEmpty else { return Double(index[id] ?? 0) }
+    return above.reduce(0, +) / Double(above.count)
+  }
+
+  // MARK: - Placement
+
+  /// One box's claim on its row, before the sweep that opens any overlap between claims.
+  struct Slot {
+    let id: String
+    let centre: CGFloat
+    let extent: CGFloat
+  }
+
+  /// How far one row reaches across the board, for the centring pass.
+  struct Span {
+    let row: [String]
+    let low: CGFloat
+    let high: CGFloat
+  }
+
+  /// Boxes into rows, in the two coordinates a layered layout actually has: *along* the
+  /// flow, which is one row per layer, and *across* it, which is where a box sits within
+  /// its row.
+  ///
+  /// **Axis-aware rather than laid out downwards and turned.** The first version placed
+  /// everything top-down and transposed the rectangles for `LR`, which is wrong in a way
+  /// that is invisible until you draw it: the spacing between layers is worked out from the
+  /// extent along the layer axis — heights, going down — and after a transpose that axis
+  /// carries the *widths*. Rows 62 points apart then held boxes 130 points wide, and every
+  /// box in an `LR` board landed on top of the one before it.
+  static func place(
+    rows: [[String]], sizes: [String: CGSize], edges: [BoardEdge], direction: BoardDirection
+  ) -> [String: CGRect] {
+    let vertical = direction == .topDown
+    func along(_ size: CGSize) -> CGFloat { vertical ? size.height : size.width }
+    func across(_ size: CGSize) -> CGFloat { vertical ? size.width : size.height }
+    func centreAcross(_ frame: CGRect) -> CGFloat { vertical ? frame.midX : frame.midY }
+
+    var parents: [String: [String]] = [:]
+    for edge in edges { parents[edge.to, default: []].append(edge.from) }
+
+    var frames: [String: CGRect] = [:]
+    var depth: CGFloat = 0
+    for row in rows {
+      let rowDepth = row.compactMap { sizes[$0].map(along) }.max() ?? minimumNodeHeight
+      // Each box wants to sit where its parents' centres say it belongs, and the sweep
+      // below opens whatever that collides with. A first row, or one whose parents are all
+      // unplaced, falls back to laying out from zero and is centred at the end.
+      var wanted: [Slot] = []
+      var cursor: CGFloat = 0
+      for id in row {
+        let size = sizes[id] ?? CGSize(width: minimumNodeWidth, height: minimumNodeHeight)
+        let above = (parents[id] ?? []).compactMap { frames[$0].map(centreAcross) }
+        let centre =
+          above.isEmpty
+          ? cursor + across(size) / 2 : above.reduce(0, +) / CGFloat(above.count)
+        wanted.append(Slot(id: id, centre: centre, extent: across(size)))
+        cursor += across(size) + siblingGap
+      }
+      var minimum = -CGFloat.greatestFiniteMagnitude
+      for entry in wanted {
+        let size = sizes[entry.id] ?? CGSize(width: minimumNodeWidth, height: minimumNodeHeight)
+        let centre = max(entry.centre, minimum + entry.extent / 2)
+        // Centred within its row on the along-axis too, so a short box beside a tall one
+        // has its arrows meet at the same height.
+        let offset = depth + (rowDepth - along(size)) / 2
+        frames[entry.id] =
+          vertical
+          ? CGRect(
+            x: centre - size.width / 2, y: offset, width: size.width, height: size.height)
+          : CGRect(
+            x: offset, y: centre - size.height / 2, width: size.width, height: size.height)
+        minimum = centre + entry.extent / 2 + siblingGap
+      }
+      depth += rowDepth + layerGap
+    }
+    return centredRows(frames, rows: rows, direction: direction)
+  }
+
+  /// Every row centred on the widest one. The sweep above only ever pushes boxes one way,
+  /// so without this a layout drifts steadily sideways as it descends.
+  static func centredRows(
+    _ frames: [String: CGRect], rows: [[String]], direction: BoardDirection
+  ) -> [String: CGRect] {
+    let vertical = direction == .topDown
+    func low(_ frame: CGRect) -> CGFloat { vertical ? frame.minX : frame.minY }
+    func high(_ frame: CGRect) -> CGFloat { vertical ? frame.maxX : frame.maxY }
+
+    let spans = rows.compactMap { row -> Span? in
+      let boxes = row.compactMap { frames[$0] }
+      guard let first = boxes.map(low).min(), let last = boxes.map(high).max() else {
+        return nil
+      }
+      return Span(row: row, low: first, high: last)
+    }
+    guard let widest = spans.map({ $0.high - $0.low }).max(), widest > 0 else { return frames }
+    var result = frames
+    for span in spans {
+      let shift = (widest - (span.high - span.low)) / 2 - span.low
+      for id in span.row {
+        guard let frame = result[id] else { continue }
+        result[id] = frame.offsetBy(
+          dx: vertical ? shift : 0, dy: vertical ? 0 : shift)
+      }
+    }
+    return result
+  }
+
+}

--- a/graphcode/Sources/Features/LoopWorkspace/BoardRouting.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/BoardRouting.swift
@@ -1,0 +1,103 @@
+import AppKit
+import GraphcodeKit
+import SwiftUI
+
+/// How a board's arrows get from box to box — the second half of `BoardLayout`, kept in its
+/// own file because the placement above it and the routing here answer different questions
+/// and neither is short.
+///
+/// Two kinds of arrow, and the difference is the whole of it. A forward arrow leaves the
+/// bottom of one box and enters the top of the next, and can be a single curve. A feedback
+/// arrow — a retry, a rejected check — has to travel back up past everything between its
+/// two ends, which means going round the outside through the bands the layout leaves empty.
+extension BoardLayout {
+  // MARK: - Routing
+
+  /// Everything a route needs to know that is the same for every arrow on the board.
+  ///
+  /// A struct rather than six parameters: the frames, the direction and the lane are one
+  /// fact about one layout, and passing them individually to a function called once per
+  /// edge made the signature longer than the routing.
+  struct RouteContext {
+    let frames: [String: CGRect]
+    let direction: BoardDirection
+    /// Which edges have to travel back up the board — see `feedbackEdges`.
+    let feedback: Set<String>
+    /// How far each arrow is bowed aside, so two arrows between the same pair of boxes do
+    /// not land on top of one another.
+    let spreads: [String: CGFloat]
+    /// Where a feedback arrow climbs, outside the widest box.
+    let lane: CGFloat
+  }
+
+  static func routes(
+    of board: SummaryBoard, frames: [String: CGRect], feedback: Set<String>, lane: CGFloat
+  ) -> [PlacedEdge] {
+    let context = RouteContext(
+      frames: frames, direction: board.direction, feedback: feedback,
+      spreads: spreads(of: board.edges), lane: lane)
+    return board.edges.compactMap { route($0, in: context) }
+  }
+
+  static func route(_ edge: BoardEdge, in context: RouteContext) -> PlacedEdge? {
+    guard let from = context.frames[edge.from], let to = context.frames[edge.to] else {
+      return nil
+    }
+    if context.feedback.contains(edge.id) {
+      return feedbackRoute(edge, from: from, to: to, lane: context.lane)
+    }
+    let spread = context.spreads[edge.id] ?? 0
+    let start: CGPoint
+    let end: CGPoint
+    switch context.direction {
+    case .topDown:
+      start = CGPoint(x: from.midX, y: from.maxY)
+      end = CGPoint(x: to.midX, y: to.minY)
+    case .leftRight:
+      start = CGPoint(x: from.maxX, y: from.midY)
+      end = CGPoint(x: to.minX, y: to.midY)
+    }
+    // The bow is across the direction of travel, so a pair of arrows separates sideways on
+    // a top-down board and vertically on a left-right one.
+    let nudge =
+      context.direction == .topDown
+      ? CGPoint(x: spread, y: 0) : CGPoint(x: 0, y: spread)
+    return PlacedEdge(
+      edge: edge, start: start, end: end, waypoints: [],
+      labelPoint: CGPoint(
+        x: (start.x + end.x) / 2 + nudge.x, y: (start.y + end.y) / 2 + nudge.y),
+      isFeedback: false, spread: spread, axis: context.direction)
+  }
+
+  /// An arrow climbing back up the flow, routed through the empty bands between layers.
+  ///
+  /// **Out of the bottom and in at the top, never out of the side.** The first version left
+  /// the source box on its right and re-entered the target on *its* right, at each box's own
+  /// mid-height — which is the height of every other box in that row, so the horizontal run
+  /// went straight through its neighbours. The boxes draw over the arrows, so the result was
+  /// not even a visible mistake: the retry arrow simply vanished behind the box beside it,
+  /// and a diagram whose whole point was the loop appeared to have none.
+  ///
+  /// The bands half a `layerGap` below one row and above another hold no boxes by
+  /// construction, which makes them the one place a horizontal run is always safe.
+  static func feedbackRoute(
+    _ edge: BoardEdge, from: CGRect, to: CGRect, lane: CGFloat
+  ) -> PlacedEdge {
+    let below = from.maxY + layerGap / 2
+    let above = to.minY - layerGap / 2
+    return PlacedEdge(
+      edge: edge,
+      start: CGPoint(x: from.midX, y: from.maxY),
+      end: CGPoint(x: to.midX, y: to.minY),
+      waypoints: [
+        CGPoint(x: from.midX, y: below),
+        CGPoint(x: lane, y: below),
+        CGPoint(x: lane, y: above),
+        CGPoint(x: to.midX, y: above),
+      ],
+      labelPoint: CGPoint(x: lane, y: (below + above) / 2),
+      // Down into the target's top, whichever way the board itself runs: the last leg of a
+      // feedback route is always the drop out of the band above its target.
+      isFeedback: true, spread: 0, axis: .topDown)
+  }
+}

--- a/graphcode/Sources/Features/LoopWorkspace/BoardTablePresentation.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/BoardTablePresentation.swift
@@ -1,0 +1,154 @@
+import GraphcodeKit
+import SwiftUI
+
+/// What each cell of a table board *is*, worked out once for the whole table before any of
+/// it is drawn.
+///
+/// A value type with no view in it, for the reason `BoardLayout` is one: deciding that a
+/// column holds numbers, or that `pass` is a verdict and `pass 3` is a phrase, is the part
+/// with rules in it, and rules that can only be checked by looking at a window are rules
+/// nobody checks.
+///
+/// **Classified per column, not per cell.** A column is numeric only if *every* cell in it
+/// is, which is what stops one stray `n/a` in a column of counts from making that column
+/// ragged — and stops a lone `61` in a column of test names from being right-aligned on its
+/// own. The alternative reads as a renderer guessing, one cell at a time.
+struct BoardTablePresentation: Equatable {
+  enum Cell: Equatable {
+    case plain(String)
+    /// A verdict: `yes`/`no`, `pass`/`fail`, `ok`/`error`, `✅`/`❌`, `true`/`false`.
+    case verdict(Bool, String)
+    /// A diffstat: `+52`, `-9`. Carries the sign separately so the renderer never has to
+    /// re-parse what this already decided.
+    case delta(isAddition: Bool, text: String)
+    /// A plain number, and where it sits in its column's range — `nil` when the column is
+    /// all one value, which is the case a bar would draw as either full or empty and mean
+    /// neither.
+    case number(String, fraction: Double?)
+  }
+
+  struct Column: Equatable {
+    let header: String
+    let alignment: BoardColumnAlignment
+    let isNumeric: Bool
+    /// Whether this column gets bars under its numbers. Only a numeric column with enough
+    /// rows to compare and some actual spread — two numbers do not make a chart, and a
+    /// column of identical values drawn as identical bars says nothing twice.
+    let showsBars: Bool
+
+    /// Right for numbers, leading for everything else — unless the author said otherwise in
+    /// the separator row, which always wins.
+    var effectiveAlignment: HorizontalAlignment {
+      switch alignment {
+      case .leading: return .leading
+      case .center: return .center
+      case .trailing: return .trailing
+      case .unspecified: return isNumeric ? .trailing : .leading
+      }
+    }
+  }
+
+  let columns: [Column]
+  let rows: [[Cell]]
+
+  /// Below this a numeric column is a pair of figures to read, not a series to compare.
+  static let minimumRowsForBars = 3
+
+  init(table: BoardTable) {
+    let body = table.normalisedRows
+    let columns = table.headers.indices.map { index -> Column in
+      let cells = body.map { $0[index] }.filter { !$0.isEmpty }
+      let numbers = cells.compactMap { Self.number(from: $0) }
+      let isNumeric = !cells.isEmpty && numbers.count == cells.count
+      let spread = (numbers.max() ?? 0) - (numbers.min() ?? 0)
+      return Column(
+        header: table.headers[index],
+        alignment: table.alignment(ofColumn: index),
+        isNumeric: isNumeric,
+        showsBars: isNumeric && cells.count >= Self.minimumRowsForBars && spread > 0)
+    }
+    // Each numeric column's own range, so a bar compares a value with the column it is in
+    // and never with the table.
+    let ranges = table.headers.indices.map { index -> (low: Double, high: Double)? in
+      guard columns[index].showsBars else { return nil }
+      let numbers = body.compactMap { Self.number(from: $0[index]) }
+      guard let low = numbers.min(), let high = numbers.max(), high > low else { return nil }
+      return (low, high)
+    }
+
+    self.columns = columns
+    rows = body.map { row in
+      row.indices.map { index in
+        Self.cell(row[index], range: ranges[index])
+      }
+    }
+  }
+
+  static func cell(_ raw: String, range: (low: Double, high: Double)?) -> Cell {
+    let text = raw.trimmingCharacters(in: .whitespaces)
+    if let verdict = verdict(of: text) { return .verdict(verdict, text) }
+    if let delta = delta(of: text) { return delta }
+    guard let value = number(from: text) else { return .plain(text) }
+    guard let range else { return .number(text, fraction: nil) }
+    return .number(text, fraction: (value - range.low) / (range.high - range.low))
+  }
+
+  /// The words a verdict is written in, and nothing else.
+  ///
+  /// **Whole-cell match only.** `pass` is a verdict; `pass 3` is a phrase about which pass,
+  /// and a table of pass numbers rendered as a column of green ticks would be actively
+  /// misleading — which is the failure mode this whole feature is meant to avoid.
+  static func verdict(of text: String) -> Bool? {
+    switch text.lowercased() {
+    case "yes", "pass", "passed", "ok", "true", "✅", "✔", "✓", "green", "clean": return true
+    case "no", "fail", "failed", "error", "false", "❌", "✗", "✘", "red", "broken": return false
+    default: return nil
+    }
+  }
+
+  /// `+52` and `-9`, and only in that shape.
+  ///
+  /// **Coloured by sign, and that is a judgement about context rather than about
+  /// arithmetic.** A signed integer in a table about code is a diffstat far more often than
+  /// it is anything else, and green-added/red-removed is the convention every diff view
+  /// already teaches. It would be the wrong reading for a column of temperature changes —
+  /// which is not a thing a coding session produces. A bare `52` is never a delta, so a
+  /// column of plain counts is untouched by this.
+  static func delta(of text: String) -> Cell? {
+    guard text.count >= 2, let first = text.first, "+-−".contains(first) else { return nil }
+    let magnitude = String(text.dropFirst())
+    guard number(from: magnitude) != nil else { return nil }
+    return .delta(isAddition: first == "+", text: text)
+  }
+
+  /// A number, allowing the separators people write them with and the units they end them
+  /// in — `1,024`, `93%`, `1.4k`, `250ms`.
+  static func number(from text: String) -> Double? {
+    var body = text.replacingOccurrences(of: ",", with: "")
+    body = body.replacingOccurrences(of: "−", with: "-")
+    let digits = body.prefix { "+-0123456789.".contains($0) }
+    guard !digits.isEmpty, let value = Double(digits) else { return nil }
+    let suffix = body.dropFirst(digits.count).lowercased()
+    switch suffix {
+    case "", "%", "ms", "s", "b", "pt", "px": return value
+    case "k": return value * 1_000
+    case "m": return value * 1_000_000
+    default: return nil
+    }
+  }
+}
+
+extension BoardTablePresentation.Column {
+  /// The frame alignment the cell views are laid out with.
+  var frameAlignment: Alignment {
+    switch effectiveAlignment {
+    case .center: return .center
+    case .trailing: return .trailing
+    default: return .leading
+    }
+  }
+
+  /// Which edge a bar grows from — the same edge its number is aligned to, so the two read
+  /// as one mark rather than as a number with a stray rule under it.
+  var barAlignment: HorizontalAlignment { effectiveAlignment }
+}

--- a/graphcode/Sources/Features/LoopWorkspace/BoardTableView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/BoardTableView.swift
@@ -1,0 +1,104 @@
+import GraphcodeKit
+import SwiftUI
+
+/// A table board — rows and columns, drawn as a `Grid` rather than as a diagram.
+///
+/// What each cell *is* was decided before any of this ran; see `BoardTablePresentation`,
+/// which is where the rules about verdicts, diffstats and numeric columns live. This only
+/// draws what it is handed.
+struct TableBoardView: View {
+  let board: SummaryBoard
+  let ceiling: CGFloat?
+
+  var body: some View {
+    if let table = board.table {
+      let presentation = BoardTablePresentation(table: table)
+      // Horizontally scrollable rather than squeezed: five columns at the rail's folded
+      // width is 40 points each, which is a column of ellipses.
+      ScrollView([.horizontal, .vertical]) {
+        Grid(alignment: .leading, horizontalSpacing: 14, verticalSpacing: 0) {
+          GridRow {
+            ForEach(Array(presentation.columns.enumerated()), id: \.offset) { _, column in
+              Text(column.header)
+                .font(.system(size: 9.5, weight: .bold))
+                .tracking(0.5)
+                .foregroundStyle(.white.opacity(0.45))
+                .frame(maxWidth: .infinity, alignment: column.frameAlignment)
+            }
+          }
+          .padding(.vertical, 5)
+          // Ruled, not striped. A `GridRow` background is applied to each *cell*, not
+          // across the row, so alternating fills came out as a ragged block behind each
+          // piece of text rather than as a band — worse than the plain rules it was meant
+          // to improve on.
+          ForEach(Array(presentation.rows.enumerated()), id: \.offset) { _, row in
+            Divider().overlay(.white.opacity(0.07)).gridCellUnsizedAxes(.horizontal)
+            GridRow {
+              ForEach(Array(row.enumerated()), id: \.offset) { index, cell in
+                BoardCellView(cell: cell, column: presentation.columns[index])
+              }
+            }
+            .padding(.vertical, 5)
+          }
+        }
+        .padding(.horizontal, 2)
+      }
+      .scrollBounceBehavior(.basedOnSize)
+      .frame(maxHeight: ceiling ?? .infinity)
+    } else {
+      BoardSourceView(source: board.source)
+    }
+  }
+}
+
+/// One cell, drawn as whatever `BoardTablePresentation` decided it was.
+private struct BoardCellView: View {
+  let cell: BoardTablePresentation.Cell
+  let column: BoardTablePresentation.Column
+
+  var body: some View {
+    content
+      .frame(maxWidth: .infinity, alignment: column.frameAlignment)
+      .fixedSize(horizontal: false, vertical: true)
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    switch cell {
+    case .plain(let text):
+      Text(text)
+        .font(.system(size: 11))
+        .foregroundStyle(.white.opacity(0.85))
+    case .verdict(let passed, let text):
+      HStack(spacing: 4) {
+        Image(systemName: passed ? "checkmark.circle.fill" : "xmark.circle.fill")
+          .font(.system(size: 9))
+        Text(text)
+          .font(.system(size: 10.5, weight: .medium))
+      }
+      .foregroundStyle(passed ? BoardPalette.affirm : BoardPalette.deny)
+      .padding(.horizontal, 5)
+      .padding(.vertical, 1.5)
+      .background(
+        (passed ? BoardPalette.affirm : BoardPalette.deny).opacity(0.12),
+        in: Capsule())
+    case .delta(let isAddition, let text):
+      Text(text)
+        .font(.system(size: 11, design: .monospaced))
+        .foregroundStyle(isAddition ? BoardPalette.affirm : BoardPalette.deny)
+    case .number(let text, let fraction):
+      VStack(alignment: column.barAlignment, spacing: 2) {
+        Text(text)
+          .font(.system(size: 11, design: .monospaced))
+          .foregroundStyle(.white.opacity(0.72))
+        if let fraction, column.showsBars {
+          // Under the figure rather than behind it. A track behind the text tints the
+          // number itself, and the one thing a number in a table has to stay is legible.
+          Capsule()
+            .fill(.white.opacity(0.22))
+            .frame(width: max(3, 34 * fraction), height: 2)
+        }
+      }
+    }
+  }
+}

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
@@ -35,6 +35,22 @@ struct LoopWorkspaceFeature {
     /// own visibility, and for the same reason: both are choices about how much of the
     /// window a person wants back, and neither should have to be remade every launch.
     var isSummaryFolded = LoopWorkspaceRail.loadSummaryFolded()
+    /// Whether the board section is collapsed to its header. Persisted separately from the
+    /// summary's fold: they answer different questions, and someone who wants the sentence
+    /// and not the diagram — or the diagram and not the sentence — is not being perverse.
+    var isBoardFolded = LoopWorkspaceRail.loadBoardFolded()
+    /// Whether a rail width has ever been committed by a drag on this machine.
+    ///
+    /// What lets a board open the rail wider without ever overruling a width somebody
+    /// chose. Read once at open rather than on every render — it only changes here, in
+    /// `railWidthChanged`, and a `UserDefaults` read per body pass would be one per pointer
+    /// event during a drag.
+    var hasCustomRailWidth = LoopWorkspaceRail.hasStoredWidth()
+    /// Whether the board has the workspace to itself. Deliberately *not* persisted: a cover
+    /// over the terminal is a thing you open to look at something, and a window that
+    /// relaunched with the terminal hidden behind a diagram would be a window that looked
+    /// broken.
+    var isBoardExpanded = false
     /// The newest beat that was on screen when this workspace was last left — what the
     /// rail's `SINCE YOU LOOKED` hairline is drawn against.
     ///
@@ -84,6 +100,10 @@ struct LoopWorkspaceFeature {
     case railWidthChanged(CGFloat)
     /// The summary section's header row.
     case summaryFoldToggled
+    /// The board section's header row.
+    case boardFoldToggled
+    /// The board section's expand button, and the cover's own close.
+    case boardExpandToggled
     /// The amber block's `Answer it` — the question is in the terminal, so this is a
     /// request for the keyboard to go there.
     case summaryAnswerTapped
@@ -221,11 +241,22 @@ struct LoopWorkspaceFeature {
       case .railWidthChanged(let width):
         state.railWidth = LoopWorkspaceRail.clamped(width)
         LoopWorkspaceRail.saveWidth(state.railWidth)
+        // From here on the width is theirs, and a board arriving never moves it again.
+        state.hasCustomRailWidth = true
         return .none
 
       case .summaryFoldToggled:
         state.isSummaryFolded.toggle()
         LoopWorkspaceRail.saveSummaryFolded(state.isSummaryFolded)
+        return .none
+
+      case .boardFoldToggled:
+        state.isBoardFolded.toggle()
+        LoopWorkspaceRail.saveBoardFolded(state.isBoardFolded)
+        return .none
+
+      case .boardExpandToggled:
+        state.isBoardExpanded.toggle()
         return .none
 
       case .summaryAnswerTapped:

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
@@ -118,7 +118,8 @@ struct LoopWorkspaceRail: View {
   /// to it (the argument that already keeps the cost rollup out of the sidebar).
   static func hasContent(
     node: LoopNode, graph: LoopGraph,
-    summarising: Bool = LoopSummaryPresentation.isProducing
+    summarising: Bool = LoopSummaryPresentation.isProducing,
+    drawing: Bool = SummaryBoardPresentation.isDrawing
   ) -> Bool {
     graph.edges.contains { $0.from == node.id || $0.to == node.id }
       || node.metricHistory.count >= 2
@@ -129,7 +130,7 @@ struct LoopWorkspaceRail: View {
       // A loop wired to nothing whose run has been drawn has the one thing the rail is
       // widest for. Its own switch, so the board's absence is never inferred from the
       // beats' — see `SummaryBoardPresentation.hasContent`.
-      || SummaryBoardPresentation.hasContent(node: node)
+      || SummaryBoardPresentation.hasContent(node: node, drawing: drawing)
   }
 
   /// How many loops this one hands off to — what the loop bar's control counts.

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
@@ -22,8 +22,13 @@ struct LoopWorkspaceRail: View {
   /// The newest beat this window had on screen when it was last left — see
   /// `LoopWorkspaceFeature.seenBeatID`.
   let seenBeatID: String?
+  /// Whether the board section is collapsed to its header. Per window and persisted,
+  /// beside the summary's own fold.
+  let isBoardFolded: Bool
   let onSummaryFoldToggled: () -> Void
   let onSummaryAnswerTapped: () -> Void
+  let onBoardFoldToggled: () -> Void
+  let onBoardExpanded: () -> Void
   let onTargetTapped: (UUID) -> Void
 
   /// The handoff's number, and now the floor rather than the fixed size. Below this the
@@ -31,10 +36,40 @@ struct LoopWorkspaceRail: View {
   static let minimumWidth: CGFloat = 212
   /// Half a 1280pt window is already more than a summary needs; past this the terminal —
   /// the pane someone is actually working in — is the thing being taken from.
-  static let maximumWidth: CGFloat = 520
+  ///
+  /// Raised from 520 when boards arrived. A sentence stops needing width at 520; a diagram
+  /// does not, and a person who drags the rail out to read one has said plainly which of
+  /// the two panes they want.
+  static let maximumWidth: CGFloat = 760
   /// Wider than the 212 the design specified, because the section that arrived after it
   /// carries prose rather than chips and rows of three.
   static let defaultWidth: CGFloat = 280
+
+  /// What the rail opens at when the loop carries a board — and *only* when nobody has ever
+  /// dragged the rail themselves (`hasStoredWidth`).
+  ///
+  /// A diagram is not prose: 280 points is four boxes across before it starts scrolling
+  /// sideways, which is the width at which a flowchart stops being worth drawing. 460 fits
+  /// a five-box layer at full size and still leaves two thirds of a 1280pt window to the
+  /// terminal. It is a default and nothing more — the drag handle is unchanged, and the
+  /// moment a width is chosen it wins over this for ever.
+  static let boardWidth: CGFloat = 460
+
+  /// Whether a width has ever been committed by a drag. What keeps `boardWidth` from
+  /// overruling a choice somebody actually made.
+  static func hasStoredWidth() -> Bool {
+    UserDefaults.standard.double(forKey: widthDefaultsKey) > 0
+  }
+
+  static let boardFoldedDefaultsKey = "loopBoardSectionFolded"
+
+  static func loadBoardFolded() -> Bool {
+    UserDefaults.standard.bool(forKey: boardFoldedDefaultsKey)
+  }
+
+  static func saveBoardFolded(_ folded: Bool) {
+    UserDefaults.standard.set(folded, forKey: boardFoldedDefaultsKey)
+  }
 
   static let visibleDefaultsKey = "loopWorkspaceRailVisible"
 
@@ -91,6 +126,10 @@ struct LoopWorkspaceRail: View {
       // anything — and that narration is the reason to open the rail at all. With the
       // producer off it is not narrating, whatever a previous switch-on left on the node.
       || LoopSummaryPresentation.hasContent(node: node, producing: summarising)
+      // A loop wired to nothing whose run has been drawn has the one thing the rail is
+      // widest for. Its own switch, so the board's absence is never inferred from the
+      // beats' — see `SummaryBoardPresentation.hasContent`.
+      || SummaryBoardPresentation.hasContent(node: node)
   }
 
   /// How many loops this one hands off to — what the loop bar's control counts.
@@ -120,6 +159,14 @@ struct LoopWorkspaceRail: View {
         LoopSummarySection(
           node: node, now: now, isFolded: isSummaryFolded, seenBeatID: seenBeatID,
           onToggleFold: onSummaryFoldToggled, onAnswer: onSummaryAnswerTapped)
+      }
+      // Under the sentence and above the graph. The order is the order of the questions:
+      // what is it doing, what shape did that have, where does it sit. A diagram above the
+      // beat would put the account of a finished pass over the thing happening now.
+      if SummaryBoardPresentation.hasContent(node: node) {
+        SummaryBoardSection(
+          node: node, isFolded: isBoardFolded, onToggleFold: onBoardFoldToggled,
+          onExpand: onBoardExpanded)
       }
       section("THIS LOOP") {
         RailMinimap(node: node, upstream: inbound, downstream: outbound.map(\.target))

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
@@ -22,8 +22,11 @@ struct LoopWorkspaceView: View {
           width: railWidth,
           isSummaryFolded: store.isSummaryFolded,
           seenBeatID: store.seenBeatID,
+          isBoardFolded: store.isBoardFolded,
           onSummaryFoldToggled: { store.send(.summaryFoldToggled) },
-          onSummaryAnswerTapped: { store.send(.summaryAnswerTapped) }
+          onSummaryAnswerTapped: { store.send(.summaryAnswerTapped) },
+          onBoardFoldToggled: { store.send(.boardFoldToggled) },
+          onBoardExpanded: { store.send(.boardExpandToggled) }
         ) { targetID in
           store.send(.railTargetTapped(targetID))
         }
@@ -35,6 +38,7 @@ struct LoopWorkspaceView: View {
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .overlay { expandedBoard }
     .onReceive(CanvasClock.tick) { now = $0 }
     .onDisappear { store.send(.workspaceLeft) }
     // The folder header goes in the toolbar, not in the `VStack` above, and the pane
@@ -53,7 +57,35 @@ struct LoopWorkspaceView: View {
   /// Whether the resize cursor is currently pushed — see `railResizeHandle`.
   @State private var isOverRailEdge = false
 
-  private var railWidth: CGFloat { dragWidth ?? store.railWidth }
+  /// The rail's width this frame.
+  ///
+  /// Three answers in priority order, and the middle one is the whole of the board's claim
+  /// on the window: a drag in progress wins; failing that, a loop carrying a diagram opens
+  /// the rail at `boardWidth` **only while nobody has ever set a width themselves**; failing
+  /// that, the stored width. A diagram needs room a sentence does not, and 280 points is
+  /// four boxes across — but a default is all this is, and one drag retires it for good.
+  private var railWidth: CGFloat {
+    if let dragWidth { return dragWidth }
+    guard !store.hasCustomRailWidth, boardIsShowing else { return store.railWidth }
+    return LoopWorkspaceRail.boardWidth
+  }
+
+  private var boardIsShowing: Bool {
+    !store.isBoardFolded && SummaryBoardPresentation.hasContent(node: store.node)
+  }
+
+  /// The board over the panes — see `ExpandedBoardView`. Only ever over a board that is
+  /// actually drawable, so the cover cannot open onto nothing if the diagram is cleared
+  /// while it is up.
+  @ViewBuilder
+  private var expandedBoard: some View {
+    if store.isBoardExpanded, let board = store.node.board, board.isDrawable {
+      ExpandedBoardView(node: store.node, board: board) {
+        store.send(.boardExpandToggled)
+      }
+      .transition(.opacity)
+    }
+  }
 
   /// The rail's leading edge, as a grab handle.
   ///

--- a/graphcode/Sources/Features/LoopWorkspace/SummaryBoardPresentation.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/SummaryBoardPresentation.swift
@@ -1,0 +1,61 @@
+import GraphcodeKit
+import SwiftUI
+
+/// What the board section says and whether it says anything — worked out once and drawn
+/// twice, the same split `LoopSummaryPresentation` makes and for the same reason: the rules
+/// about when a picture is worth 460 points of window are assertable without a window.
+struct SummaryBoardPresentation: Equatable {
+  enum Mode: Equatable {
+    /// A working loop that has finished a pass and has no board for it. Honest about
+    /// latency for the same reason `LoopSummaryPresentation.starting` is — a person who has
+    /// just switched the experiment on needs to see that something is coming.
+    case pending
+    case drawn
+  }
+
+  let mode: Mode
+  let board: SummaryBoard?
+  /// The pass the board describes, which is not always the pass the loop is on.
+  let pass: Int?
+  /// Whether the loop has moved on since this was drawn. Not an error and not hidden: a
+  /// board is an account of one finished pass, and saying which one is what stops it being
+  /// read as a claim about right now.
+  let isStale: Bool
+
+  /// Whether the composer is switched on, from the app's own live copy of the settings
+  /// file — the same read `LoopSummaryPresentation.isProducing` makes, and no disk on the
+  /// render path.
+  ///
+  /// Both switches, in the same order the daemon asks them: a board is drawn from the
+  /// summary, so the picture without the reading behind it would be a drawing of a run
+  /// nothing is narrating.
+  static var isDrawing: Bool {
+    let settings = SettingsModel.shared.settings
+    return settings.summarisesLoops && settings.visualisesSummaries
+  }
+
+  /// Whether the section has anything worth the space.
+  ///
+  /// A drawn board always qualifies. A *pending* one qualifies only while the loop is
+  /// working: the composer is told to answer `NONE` for a thin pass and most passes are
+  /// thin, so a quiet loop with no board has probably been looked at and declined — and a
+  /// permanent "nothing yet" on every finished loop is precisely the blank chrome
+  /// `LoopWorkspaceRail.hasContent` exists to keep out of the rail.
+  static func hasContent(node: LoopNode, drawing: Bool = isDrawing) -> Bool {
+    guard drawing else { return false }
+    if node.board?.isDrawable == true { return true }
+    return isWorking(node) && node.summary?.passes.isEmpty == false
+  }
+
+  private static func isWorking(_ node: LoopNode) -> Bool {
+    node.presence?.presence == .busy && !node.isResolved
+  }
+
+  init(node: LoopNode) {
+    let board = node.board?.isDrawable == true ? node.board : nil
+    self.board = board
+    mode = board == nil ? .pending : .drawn
+    pass = board?.pass
+    isStale = (node.summary?.currentPass ?? 0) > (board?.pass ?? Int.max)
+  }
+}

--- a/graphcode/Sources/Features/LoopWorkspace/SummaryBoardSection.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/SummaryBoardSection.swift
@@ -1,0 +1,170 @@
+import AppKit
+import GraphcodeKit
+import SwiftUI
+
+/// The picture of the run, under the sentence about it — the second section of the
+/// workspace rail.
+///
+/// `LoopSummarySection` above answers *what is it doing*, in the agent's own words. This
+/// answers *what shape did the work have*, which is the question a sentence is bad at: a
+/// plan with a branch in it, a pipeline with four stages, a table of what six files each
+/// gave up. The rail opens wider when one of these is showing, because a diagram at 188
+/// points is a diagram nobody reads.
+struct SummaryBoardSection: View {
+  let node: LoopNode
+  let isFolded: Bool
+  let onToggleFold: () -> Void
+  let onExpand: () -> Void
+
+  private var presentation: SummaryBoardPresentation {
+    SummaryBoardPresentation(node: node)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 7) {
+      let presentation = presentation
+      header(presentation)
+      if !isFolded {
+        content(presentation)
+      }
+      Rectangle().fill(.white.opacity(0.07)).frame(height: 1)
+    }
+  }
+
+  @ViewBuilder
+  private func content(_ presentation: SummaryBoardPresentation) -> some View {
+    if let board = presentation.board {
+      if let title = board.title, !title.isEmpty {
+        Text(title)
+          .font(.system(size: 11.5, weight: .medium))
+          .foregroundStyle(.white.opacity(0.75))
+          .lineLimit(2)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      SummaryBoardView(board: board, accent: node.loopType.accent)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    } else {
+      Text("Nothing to draw yet")
+        .font(.system(size: 11))
+        .foregroundStyle(.white.opacity(0.35))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 10)
+    }
+  }
+
+  /// The word, which pass it is of, and the two things you can do to a board: take the
+  /// Mermaid somewhere else, or give it the whole window.
+  ///
+  /// The whole row folds it, like the summary's — a 14pt chevron is not a click target
+  /// anyone aims at. The buttons above it stop the tap from reaching the row, which is why
+  /// they are buttons rather than tap gestures.
+  private func header(_ presentation: SummaryBoardPresentation) -> some View {
+    HStack(spacing: 7) {
+      Text(headerTitle(presentation))
+        .font(.system(size: 10.5, weight: .bold))
+        .tracking(0.63)
+        .foregroundStyle(.white.opacity(0.5))
+      if let pass = presentation.pass, pass > 0 {
+        Text("PASS \(pass)")
+          .font(.system(size: 9.5, weight: .medium, design: .monospaced))
+          .foregroundStyle(.white.opacity(presentation.isStale ? 0.35 : 0.5))
+          .help(
+            presentation.isStale
+              ? "Drawn from pass \(pass); the loop has moved on since"
+              : "Drawn from pass \(pass)")
+      }
+      Spacer(minLength: 0)
+      if let board = presentation.board, !isFolded {
+        iconButton("doc.on.doc", help: "Copy the Mermaid") { copy(board.source) }
+        iconButton("arrow.up.left.and.arrow.down.right", help: "Fill the window", action: onExpand)
+      }
+      Image(systemName: isFolded ? "chevron.down" : "chevron.up")
+        .font(.system(size: 8, weight: .semibold))
+        .foregroundStyle(.white.opacity(0.6))
+        .frame(width: 14, height: 14)
+        .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 3))
+    }
+    .contentShape(Rectangle())
+    .onTapGesture(perform: onToggleFold)
+    .help(isFolded ? "Show the diagram" : "Collapse the diagram")
+  }
+
+  private func headerTitle(_ presentation: SummaryBoardPresentation) -> LocalizedStringKey {
+    switch presentation.mode {
+    case .pending: return "VISUALISED"
+    case .drawn: return presentation.board?.form == .table ? "IN COLUMNS" : "THE SHAPE OF IT"
+    }
+  }
+
+  private func iconButton(
+    _ symbol: String, help: LocalizedStringKey, action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      Image(systemName: symbol)
+        .font(.system(size: 8.5, weight: .semibold))
+        .foregroundStyle(.white.opacity(0.6))
+        .frame(width: 14, height: 14)
+        .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 3))
+    }
+    .buttonStyle(.plain)
+    .help(help)
+  }
+
+  /// The source, not a rendering. A board's whole portability is that it is Mermaid — it
+  /// pastes into a pull request, an issue or anywhere else that draws one, and graphcode
+  /// happens to be a place that draws it natively.
+  private func copy(_ source: String) {
+    let pasteboard = NSPasteboard.general
+    pasteboard.clearContents()
+    pasteboard.setString("```mermaid\n\(source)\n```", forType: .string)
+  }
+}
+
+/// A board with the workspace to itself — what the section's expand button opens.
+///
+/// A cover over the panes rather than a window of its own: the diagram is *about* the
+/// session in the terminal underneath, and a separate window would be one more thing to
+/// find, arrange and close. Escape and the button both put it back.
+struct ExpandedBoardView: View {
+  let node: LoopNode
+  let board: SummaryBoard
+  let onClose: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(spacing: 10) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(board.title ?? node.title)
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(.white.opacity(0.9))
+          Text(caption)
+            .font(.system(size: 10.5, design: .monospaced))
+            .foregroundStyle(.white.opacity(0.45))
+        }
+        Spacer(minLength: 0)
+        Button(action: onClose) {
+          Image(systemName: "xmark")
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(.white.opacity(0.7))
+            .frame(width: 22, height: 22)
+            .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 5))
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut(.cancelAction)
+        .help("Close")
+      }
+      SummaryBoardView(board: board, accent: node.loopType.accent)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+    .padding(20)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(.ultraThinMaterial)
+  }
+
+  private var caption: String {
+    var parts: [String] = []
+    if board.pass > 0 { parts.append("pass \(board.pass)") }
+    parts.append(board.composedAt.formatted(date: .omitted, time: .shortened))
+    return parts.joined(separator: " · ")
+  }
+}

--- a/graphcode/Sources/Features/LoopWorkspace/SummaryBoardSection.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/SummaryBoardSection.swift
@@ -76,6 +76,9 @@ struct SummaryBoardSection: View {
       Spacer(minLength: 0)
       if let board = presentation.board, !isFolded {
         iconButton("doc.on.doc", help: "Copy the Mermaid") { copy(board.source) }
+        if board.form == .flow {
+          iconButton("square.and.arrow.down", help: "Export for Excalidraw") { export(board) }
+        }
         iconButton("arrow.up.left.and.arrow.down.right", help: "Fill the window", action: onExpand)
       }
       Image(systemName: isFolded ? "chevron.down" : "chevron.up")
@@ -117,6 +120,39 @@ struct SummaryBoardSection: View {
     let pasteboard = NSPasteboard.general
     pasteboard.clearContents()
     pasteboard.setString("```mermaid\n\(source)\n```", forType: .string)
+  }
+
+  /// The same diagram, somewhere it can be rearranged by hand.
+  ///
+  /// **Flow boards only.** A table has no geometry to export — it is rows and columns, and
+  /// Excalidraw has no table. Copying the Markdown is what a table is portable *as*, so the
+  /// button is simply absent rather than present and disappointing.
+  ///
+  /// A save panel rather than a fixed location: this is a file the human is going to open
+  /// somewhere else, so where it lands is theirs to choose.
+  private func export(_ board: SummaryBoard) {
+    let panel = NSSavePanel()
+    panel.nameFieldStringValue = "\(fileStem(board)).excalidraw"
+    panel.allowedContentTypes = []
+    panel.canCreateDirectories = true
+    panel.title = String(localized: "Export for Excalidraw")
+    guard panel.runModal() == .OK, let url = panel.url else { return }
+    // Written from the same layout the rail is drawing, so what lands in the file is what
+    // is on screen rather than a second interpretation of the Mermaid.
+    guard
+      let data = try? BoardExcalidrawExport.data(
+        for: board, layout: BoardLayout(board: board))
+    else { return }
+    try? data.write(to: url)
+  }
+
+  private func fileStem(_ board: SummaryBoard) -> String {
+    let name = board.title ?? node.title
+    let safe = name.unicodeScalars.map {
+      CharacterSet.alphanumerics.contains($0) ? Character($0) : "-"
+    }
+    let stem = String(safe).trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    return stem.isEmpty ? "board" : stem
   }
 }
 

--- a/graphcode/Sources/Features/LoopWorkspace/SummaryBoardView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/SummaryBoardView.swift
@@ -1,0 +1,366 @@
+import GraphcodeKit
+import SwiftUI
+
+/// A board, drawn — the flowchart, the table, or the Mermaid itself when this build cannot
+/// draw what the composer wrote.
+///
+/// Native SwiftUI shapes rather than a web view, and that is a product decision before it
+/// is a technical one. The app ships no WebKit and no JavaScript; a board is a few dozen
+/// structs that lay out in microseconds, so it can live in a rail that redraws on every
+/// clock tick and inside a `scaleEffect` without either becoming a frame budget problem.
+/// What it costs is fidelity: `MermaidBoardParser` reads a subset, and anything outside it
+/// falls through to `BoardSourceView` rather than to an error.
+struct SummaryBoardView: View {
+  let board: SummaryBoard
+  /// The loop's own accent, so a board reads as belonging to the card that opened it.
+  let accent: Color
+  /// How tall the board may get before it scrolls instead of growing. `nil` means take
+  /// everything, which is what the expanded cover hands it; the rail hands it a ceiling so
+  /// a twelve-layer flowchart cannot push the graph sections off the bottom.
+  var ceiling: CGFloat? = SummaryBoardView.railCeiling
+
+  /// Two thirds of a 900pt window's rail, after the summary above it has had its 120.
+  static let railCeiling: CGFloat = 340
+
+  var body: some View {
+    switch board.form {
+    case .flow: FlowBoardView(board: board, accent: accent, ceiling: ceiling)
+    case .table: TableBoardView(board: board, ceiling: ceiling)
+    }
+  }
+}
+
+// MARK: - Flow
+
+private struct FlowBoardView: View {
+  let board: SummaryBoard
+  let accent: Color
+  let ceiling: CGFloat?
+
+  /// The rail's content width, once the layout has been given one. Read rather than
+  /// inferred from a `GeometryReader` wrapped round the whole thing: a `GeometryReader`
+  /// takes the height it is offered instead of the height its content needs, which for a
+  /// diagram means either a fixed panel with a gap under it or one that never scrolls.
+  @State private var available: CGFloat = 0
+
+  /// **Floored rather than left to shrink.** A board that always fitted would be legible
+  /// only in the sense that it was all on screen; past about half size the labels stop
+  /// being readable and the right answer is to let the panel scroll.
+  static let minimumScale: CGFloat = 0.55
+
+  var body: some View {
+    let layout = BoardLayout(board: board)
+    if layout.nodes.isEmpty {
+      // Parsed to nothing — a diagram type outside the subset, or a flow with no arrows in
+      // it. The Mermaid is still the answer; it is just text this build cannot draw.
+      BoardSourceView(source: board.source)
+    } else {
+      let scale = scale(for: layout)
+      ScrollView([.horizontal, .vertical]) {
+        diagram(layout)
+          .frame(width: layout.size.width, height: layout.size.height)
+          .scaleEffect(scale, anchor: .topLeading)
+          // `alignment` is load-bearing, not decoration. `scaleEffect` draws smaller
+          // without changing the layout size, so this frame is being handed a box that is
+          // still full size — and centred, the default, it pulls that box left and up by
+          // half the difference, taking the drawing with it. At 0.78 on a 798pt board that
+          // put the first box eighty points off the leading edge, clipped.
+          .frame(
+            width: layout.size.width * scale, height: layout.size.height * scale,
+            alignment: .topLeading
+          )
+          // Centred when it does not fill the panel, rather than left-aligned. A four-box
+          // flow in a 460pt rail is 270 points wide, and hard against one edge it reads as
+          // a diagram that has been cut off.
+          .padding(.leading, max(0, (available - layout.size.width * scale) / 2))
+          .padding(.vertical, 2)
+      }
+      .scrollBounceBehavior(.basedOnSize)
+      .frame(height: ceiling.map { min(layout.size.height * scale + 4, $0) })
+      .frame(maxHeight: ceiling == nil ? .infinity : nil)
+      .onGeometryChange(for: CGFloat.self) {
+        $0.size.width
+      } action: {
+        available = $0
+      }
+    }
+  }
+
+  /// Fit to the width there is, down to the floor. Zero width is the first pass, before the
+  /// panel has been measured — full size then, corrected on the next.
+  private func scale(for layout: BoardLayout) -> CGFloat {
+    guard available > 0, layout.size.width > 0 else { return 1 }
+    return min(1, max(Self.minimumScale, available / layout.size.width))
+  }
+
+  private func diagram(_ layout: BoardLayout) -> some View {
+    ZStack(alignment: .topLeading) {
+      // One `Canvas` for every arrow rather than a shape view each: the edges are the part
+      // with no text in them, and drawing forty of them as separate views is forty layers
+      // for something that is one path.
+      Canvas { context, _ in
+        for edge in layout.edges {
+          context.stroke(
+            BoardArrow.path(for: edge), with: .color(.white.opacity(edge.isFeedback ? 0.22 : 0.34)),
+            style: BoardArrow.stroke(edge.edge.style))
+          context.fill(BoardArrow.head(for: edge), with: .color(.white.opacity(0.42)))
+        }
+      }
+      ForEach(layout.edges) { edge in
+        if let label = edge.edge.label, !label.isEmpty {
+          Text(label)
+            .font(.system(size: 9, weight: .medium))
+            .foregroundStyle(.white.opacity(0.62))
+            .lineLimit(1)
+            .padding(.horizontal, 3.5)
+            .padding(.vertical, 1)
+            .background(BoardPalette.surface, in: RoundedRectangle(cornerRadius: 3))
+            .position(edge.labelPoint)
+        }
+      }
+      ForEach(layout.nodes) { placed in
+        BoardNodeView(node: placed.node, accent: accent)
+          .frame(width: placed.frame.width, height: placed.frame.height)
+          .position(x: placed.frame.midX, y: placed.frame.midY)
+      }
+    }
+  }
+}
+
+private struct BoardNodeView: View {
+  let node: BoardNode
+  let accent: Color
+
+  var body: some View {
+    Text(node.text)
+      .font(.system(size: 11.5))
+      .foregroundStyle(.white.opacity(0.88))
+      .multilineTextAlignment(.center)
+      .padding(.horizontal, 4)
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .background(shape.fill(fill))
+      .overlay(shape.stroke(stroke, lineWidth: 1))
+      .help(node.text)
+  }
+
+  /// `AnyShape` rather than four branches drawing four backgrounds: the fill and the stroke
+  /// have to be the *same* outline or a diamond ends up with a rectangle's border.
+  private var shape: AnyShape {
+    switch node.shape {
+    case .box: return AnyShape(RoundedRectangle(cornerRadius: 4))
+    case .rounded: return AnyShape(RoundedRectangle(cornerRadius: 10))
+    case .terminal: return AnyShape(Capsule())
+    case .decision: return AnyShape(BoardDiamond())
+    }
+  }
+
+  /// Only two shapes are tinted — the branch and the end. Colouring every box would make
+  /// the accent mean "this is a box", and the whole point of the shapes is that the run's
+  /// structure is legible before a word is read.
+  private var fill: Color {
+    switch node.shape {
+    case .decision: return accent.opacity(0.16)
+    case .terminal: return accent.opacity(0.1)
+    default: return .white.opacity(0.05)
+    }
+  }
+
+  private var stroke: Color {
+    switch node.shape {
+    case .decision: return accent.opacity(0.5)
+    case .terminal: return accent.opacity(0.35)
+    default: return .white.opacity(0.14)
+    }
+  }
+}
+
+struct BoardDiamond: Shape {
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+    path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+    path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+    path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+    path.addLine(to: CGPoint(x: rect.minX, y: rect.midY))
+    path.closeSubpath()
+    return path
+  }
+}
+
+/// The arrows: the line, its dash pattern, and the head.
+enum BoardArrow {
+  static let headLength: CGFloat = 6
+  static let headWidth: CGFloat = 4.5
+  /// How far a straight arrow bows towards its own midpoint. A perfectly straight line
+  /// between two boxes that are not vertically aligned reads as a mistake; a slight curve
+  /// reads as a route.
+  static let bow: CGFloat = 0.42
+
+  static func stroke(_ style: BoardEdgeStyle) -> StrokeStyle {
+    switch style {
+    case .solid: return StrokeStyle(lineWidth: 1.2, lineCap: .round)
+    case .dashed: return StrokeStyle(lineWidth: 1.2, lineCap: .round, dash: [3, 3])
+    case .thick: return StrokeStyle(lineWidth: 2.1, lineCap: .round)
+    }
+  }
+
+  static func path(for edge: BoardLayout.PlacedEdge) -> Path {
+    var path = Path()
+    path.move(to: edge.start)
+    if edge.waypoints.isEmpty {
+      // A cubic whose controls sit on the *axis of travel* — straight out of the box it
+      // leaves and straight into the one it enters, however far sideways the two are. The
+      // spread pushes both controls the same way, which separates two arrows sharing a pair
+      // of boxes without either leaving its own ends.
+      // Offset along the axis of travel only. Adding the sideways component too made the
+      // curve arrive along the chord, and a box two columns over then took its arrow in
+      // the side of its top edge.
+      let travel = edge.axis == .topDown ? edge.end.y - edge.start.y : edge.end.x - edge.start.x
+      let reach = travel * bow
+      let control1 =
+        edge.axis == .topDown
+        ? CGPoint(x: edge.start.x + edge.spread, y: edge.start.y + reach)
+        : CGPoint(x: edge.start.x + reach, y: edge.start.y + edge.spread)
+      let control2 =
+        edge.axis == .topDown
+        ? CGPoint(x: edge.end.x + edge.spread, y: edge.end.y - reach)
+        : CGPoint(x: edge.end.x - reach, y: edge.end.y + edge.spread)
+      path.addCurve(to: edge.end, control1: control1, control2: control2)
+    } else {
+      // Orthogonal, with the corners rounded. A feedback arrow runs through the empty bands
+      // between layers, so its bends are right angles rather than a curve — and a right
+      // angle drawn sharp at 1.2pt reads as two lines that happen to meet.
+      var previous = edge.start
+      for (index, point) in edge.waypoints.enumerated() {
+        let next = index + 1 < edge.waypoints.count ? edge.waypoints[index + 1] : edge.end
+        path.addLine(to: shortened(point, towards: previous))
+        path.addQuadCurve(to: shortened(point, towards: next), control: point)
+        previous = point
+      }
+      path.addLine(to: edge.end)
+    }
+    return path
+  }
+
+  /// A point pulled back off a corner towards its neighbour, so the quadratic that rounds
+  /// the corner has somewhere to start. Never more than half the segment, or a short leg
+  /// would round past its own far end.
+  private static func shortened(_ corner: CGPoint, towards neighbour: CGPoint) -> CGPoint {
+    let dx = neighbour.x - corner.x
+    let dy = neighbour.y - corner.y
+    let length = max(sqrt(dx * dx + dy * dy), 0.001)
+    let radius = min(cornerRadius, length / 2)
+    return CGPoint(x: corner.x + dx / length * radius, y: corner.y + dy / length * radius)
+  }
+
+  static let cornerRadius: CGFloat = 6
+
+  /// A filled triangle at the arrow's end, pointing the way the last segment travels.
+  static func head(for edge: BoardLayout.PlacedEdge) -> Path {
+    let approach = edge.waypoints.last ?? edge.start
+    let dx = edge.end.x - approach.x
+    let dy = edge.end.y - approach.y
+    let length = max(sqrt(dx * dx + dy * dy), 0.001)
+    // A bowed arrow arrives along its own axis rather than along the chord — see
+    // `PlacedEdge.axis`. Only an elbowed route, whose last leg is a straight line, can take
+    // its direction from the two points that make that leg.
+    let unit: CGPoint
+    if edge.waypoints.isEmpty {
+      unit =
+        edge.axis == .topDown
+        ? CGPoint(x: 0, y: edge.end.y >= edge.start.y ? 1 : -1)
+        : CGPoint(x: edge.end.x >= edge.start.x ? 1 : -1, y: 0)
+    } else {
+      unit = CGPoint(x: dx / length, y: dy / length)
+    }
+    let base = CGPoint(
+      x: edge.end.x - unit.x * headLength, y: edge.end.y - unit.y * headLength)
+    let normal = CGPoint(x: -unit.y, y: unit.x)
+    var path = Path()
+    path.move(to: edge.end)
+    path.addLine(
+      to: CGPoint(x: base.x + normal.x * headWidth, y: base.y + normal.y * headWidth))
+    path.addLine(
+      to: CGPoint(x: base.x - normal.x * headWidth, y: base.y - normal.y * headWidth))
+    path.closeSubpath()
+    return path
+  }
+}
+
+// MARK: - Table
+
+private struct TableBoardView: View {
+  let board: SummaryBoard
+  let ceiling: CGFloat?
+
+  var body: some View {
+    if let table = board.table {
+      // Horizontally scrollable rather than squeezed: five columns at the rail's folded
+      // width is 40 points each, which is a column of ellipses.
+      ScrollView([.horizontal, .vertical]) {
+        Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 12, verticalSpacing: 0) {
+          GridRow {
+            ForEach(Array(table.headers.enumerated()), id: \.offset) { _, header in
+              Text(header)
+                .font(.system(size: 9.5, weight: .bold))
+                .tracking(0.5)
+                .foregroundStyle(.white.opacity(0.45))
+            }
+          }
+          .padding(.vertical, 5)
+          // Ruled, not striped. A `GridRow` background is applied to each *cell*, not across
+          // the row, so alternating fills came out as a ragged block behind each piece of
+          // text rather than as a band — worse than the plain rules it was meant to improve
+          // on.
+          ForEach(Array(table.normalisedRows.enumerated()), id: \.offset) { _, row in
+            Divider().overlay(.white.opacity(0.07)).gridCellUnsizedAxes(.horizontal)
+            GridRow {
+              ForEach(Array(row.enumerated()), id: \.offset) { column, cell in
+                Text(cell)
+                  .font(.system(size: 11, design: column == 0 ? .default : .monospaced))
+                  .foregroundStyle(.white.opacity(column == 0 ? 0.85 : 0.65))
+                  .fixedSize(horizontal: false, vertical: true)
+              }
+            }
+            .padding(.vertical, 5)
+          }
+        }
+        .padding(.horizontal, 2)
+      }
+      .scrollBounceBehavior(.basedOnSize)
+      .frame(maxHeight: ceiling ?? .infinity)
+    } else {
+      BoardSourceView(source: board.source)
+    }
+  }
+}
+
+// MARK: - Fallback
+
+/// What a board looks like when this build cannot draw it: its own source, as code.
+///
+/// The honest outcome rather than a failure state, and the reason `SummaryBoard.source` is
+/// the field the composer actually produces. A diagram type the parser does not read is
+/// still a diagram — it renders anywhere else that speaks Mermaid, and the copy button in
+/// the section header is how it gets there.
+struct BoardSourceView: View {
+  let source: String
+
+  var body: some View {
+    ScrollView([.horizontal, .vertical]) {
+      Text(source)
+        .font(.system(size: 10, design: .monospaced))
+        .foregroundStyle(.white.opacity(0.6))
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+    }
+    .scrollBounceBehavior(.basedOnSize)
+    .background(BoardPalette.surface, in: RoundedRectangle(cornerRadius: 6))
+  }
+}
+
+enum BoardPalette {
+  /// The same #16161a `RailMinimap` sits on, so the two panels in one rail read as one
+  /// surface rather than two.
+  static let surface = Color(red: 0.086, green: 0.086, blue: 0.102)
+}

--- a/graphcode/Sources/Features/LoopWorkspace/SummaryBoardView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/SummaryBoardView.swift
@@ -286,54 +286,6 @@ enum BoardArrow {
   }
 }
 
-// MARK: - Table
-
-private struct TableBoardView: View {
-  let board: SummaryBoard
-  let ceiling: CGFloat?
-
-  var body: some View {
-    if let table = board.table {
-      // Horizontally scrollable rather than squeezed: five columns at the rail's folded
-      // width is 40 points each, which is a column of ellipses.
-      ScrollView([.horizontal, .vertical]) {
-        Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 12, verticalSpacing: 0) {
-          GridRow {
-            ForEach(Array(table.headers.enumerated()), id: \.offset) { _, header in
-              Text(header)
-                .font(.system(size: 9.5, weight: .bold))
-                .tracking(0.5)
-                .foregroundStyle(.white.opacity(0.45))
-            }
-          }
-          .padding(.vertical, 5)
-          // Ruled, not striped. A `GridRow` background is applied to each *cell*, not across
-          // the row, so alternating fills came out as a ragged block behind each piece of
-          // text rather than as a band — worse than the plain rules it was meant to improve
-          // on.
-          ForEach(Array(table.normalisedRows.enumerated()), id: \.offset) { _, row in
-            Divider().overlay(.white.opacity(0.07)).gridCellUnsizedAxes(.horizontal)
-            GridRow {
-              ForEach(Array(row.enumerated()), id: \.offset) { column, cell in
-                Text(cell)
-                  .font(.system(size: 11, design: column == 0 ? .default : .monospaced))
-                  .foregroundStyle(.white.opacity(column == 0 ? 0.85 : 0.65))
-                  .fixedSize(horizontal: false, vertical: true)
-              }
-            }
-            .padding(.vertical, 5)
-          }
-        }
-        .padding(.horizontal, 2)
-      }
-      .scrollBounceBehavior(.basedOnSize)
-      .frame(maxHeight: ceiling ?? .infinity)
-    } else {
-      BoardSourceView(source: board.source)
-    }
-  }
-}
-
 // MARK: - Fallback
 
 /// What a board looks like when this build cannot draw it: its own source, as code.
@@ -360,6 +312,11 @@ struct BoardSourceView: View {
 }
 
 enum BoardPalette {
+  /// The same green a succeeded card wears, and the same red the app already uses for a
+  /// failure — a verdict in a table must not invent its own vocabulary.
+  static let affirm = Color(red: 0.188, green: 0.820, blue: 0.345)  // #30d158
+  static let deny = Color(red: 1.0, green: 0.271, blue: 0.227)  // #ff453a
+
   /// The same #16161a `RailMinimap` sits on, so the two panels in one rail read as one
   /// surface rather than two.
   static let surface = Color(red: 0.086, green: 0.086, blue: 0.102)

--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -136,6 +136,21 @@ struct SettingsView: View {
           .fixedSize(horizontal: false, vertical: true)
 
         Toggle(
+          "Visualise what loops did (experimental)",
+          isOn: $model.settings.visualisesSummaries
+        )
+        .disabled(!model.settings.summarisesLoops)
+        Text(
+          "Draws each finished pass as a flowchart or a table, under the summary in the "
+            + "loop's rail. One short call to your backend's CLI per pass — not per "
+            + "change — and most passes are drawn as nothing, because most passes have no "
+            + "shape worth a diagram. The Mermaid is copyable."
+        )
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+        Toggle(
           "Daemon heartbeat (experimental)",
           isOn: $model.settings.daemonHeartbeatEnabled)
         Text(

--- a/graphcode/Tests/BoardExportTests.swift
+++ b/graphcode/Tests/BoardExportTests.swift
@@ -1,0 +1,243 @@
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// The `.excalidraw` file a board exports to.
+///
+/// Every assertion here is about the *format* rather than about the picture, because the
+/// picture has already been laid out and tested: this is a serialiser over geometry
+/// `BoardLayout` computed. What can go wrong is exactly what a schema-shaped format lets go
+/// wrong — a field the app that reads it needs and this one did not write, or a coordinate
+/// in the wrong space.
+@Suite
+struct BoardExportTests {
+
+  private func board() throws -> SummaryBoard {
+    try #require(
+      MermaidBoardParser.board(
+        fromReply: """
+          %% title: Release gate
+          flowchart TD
+            A([Start]) --> B[Build it]
+            B --> C{Green?}
+            C -->|yes| D([Ship])
+            C -.->|no| B
+          """, pass: 4, now: Date(timeIntervalSince1970: 0)))
+  }
+
+  private func document() throws -> [String: Any] {
+    let subject = try board()
+    return BoardExcalidrawExport.document(
+      for: subject, layout: BoardLayout(board: subject),
+      now: Date(timeIntervalSince1970: 1_700_000_000))
+  }
+
+  private func elements(_ document: [String: Any]) -> [[String: Any]] {
+    document["elements"] as? [[String: Any]] ?? []
+  }
+
+  @Test
+  func theFileHasTheTopLevelShapeExcalidrawExpects() throws {
+    let file = try document()
+    #expect(file["type"] as? String == "excalidraw")
+    #expect(file["version"] as? Int == BoardExcalidrawExport.schemaVersion)
+    #expect(file["source"] is String)
+    #expect(file["files"] is [String: Any])
+    #expect(file["appState"] is [String: Any])
+    #expect(!elements(file).isEmpty)
+  }
+
+  @Test
+  func everyElementCarriesTheFieldsTheSchemaRequires() throws {
+    // From `_ExcalidrawElementBase`. A reader that finds one of these missing does not
+    // fail loudly — it draws the element wrong, or not at all.
+    let required = [
+      "id", "type", "x", "y", "width", "height", "angle", "strokeColor", "backgroundColor",
+      "fillStyle", "strokeWidth", "strokeStyle", "roughness", "opacity", "groupIds",
+      "frameId", "roundness", "seed", "version", "versionNonce", "isDeleted",
+      "boundElements", "updated", "link", "locked",
+    ]
+    for element in elements(try document()) {
+      let type = element["type"] as? String ?? "?"
+      for key in required {
+        #expect(element[key] != nil, "\(type) element is missing \(key)")
+      }
+    }
+  }
+
+  @Test
+  func eachBoxBecomesAShapeOfTheRightKind() throws {
+    let byID = Dictionary(
+      elements(try document()).compactMap { element -> (String, [String: Any])? in
+        guard let id = element["id"] as? String else { return nil }
+        return (id, element)
+      }, uniquingKeysWith: { first, _ in first })
+
+    #expect(byID["gc-box-A"]?["type"] as? String == "ellipse")  // ([Start])
+    #expect(byID["gc-box-B"]?["type"] as? String == "rectangle")  // [Build it]
+    #expect(byID["gc-box-C"]?["type"] as? String == "diamond")  // {Green?}
+    #expect(byID["gc-box-D"]?["type"] as? String == "ellipse")  // ([Ship])
+  }
+
+  /// A bound label moves, wraps and re-centres with its box. An unbound one is a separate
+  /// object that is left behind the first time anybody drags anything — which is the whole
+  /// reason to export to an editor rather than to an image.
+  @Test
+  func everyLabelIsBoundToItsBoxInBothDirections() throws {
+    let all = elements(try document())
+    let shapes = all.filter {
+      ($0["type"] as? String).map { $0 != "text" && $0 != "arrow" } == true
+    }
+    // Box labels only — an arrow's label is bound the same way but to an arrow, and has its
+    // own test below.
+    let texts = all.filter { element in
+      guard element["type"] as? String == "text" else { return false }
+      let container = element["containerId"] as? String
+      return shapes.contains { $0["id"] as? String == container }
+    }
+    #expect(texts.count == shapes.count)
+
+    for text in texts {
+      let container = try #require(text["containerId"] as? String)
+      let box = try #require(shapes.first { $0["id"] as? String == container })
+      let bound = try #require(box["boundElements"] as? [[String: String]])
+      #expect(bound.contains { $0["id"] == text["id"] as? String && $0["type"] == "text" })
+      // The fields Excalidraw needs to lay text out inside a container.
+      for key in [
+        "text", "originalText", "fontSize", "fontFamily", "textAlign",
+        "verticalAlign", "lineHeight",
+      ] {
+        #expect(text[key] != nil, "text element is missing \(key)")
+      }
+    }
+  }
+
+  /// **The one mistake this format invites.** `points` are local to the arrow, not to the
+  /// canvas: the first is always the origin and the rest are offsets from it. Absolute
+  /// coordinates draw every arrow at twice its intended distance from the origin.
+  @Test
+  func arrowPointsAreLocalToTheArrowAndStartAtItsOrigin() throws {
+    let arrows = elements(try document()).filter { $0["type"] as? String == "arrow" }
+    #expect(!arrows.isEmpty)
+
+    for arrow in arrows {
+      let points = try #require(arrow["points"] as? [[CGFloat]])
+      #expect(points.count >= 2)
+      #expect(points[0] == [0, 0])
+      let width = try #require(arrow["width"] as? CGFloat)
+      let height = try #require(arrow["height"] as? CGFloat)
+      // The frame has to cover every point, or the element's own bounding box is wrong and
+      // selecting it in Excalidraw grabs the wrong area.
+      #expect(points.allSatisfy { abs($0[0]) <= width + 0.001 })
+      #expect(points.allSatisfy { abs($0[1]) <= height + 0.001 })
+    }
+  }
+
+  @Test
+  func aDashedLinkStaysDashed() throws {
+    let arrows = elements(try document()).filter { $0["type"] as? String == "arrow" }
+    #expect(arrows.filter { $0["strokeStyle"] as? String == "dashed" }.count == 1)
+    #expect(arrows.allSatisfy { $0["endArrowhead"] as? String == "arrow" })
+  }
+
+  /// **An arrow label is a bound text element, not a field on the arrow.**
+  /// `ExcalidrawLinearElement` has no `label` property, so writing one produces a file that
+  /// opens without complaint and has no edge labels on it — which for a flowchart of
+  /// decisions loses the half that says which branch is which.
+  @Test
+  func edgeLabelsAreBoundTextRatherThanAFieldOnTheArrow() throws {
+    let all = elements(try document())
+    let arrows = all.filter { $0["type"] as? String == "arrow" }
+    #expect(arrows.allSatisfy { $0["label"] == nil })
+
+    // Two labelled links in the fixture: `-->|yes|` and `-.->|no|`.
+    let labelled = arrows.filter { $0["boundElements"] is [[String: String]] }
+    #expect(labelled.count == 2)
+
+    let texts = all.filter { $0["type"] as? String == "text" }
+    for arrow in labelled {
+      let bound = try #require(arrow["boundElements"] as? [[String: String]])
+      let textID = try #require(bound.first?["id"])
+      let text = try #require(texts.first { $0["id"] as? String == textID })
+      #expect(text["containerId"] as? String == arrow["id"] as? String)
+    }
+    #expect(
+      Set(texts.compactMap { $0["text"] as? String })
+        .isSuperset(of: ["yes", "no"]))
+  }
+
+  /// **A zero-sized text element is discarded by Excalidraw's `restore`.** Verified by
+  /// importing a file written that way: every box label came back and every arrow label was
+  /// gone, silently. A flowchart of decisions that loses its yes and its no is a flowchart
+  /// of nothing.
+  /// The exported drawing is bigger than the one on screen, and uniformly so — see
+  /// `exportScale`. A box that kept its screen size would have its 16pt hand-drawn label
+  /// overflow it, which is what the first version did.
+  @Test
+  func theWholeDrawingIsScaledByTheSameFactor() throws {
+    let subject = try board()
+    let layout = BoardLayout(board: subject)
+    let file = BoardExcalidrawExport.document(for: subject, layout: layout)
+    let boxes = elements(file).filter { $0["id"] as? String == "gc-box-B" }
+    let onScreen = try #require(layout.nodes.first { $0.id == "B" }?.frame)
+    let exported = try #require(boxes.first)
+
+    let width = try #require(exported["width"] as? CGFloat)
+    let originX = try #require(exported["x"] as? CGFloat)
+    #expect(abs(width - onScreen.width * BoardExcalidrawExport.exportScale) < 0.001)
+    #expect(abs(originX - onScreen.minX * BoardExcalidrawExport.exportScale) < 0.001)
+
+    // Arrows are scaled by the same factor or they stop meeting the boxes.
+    let arrow = try #require(
+      elements(file).first { $0["id"] as? String == "gc-edge-A-B-" })
+    let arrowX = try #require(arrow["x"] as? CGFloat)
+    let start = try #require(layout.edges.first { $0.edge.from == "A" }?.start)
+    #expect(abs(arrowX - start.x * BoardExcalidrawExport.exportScale) < 0.001)
+  }
+
+  @Test
+  func everyTextElementHasARealSize() throws {
+    let texts = elements(try document()).filter { $0["type"] as? String == "text" }
+    #expect(!texts.isEmpty)
+    for text in texts {
+      let width = try #require(text["width"] as? CGFloat)
+      let height = try #require(text["height"] as? CGFloat)
+      #expect(width > 0, "\(text["text"] as? String ?? "?") has no width")
+      #expect(height > 0, "\(text["text"] as? String ?? "?") has no height")
+    }
+  }
+
+  /// Dark ink, because the file opens on white paper. The rail's own near-white strokes
+  /// would be an export nobody can see, which is worse than no export.
+  @Test
+  func theExportUsesInkThatShowsOnAWhiteCanvas() throws {
+    for element in elements(try document()) {
+      let stroke = try #require(element["strokeColor"] as? String)
+      #expect(stroke != "transparent")
+      #expect(!stroke.lowercased().hasPrefix("#ff"), "\(stroke) will not read on white")
+    }
+  }
+
+  /// Exporting the same board twice must produce the same bytes, or every export is a diff
+  /// against the last one. Only `updated` is a clock, and it is passed in.
+  @Test
+  func theSameBoardExportsToTheSameBytes() throws {
+    let subject = try board()
+    let layout = BoardLayout(board: subject)
+    let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+    let first = try BoardExcalidrawExport.data(for: subject, layout: layout, now: stamp)
+    let second = try BoardExcalidrawExport.data(for: subject, layout: layout, now: stamp)
+    #expect(first == second)
+  }
+
+  @Test
+  func theWholeFileIsValidJSON() throws {
+    let subject = try board()
+    let data = try BoardExcalidrawExport.data(
+      for: subject, layout: BoardLayout(board: subject))
+    let reparsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    #expect(reparsed?["type"] as? String == "excalidraw")
+  }
+}

--- a/graphcode/Tests/BoardLayoutTests.swift
+++ b/graphcode/Tests/BoardLayoutTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// Where the boxes end up. The layout is the half of the board feature that has arithmetic
+/// in it, and arithmetic that can only be checked by looking at a window is arithmetic
+/// nobody checks.
+@Suite
+struct BoardLayoutTests {
+
+  private func board(
+    _ edges: [(String, String)], direction: BoardDirection = .topDown,
+    nodes: [BoardNode]? = nil
+  ) -> SummaryBoard {
+    let ids = nodes?.map(\.id) ?? Array(Set(edges.flatMap { [$0.0, $0.1] })).sorted()
+    return SummaryBoard(
+      form: .flow, direction: direction,
+      nodes: nodes ?? ids.map { BoardNode(id: $0, text: $0) },
+      edges: edges.map { BoardEdge(from: $0.0, to: $0.1) },
+      source: "", pass: 1)
+  }
+
+  private func layer(_ layout: BoardLayout, _ id: String) -> CGFloat? {
+    layout.nodes.first { $0.id == id }?.frame.minY
+  }
+
+  @Test
+  func aChainDescendsOneLayerAtATime() throws {
+    let layout = BoardLayout(board: board([("A", "B"), ("B", "C")]))
+    let first = try #require(layer(layout, "A"))
+    let second = try #require(layer(layout, "B"))
+    let third = try #require(layer(layout, "C"))
+
+    #expect(first < second)
+    #expect(second < third)
+  }
+
+  /// Longest path, not shortest: a step with two prerequisites belongs *under both*, or the
+  /// arrow from the deeper one runs backwards up the diagram.
+  @Test
+  func aJoinSitsBelowItsDeepestPrerequisite() throws {
+    let layout = BoardLayout(board: board([("A", "B"), ("B", "C"), ("A", "C")]))
+    let branch = try #require(layer(layout, "B"))
+    let join = try #require(layer(layout, "C"))
+
+    #expect(branch < join)
+  }
+
+  /// The commonest shape a real run has — a check that sends you back to the work. Without
+  /// cycle-breaking there is no topological order at all and the layout has nothing to do.
+  @Test
+  func aRetryLoopStillHasLayersAndIsRoutedRound() throws {
+    let layout = BoardLayout(
+      board: board([("A", "B"), ("B", "C"), ("C", "B"), ("C", "D")]))
+
+    #expect(layout.nodes.count == 4)
+    let feedback = layout.edges.filter(\.isFeedback)
+    #expect(feedback.map(\.edge.from) == ["C"])
+    #expect(feedback.map(\.edge.to) == ["B"])
+  }
+
+  /// **The invariant a retry arrow actually has to hold.** Boxes are drawn over the arrows,
+  /// so a feedback route that crosses one does not look like a mistake — the arrow simply
+  /// vanishes behind it, and a diagram whose whole point is the loop appears to have none.
+  /// That is precisely what the first routing did: out of the source's right side, at the
+  /// same height as every other box in its row.
+  @Test
+  func afeedbackArrowCrossesNoBoxOnItsWayBack() {
+    let layout = BoardLayout(
+      board: board([
+        // Two retries, each with a sibling sitting between the arrow and its lane.
+        ("A", "B"), ("B", "C"), ("C", "D"), ("D", "E"), ("E", "F"),
+        ("D", "G"), ("E", "H"), ("F", "B"), ("H", "D"),
+      ]))
+    let feedback = layout.edges.filter(\.isFeedback)
+    #expect(!feedback.isEmpty)
+
+    for edge in feedback {
+      let ends: Set<String> = [edge.edge.from, edge.edge.to]
+      let points = [edge.start] + edge.waypoints + [edge.end]
+      for (start, end) in zip(points, points.dropFirst()) {
+        for placed in layout.nodes where !ends.contains(placed.id) {
+          #expect(
+            !Self.segment(start, end, crosses: placed.frame),
+            "\(edge.edge.from)→\(edge.edge.to) runs through \(placed.id)")
+        }
+      }
+    }
+  }
+
+  /// Sampled rather than solved. A segment/rectangle intersection is a page of code to get
+  /// right and this is a test — sixty points along a leg catches any crossing wide enough
+  /// to hide a box behind.
+  private static func segment(_ start: CGPoint, _ end: CGPoint, crosses rect: CGRect) -> Bool {
+    let box = rect.insetBy(dx: 0.5, dy: 0.5)
+    return (0...60).contains { step in
+      let fraction = CGFloat(step) / 60
+      return box.contains(
+        CGPoint(
+          x: start.x + (end.x - start.x) * fraction,
+          y: start.y + (end.y - start.y) * fraction))
+    }
+  }
+
+  /// Two arrows joining the same pair of boxes must not land on top of each other: drawn
+  /// straight they are one line with two labels stacked on one point, and the second label
+  /// is simply invisible.
+  @Test
+  func twoArrowsBetweenTheSamePairAreHeldApart() {
+    let layout = BoardLayout(
+      board: SummaryBoard(
+        form: .flow,
+        nodes: [BoardNode(id: "A", text: "A", shape: .decision), BoardNode(id: "B", text: "B")],
+        edges: [
+          BoardEdge(from: "A", to: "B", label: "yes"),
+          BoardEdge(from: "A", to: "B", label: "no"),
+        ], source: "", pass: 1))
+
+    let labels = layout.edges.map(\.labelPoint)
+    #expect(labels.count == 2)
+    #expect(labels[0] != labels[1])
+    #expect(abs(labels[0].x - labels[1].x) >= BoardLayout.parallelSpread - 0.001)
+  }
+
+  @Test
+  func everythingIsDrawnInsideTheSizeItReports() {
+    let layout = BoardLayout(
+      board: board([("A", "B"), ("A", "C"), ("B", "D"), ("C", "D"), ("D", "A")]))
+
+    #expect(layout.size.width > 0)
+    #expect(layout.size.height > 0)
+    #expect(layout.nodes.allSatisfy { $0.frame.minX >= 0 && $0.frame.minY >= 0 })
+    #expect(layout.nodes.allSatisfy { $0.frame.maxX <= layout.size.width + 0.5 })
+    #expect(layout.nodes.allSatisfy { $0.frame.maxY <= layout.size.height + 0.5 })
+  }
+
+  @Test
+  func siblingsNeverOverlap() {
+    let layout = BoardLayout(
+      board: board([
+        ("A", "B"), ("A", "C"), ("A", "D"), ("A", "E"),
+        ("B", "F"), ("C", "F"), ("D", "G"), ("E", "G"),
+      ]))
+
+    for first in layout.nodes {
+      for second in layout.nodes where first.id != second.id {
+        #expect(!first.frame.insetBy(dx: 0.5, dy: 0.5).intersects(second.frame))
+      }
+    }
+  }
+
+  @Test
+  func anLRBoardRunsAcrossRatherThanDown() throws {
+    let layout = BoardLayout(board: board([("A", "B"), ("B", "C")], direction: .leftRight))
+    let head = try #require(layout.nodes.first { $0.id == "A" }?.frame)
+    let tail = try #require(layout.nodes.first { $0.id == "C" }?.frame)
+
+    #expect(head.maxX <= tail.minX)
+    // And the boxes keep the size their labels measured to — transposing positions must
+    // not transpose the boxes themselves into tall slivers.
+    #expect(head.width > head.height)
+  }
+
+  /// A diamond wastes its corners, so the same words need a bigger box inside one.
+  @Test
+  func aDecisionIsGivenRoomForItsCorners() {
+    let plain = BoardLayout.nodeSize(BoardNode(id: "A", text: "Did it work", shape: .box))
+    let diamond = BoardLayout.nodeSize(
+      BoardNode(id: "A", text: "Did it work", shape: .decision))
+
+    #expect(diamond.width > plain.width)
+    #expect(diamond.height > plain.height)
+  }
+
+  /// Two polls of an unchanged board must draw the same picture — a diagram that shuffles
+  /// itself between ticks is one nobody trusts.
+  @Test
+  func theSameBoardLaysOutTheSameWayTwice() {
+    let subject = board([("A", "B"), ("A", "C"), ("B", "D"), ("C", "D")])
+    #expect(BoardLayout(board: subject) == BoardLayout(board: subject))
+  }
+
+  @Test
+  func aTableOrAOneBoxFlowLaysOutToNothing() {
+    #expect(
+      BoardLayout(
+        board: SummaryBoard(
+          form: .table, table: BoardTable(headers: ["a"], rows: [["b"]]), source: "", pass: 1)
+      ).nodes.isEmpty)
+    #expect(BoardLayout(board: board([], nodes: [BoardNode(id: "A", text: "A")])).nodes.isEmpty)
+  }
+}

--- a/graphcode/Tests/BoardTablePresentationTests.swift
+++ b/graphcode/Tests/BoardTablePresentationTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// What a table cell is taken to be, which is the half of the table renderer that can be
+/// wrong about something.
+///
+/// Drawing a cell as a green tick is a *claim* that it is a verdict, and the interesting
+/// cases here are all the near-misses: the word `pass` inside a phrase, a bare number that
+/// is not a diffstat, a column that is numeric except for one `n/a`.
+@Suite
+struct BoardTablePresentationTests {
+
+  private func table(
+    _ headers: [String], _ rows: [[String]], alignments: [BoardColumnAlignment] = []
+  ) -> BoardTablePresentation {
+    BoardTablePresentation(
+      table: BoardTable(headers: headers, rows: rows, alignments: alignments))
+  }
+
+  // MARK: - Columns
+
+  @Test
+  func aColumnIsNumericOnlyWhenEveryCellIs() {
+    let clean = table(["File", "Lines"], [["a.swift", "438"], ["b.swift", "12"]])
+    #expect(clean.columns.map(\.isNumeric) == [false, true])
+
+    // One `n/a` and the column stops being a column of numbers — otherwise a single stray
+    // cell leaves the rest right-aligned around nothing.
+    let ragged = table(["File", "Lines"], [["a.swift", "438"], ["b.swift", "n/a"]])
+    #expect(ragged.columns.map(\.isNumeric) == [false, false])
+  }
+
+  @Test
+  func numbersGoRightUnlessTheAuthorSaidOtherwise() {
+    let inferred = table(["File", "Lines"], [["a", "1"], ["b", "2"]])
+    #expect(inferred.columns.map(\.effectiveAlignment) == [.leading, .trailing])
+
+    // The separator row always wins: it is the author being explicit, and the parser has
+    // read it since before boards could draw a table properly.
+    let stated = table(
+      ["File", "Lines"], [["a", "1"], ["b", "2"]], alignments: [.center, .leading])
+    #expect(stated.columns.map(\.effectiveAlignment) == [.center, .leading])
+  }
+
+  @Test
+  func barsNeedEnoughRowsAndSomeActualSpread() {
+    #expect(table(["N"], [["1"], ["9"]]).columns[0].showsBars == false)
+    #expect(table(["N"], [["4"], ["4"], ["4"]]).columns[0].showsBars == false)
+    #expect(table(["N"], [["1"], ["5"], ["9"]]).columns[0].showsBars)
+  }
+
+  /// A bar compares a value with its own column, never with the table — otherwise a column
+  /// of percentages beside a column of line counts draws every percentage as empty.
+  @Test
+  func aBarIsScaledWithinItsOwnColumn() throws {
+    let subject = table(
+      ["Small", "Large"], [["1", "1000"], ["5", "5000"], ["9", "9000"]])
+    guard case .number(_, let small) = subject.rows[1][0],
+      case .number(_, let large) = subject.rows[1][1]
+    else {
+      Issue.record("expected two numeric cells")
+      return
+    }
+    #expect(try #require(small) == 0.5)
+    #expect(try #require(large) == 0.5)
+  }
+
+  // MARK: - Cells
+
+  @Test
+  func theWordsAVerdictIsWrittenInAreRecognised() {
+    for word in ["yes", "PASS", "ok", "true", "✅", "clean"] {
+      #expect(BoardTablePresentation.verdict(of: word) == true, "\(word)")
+    }
+    for word in ["no", "FAIL", "error", "false", "❌", "broken"] {
+      #expect(BoardTablePresentation.verdict(of: word) == false, "\(word)")
+    }
+  }
+
+  /// **The one that would be actively misleading.** `pass` is a verdict; `pass 3` is a
+  /// phrase about which pass, and a column of pass numbers drawn as green ticks is exactly
+  /// the confidently-wrong rendering this whole feature is meant to avoid.
+  @Test
+  func aVerdictWordInsideAPhraseIsNotAVerdict() {
+    #expect(BoardTablePresentation.verdict(of: "pass 3") == nil)
+    #expect(BoardTablePresentation.verdict(of: "no changes") == nil)
+    #expect(BoardTablePresentation.verdict(of: "okay then") == nil)
+
+    let subject = table(["Pass", "Result"], [["pass 3", "pass"], ["pass 4", "fail"]])
+    #expect(subject.rows[0][0] == .plain("pass 3"))
+    #expect(subject.rows[0][1] == .verdict(true, "pass"))
+    #expect(subject.rows[1][1] == .verdict(false, "fail"))
+  }
+
+  @Test
+  func onlyASignedNumberIsADiffstat() {
+    let subject = table(["File", "Change"], [["a", "+52"], ["b", "-9"], ["c", "52"]])
+    #expect(subject.rows[0][1] == .delta(isAddition: true, text: "+52"))
+    #expect(subject.rows[1][1] == .delta(isAddition: false, text: "-9"))
+    // A bare count is never a delta, so a column of plain numbers is left alone.
+    if case .delta = subject.rows[2][1] {
+      Issue.record("52 was read as a diffstat")
+    }
+  }
+
+  @Test
+  func numbersArePickedOutOfTheFormsPeopleWriteThemIn() {
+    #expect(BoardTablePresentation.number(from: "1,024") == 1024)
+    #expect(BoardTablePresentation.number(from: "93%") == 93)
+    #expect(BoardTablePresentation.number(from: "1.4k") == 1400)
+    #expect(BoardTablePresentation.number(from: "250ms") == 250)
+    #expect(BoardTablePresentation.number(from: "−9") == -9)
+    #expect(BoardTablePresentation.number(from: "GraphStore.swift") == nil)
+    #expect(BoardTablePresentation.number(from: "3 files") == nil)
+    #expect(BoardTablePresentation.number(from: "") == nil)
+  }
+}

--- a/graphcode/Tests/BoardsOffRegressionTests.swift
+++ b/graphcode/Tests/BoardsOffRegressionTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// What the app does when nobody has switched the experiment on — which is every install
+/// by default, and therefore the only behaviour most people will ever see.
+///
+/// The bar is not "the feature is hidden". It is that **nothing observable changed**: no
+/// process is spawned, no byte is added to a graph file, no extra broadcast is sent, and
+/// every surface answers exactly what it answered before boards existed. A dormant feature
+/// that still costs a subprocess, or still marks the graph dirty every fifteen seconds, has
+/// regressed the app for the people who never asked for it.
+@Suite
+struct BoardsOffRegressionTests {
+
+  private func node(_ title: String, passes: Int) -> LoopNode {
+    var node = LoopNode(
+      title: title, loopType: .goalBased, goal: GoalSpec(summary: "done"), state: .running)
+    node.summary = LoopSummary(
+      beats: [
+        SummaryBeat(
+          id: "\(title)-b", at: Date(timeIntervalSince1970: 10), pass: passes,
+          kind: .editing, text: "Editing the thing")
+      ],
+      passes: (1..<max(passes, 1)).map { PassSummary(pass: $0, text: "did pass \($0)") },
+      currentPass: passes)
+    return node
+  }
+
+  private func graph(_ nodes: [LoopNode]) -> LoopGraph {
+    var graph = LoopGraph(scope: LoopGraphScope(projectPath: "/tmp/p", name: "p"))
+    for node in nodes { graph.nodes.append(node) }
+    return graph
+  }
+
+  private actor Probe {
+    private(set) var asked = 0
+    func compose() -> SummaryBoard? {
+      asked += 1
+      return nil
+    }
+  }
+
+  /// Counts what the daemon tells its clients, which is also what it writes to disk.
+  private final class Writes: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    func record() { lock.withLock { count += 1 } }
+    var value: Int { lock.withLock { count } }
+  }
+
+  // MARK: - Nothing runs
+
+  @Test
+  func noComposerIsEverInvokedAndNoBoardIsEverSet() async {
+    let probe = Probe()
+    let store = GraphStore(
+      graph: graph([node("A", passes: 4), node("B", passes: 7)]),
+      onReadPresence: { _, _ in PresenceReading(presence: .busy, confidence: .reported) },
+      onComposeBoard: { _, _, _ in await probe.compose() },
+      onBoardsEnabled: { false })
+    let descriptor = open("/dev/null", O_WRONLY)
+    await store.addConnection(id: UUID(), fileDescriptor: descriptor)
+    defer { close(descriptor) }
+
+    for _ in 0..<5 { await store.pollPresence() }
+
+    #expect(await probe.asked == 0)
+    #expect(await store.graph.nodes.allSatisfy { $0.board == nil })
+  }
+
+  /// **The quiet regression.** `refreshBoards` runs on every tick whether or not the
+  /// experiment is on. If it reported a change it had not made, the daemon would write the
+  /// graph to disk and broadcast to every client every fifteen seconds, for ever, on behalf
+  /// of a feature nobody switched on — the exact cost `PresencePollingTests` exists to keep
+  /// out of the poll.
+  @Test
+  func thePollDoesNotReportAChangeItDidNotMake() async {
+    let writes = Writes()
+    let store = GraphStore(
+      graph: graph([node("A", passes: 4)]),
+      onGraphChanged: { _ in writes.record() },
+      onReadPresence: { _, _ in PresenceReading(presence: .busy, confidence: .reported) },
+      onComposeBoard: { _, _, _ in nil },
+      onBoardsEnabled: { false })
+    let descriptor = open("/dev/null", O_WRONLY)
+    await store.addConnection(id: UUID(), fileDescriptor: descriptor)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    let settled = writes.value
+    for _ in 0..<5 { await store.pollPresence() }
+
+    #expect(writes.value == settled, "the graph was written on a tick that changed nothing")
+  }
+
+  // MARK: - Nothing on screen moves
+
+  /// The rail's own answer, with the board switch off, must be the one it gave before the
+  /// board section existed: edges, or a metric series, or a beat — and nothing else.
+  @Test
+  func theRailOpensOnExactlyWhatItAlwaysOpenedOn() {
+    var wired = node("wired", passes: 2)
+    var lonely = node("lonely", passes: 2)
+    // A board left on a node by a previous switch-on must not reopen the rail either.
+    lonely.board = SummaryBoard(
+      form: .flow,
+      nodes: [BoardNode(id: "A", text: "one"), BoardNode(id: "B", text: "two")],
+      edges: [BoardEdge(from: "A", to: "B")], source: "", pass: 2)
+    var measured = node("measured", passes: 2)
+    measured.metricHistory = [
+      MetricSample(value: 1, recordedAt: Date(timeIntervalSince1970: 1)),
+      MetricSample(value: 2, recordedAt: Date(timeIntervalSince1970: 2)),
+    ]
+    wired.summary = nil
+    lonely.summary = nil
+    measured.summary = nil
+
+    var subject = LoopGraph(scope: LoopGraphScope(projectPath: "/tmp/p", name: "p"))
+    subject.nodes.append(wired)
+    subject.nodes.append(lonely)
+    subject.nodes.append(measured)
+    subject.edges.append(LoopEdge(from: wired.id, to: measured.id, condition: .onSuccess))
+
+    for node in [wired, lonely, measured] {
+      let opens = LoopWorkspaceRail.hasContent(
+        node: node, graph: subject, summarising: false, drawing: false)
+      // wired has an edge, measured has two samples, lonely has neither — and a board it
+      // is not allowed to count.
+      #expect(opens == (node.id != lonely.id), "\(node.title)")
+    }
+  }
+
+  @Test
+  func theBoardSectionNeverClaimsContentWhileTheSwitchIsOff() {
+    var drawn = node("drawn", passes: 3)
+    drawn.board = SummaryBoard(
+      form: .flow,
+      nodes: [BoardNode(id: "A", text: "one"), BoardNode(id: "B", text: "two")],
+      edges: [BoardEdge(from: "A", to: "B")], source: "", pass: 3)
+    drawn.presence = PresenceReading(presence: .busy, confidence: .reported)
+
+    #expect(!SummaryBoardPresentation.hasContent(node: drawn, drawing: false))
+    // And with it on, the same node does — so the assertion above is about the switch and
+    // not about the node being empty.
+    #expect(SummaryBoardPresentation.hasContent(node: drawn, drawing: true))
+  }
+
+  // MARK: - Nothing on disk changes
+
+  /// A graph file written by this build, for a loop that never drew a board, must carry no
+  /// trace of the feature — same keys, same size, readable by the build before this one.
+  @Test
+  func aNodeWithoutABoardAddsNothingToTheGraphFile() throws {
+    let plain = node("A", passes: 3)
+    #expect(plain.board == nil)
+
+    let data = try JSONEncoder().encode(plain)
+    let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    #expect(object["board"] == nil, "a nil board still wrote a key")
+  }
+
+  /// A settings file written before the key existed loads with the experiment off, and
+  /// every other answer in it unchanged.
+  @Test
+  func anOlderSettingsFileGainsNothingButTheDefault() throws {
+    var before = GraphcodeSettings()
+    before.summarisesLoops = true
+    before.summaryUsesModel = true
+    let data = try JSONEncoder().encode(before)
+    var object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    object.removeValue(forKey: "visualisesSummaries")
+
+    let older = try JSONSerialization.data(withJSONObject: object)
+    let loaded = try JSONDecoder().decode(GraphcodeSettings.self, from: older)
+
+    #expect(!loaded.visualisesSummaries)
+    // Nothing else moved. Switching the rail on must never imply switching this on.
+    #expect(loaded.summarisesLoops)
+    #expect(loaded.summaryUsesModel)
+    #expect(loaded.daemonHeartbeatEnabled == before.daemonHeartbeatEnabled)
+    #expect(loaded.sharesLoops == before.sharesLoops)
+  }
+
+  @Test
+  func aFreshSettingsFileHasTheExperimentOff() {
+    #expect(!GraphcodeSettings().visualisesSummaries)
+  }
+}

--- a/graphcode/Tests/MermaidBoardParserTests.swift
+++ b/graphcode/Tests/MermaidBoardParserTests.swift
@@ -258,8 +258,20 @@ struct MermaidBoardParserTests {
 
     #expect(parsed.nodes.count == 2)
   }
+}
 
-  // MARK: - Tables
+/// The other half of the subset: a Markdown table, and the separator row that says which
+/// way each column reads.
+///
+/// Its own suite rather than more of the one above — they share no fixture, and the flow
+/// cases are the ones with the syntax in them.
+@Suite
+struct MermaidTableParserTests {
+
+  private func board(_ reply: String, pass: Int = 3) -> SummaryBoard? {
+    MermaidBoardParser.board(
+      fromReply: reply, pass: pass, now: Date(timeIntervalSince1970: 0))
+  }
 
   @Test
   func aMarkdownTableBecomesRowsAndColumns() throws {
@@ -307,5 +319,39 @@ struct MermaidBoardParserTests {
   @Test
   func aTableWithNoRowsIsNotABoard() {
     #expect(board("| A | B |\n|---|---|\n|  |  |") == nil)
+  }
+
+  /// The separator row's colons are the author saying which way a column reads. The parser
+  /// has always had to look at that row to know it *was* a separator; until boards could
+  /// draw a table properly it threw the answer away.
+
+  @Test
+  func theSeparatorRowsColonsAreRead() {
+    #expect(
+      MermaidBoardParser.alignments(ofSeparator: "|---|:---|---:|:---:|")
+        == [.unspecified, .leading, .trailing, .center])
+  }
+
+  @Test
+  func aParsedTableCarriesItsAlignmentsThrough() throws {
+    let board = try #require(
+      MermaidBoardParser.board(
+        fromReply: """
+          | File | Lines |
+          |:---|---:|
+          | a.swift | 438 |
+          | b.swift | 12 |
+          """, pass: 1))
+    #expect(board.table?.alignments == [.leading, .trailing])
+  }
+
+  /// A board written before alignments existed still draws — the list is padded to the
+  /// header count on the way in rather than trusted to match.
+  @Test
+  func aTableWithoutAlignmentsStillDecodes() throws {
+    let json = Data(#"{"headers":["A","B"],"rows":[["1","2"]]}"#.utf8)
+    let decoded = try JSONDecoder().decode(BoardTable.self, from: json)
+    #expect(decoded.alignments == [.unspecified, .unspecified])
+    #expect(decoded.alignment(ofColumn: 5) == .unspecified)
   }
 }

--- a/graphcode/Tests/MermaidBoardParserTests.swift
+++ b/graphcode/Tests/MermaidBoardParserTests.swift
@@ -1,0 +1,311 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// What the composer is allowed to write, and what happens to everything else.
+///
+/// The parser is the one place in the board pipeline where a model's free text becomes a
+/// structure the app draws, so the interesting cases are all the ones where the reply is
+/// nearly right: a banner in front of it, a fence it forgot to close, a diagram type
+/// nobody asked for, a table with a cell missing.
+@Suite
+struct MermaidBoardParserTests {
+
+  private func board(_ reply: String, pass: Int = 3) -> SummaryBoard? {
+    MermaidBoardParser.board(
+      fromReply: reply, pass: pass, now: Date(timeIntervalSince1970: 0))
+  }
+
+  // MARK: - Flowcharts
+
+  @Test
+  func aFlowchartBecomesBoxesAndArrows() throws {
+    let parsed = try #require(
+      board(
+        """
+        ```mermaid
+        %% title: The release gate
+        flowchart TD
+          A([Start]) --> B[Run make check]
+          B --> C{Green?}
+          C -->|yes| D([Ship it])
+          C -->|no| B
+        ```
+        """))
+
+    #expect(parsed.form == .flow)
+    #expect(parsed.title == "The release gate")
+    #expect(parsed.direction == .topDown)
+    #expect(parsed.nodes.map(\.id) == ["A", "B", "C", "D"])
+    #expect(parsed.nodes.map(\.text) == ["Start", "Run make check", "Green?", "Ship it"])
+    #expect(parsed.nodes.map(\.shape) == [.terminal, .box, .decision, .terminal])
+    #expect(
+      parsed.edges.map { "\($0.from)\($0.label.map { label in "|\(label)|" } ?? "")\($0.to)" }
+        == ["AB", "BC", "C|yes|D", "C|no|B"])
+    // The pass is the store's, never the model's — nothing in the reply above set it.
+    #expect(parsed.pass == 3)
+  }
+
+  /// The label belongs to the link *before* the node it is read against, which is the one
+  /// off-by-one this parser can make and the reason chains are tested rather than assumed.
+  @Test
+  func aChainedLineKeepsEachLabelOnItsOwnArrow() throws {
+    let parsed = try #require(
+      board(
+        """
+        flowchart LR
+          A[One] -->|first| B[Two] -->|second| C[Three]
+        """))
+
+    #expect(parsed.direction == .leftRight)
+    #expect(parsed.edges.map(\.label) == ["first", "second"])
+    #expect(parsed.edges.map(\.from) == ["A", "B"])
+    #expect(parsed.edges.map(\.to) == ["B", "C"])
+  }
+
+  @Test
+  func bothSpellingsOfAnEdgeLabelAreRead() throws {
+    let parsed = try #require(
+      board(
+        """
+        flowchart TD
+          A[a] -- no --> B[b]
+          B -.-> C[c]
+          C == the spine ==> D[d]
+          D --- E[e]
+        """))
+
+    #expect(parsed.edges.map(\.label) == ["no", nil, "the spine", nil])
+    #expect(parsed.edges.map(\.style) == [.solid, .dashed, .thick, .solid])
+  }
+
+  /// A node named once with a label and again without keeps the label. Mermaid's own
+  /// convention, and taking the later mention would blank half a diagram.
+  @Test
+  func aLaterBareMentionDoesNotBlankALabel() throws {
+    let parsed = try #require(
+      board(
+        """
+        flowchart TD
+          A[Read the transcript] --> B[Fold it in]
+          B --> A
+        """))
+
+    #expect(parsed.nodes.first { $0.id == "A" }?.text == "Read the transcript")
+  }
+
+  @Test
+  func quotedLabelsAndLineBreaksAreTheSyntaxNotTheText() throws {
+    let parsed = try #require(
+      board(
+        """
+        flowchart TD
+          A["Read UsageProbe.swift, twice"] --> B["One<br/>two"]
+        """))
+
+    #expect(parsed.nodes.map(\.text) == ["Read UsageProbe.swift, twice", "One two"])
+  }
+
+  @Test
+  func stylingDirectivesAreDroppedRatherThanRefused() throws {
+    let parsed = try #require(
+      board(
+        """
+        flowchart TD
+          subgraph one
+          A[a] --> B[b]
+          end
+          classDef big fill:#f00
+          class A big
+          linkStyle 0 stroke:#fff
+          click A "https://example.com"
+        """))
+
+    #expect(parsed.nodes.map(\.id) == ["A", "B"])
+    #expect(parsed.edges.count == 1)
+  }
+
+  // MARK: - What is refused
+
+  @Test
+  func aDiagramTypeOutsideTheSubsetIsNotABoard() {
+    #expect(
+      board(
+        """
+        ```mermaid
+        sequenceDiagram
+          Alice->>Bob: Hello
+        ```
+        """) == nil)
+  }
+
+  /// One box and no arrows is a sentence in a rectangle, and the summary above the board
+  /// already says it better — see `SummaryBoard.isDrawable`.
+  @Test
+  func aSingleBoxIsNotWorthDrawing() {
+    #expect(board("flowchart TD\n  A[Only this]") == nil)
+  }
+
+  @Test
+  func anEdgeIntoNothingIsDroppedRatherThanDrawnToNowhere() throws {
+    // 24 boxes is the cap; the 25th and every arrow reaching it must go together.
+    var lines = ["flowchart TD"]
+    for index in 0..<30 { lines.append("  N\(index)[step \(index)] --> N\(index + 1)[step]") }
+    let parsed = try #require(board(lines.joined(separator: "\n")))
+
+    #expect(parsed.nodes.count == SummaryBoard.maxNodes)
+    let known = Set(parsed.nodes.map(\.id))
+    #expect(parsed.edges.allSatisfy { known.contains($0.from) && known.contains($0.to) })
+  }
+
+  // MARK: - What a real model actually writes
+
+  /// Verbatim `claude -p --model haiku` output for the composer's own prompt, over a run
+  /// that genuinely branched — the release loop that hit a notarisation rejection, a
+  /// blocked merge and a non-fast-forward push.
+  ///
+  /// Fixtures written by hand test the parser against what its author imagined; this tests
+  /// it against what the fast tier does when nobody is watching. It is also the only case
+  /// here with two independent retry loops in it, which is what the layout's cycle-breaking
+  /// exists for.
+  @Test
+  func theFastTiersOwnOutputParses() throws {
+    let parsed = try #require(
+      board(
+        """
+        ```mermaid
+        flowchart TD
+          A([Start]) --> B["Bump version, push main"]
+          B --> C["Build DMG"]
+          C --> D["Notarise"]
+          D --> E{Pass?}
+          E -->|No| F["Re-sign helpers"]
+          F --> C
+          E -->|Yes| G["Try gh pr merge"]
+          G --> H{Allowed?}
+          H -->|No| I["Use git merge"]
+          H -->|Yes| I
+          I --> J["Push to tap"]
+          J --> K{Fast-forward?}
+          K -->|No| L["Re-clone tap"]
+          L --> J
+          K -->|Yes| M([Done])
+        ```
+        """))
+
+    #expect(parsed.nodes.count == 13)
+    #expect(parsed.edges.count == 15)
+    #expect(
+      parsed.nodes.filter { $0.shape == .decision }.map(\.text) == [
+        "Pass?", "Allowed?", "Fast-forward?",
+      ])
+    #expect(parsed.nodes.filter { $0.shape == .terminal }.map(\.id) == ["A", "M"])
+    // The comma inside a quoted label is the label's, not the diagram's.
+    #expect(parsed.nodes.first { $0.id == "B" }?.text == "Bump version, push main")
+    #expect(parsed.edges.filter { $0.label == "No" }.count == 3)
+  }
+
+  /// The same prompt against a run of findings. The separator row here has no colons and
+  /// the cells carry bare numbers — what a model writes when asked for a table, rather than
+  /// the fully-aligned form a person writes.
+  @Test
+  func theFastTiersOwnTableParses() throws {
+    let parsed = try #require(
+      board(
+        """
+        | Test | Lines | Limit |
+        |---|---|---|
+        | RemoteSessionResumeTests | 438 | 400 |
+        | CheckForUpdatesTests | 414 | 400 |
+        | NodeDraftTests | 259 | 250 |
+        | RemoteCLIShimTests | 61 | 50 |
+        """))
+
+    #expect(parsed.form == .table)
+    #expect(parsed.table?.rows.count == 4)
+    #expect(parsed.table?.rows.last == ["RemoteCLIShimTests", "61", "50"])
+  }
+
+  // MARK: - Fences and noise
+
+  @Test
+  func theLastBlockWinsOverAnyBannerBeforeIt() throws {
+    let parsed = try #require(
+      board(
+        """
+        Welcome to the CLI. Reading config…
+        Here is a diagram of what happened:
+
+        ```mermaid
+        flowchart TD
+          A[a] --> B[b]
+        ```
+        """))
+
+    #expect(parsed.nodes.count == 2)
+  }
+
+  @Test
+  func anUnclosedFenceIsStillAnAnswer() throws {
+    let parsed = try #require(
+      board(
+        """
+        ```mermaid
+        flowchart TD
+          A[a] --> B[b]
+        """))
+
+    #expect(parsed.nodes.count == 2)
+  }
+
+  // MARK: - Tables
+
+  @Test
+  func aMarkdownTableBecomesRowsAndColumns() throws {
+    let parsed = try #require(
+      board(
+        """
+        | File | Change | Lines |
+        |---|---:|---|
+        | GraphStore.swift | refreshBoards | +52 |
+        | LoopNode.swift | board field | +9 |
+        """))
+
+    #expect(parsed.form == .table)
+    #expect(parsed.table?.headers == ["File", "Change", "Lines"])
+    #expect(parsed.table?.rows.count == 2)
+    #expect(parsed.table?.rows.first == ["GraphStore.swift", "refreshBoards", "+52"])
+  }
+
+  @Test
+  func aShortRowIsPaddedRatherThanCrashingTheColumnIndex() throws {
+    let parsed = try #require(
+      board(
+        """
+        | A | B | C |
+        |---|---|---|
+        | one | two |
+        """))
+
+    #expect(parsed.table?.normalisedRows == [["one", "two", ""]])
+  }
+
+  /// The separator row is required. Without it a flowchart line carrying a pipe parses as
+  /// a one-row table, and a board that draws the wrong *form* is worse than no board.
+  @Test
+  func pipesWithoutASeparatorAreNotATable() {
+    #expect(
+      board(
+        """
+        | just | some | text |
+        | more | of   | it   |
+        | and  | more | yet  |
+        """) == nil)
+  }
+
+  @Test
+  func aTableWithNoRowsIsNotABoard() {
+    #expect(board("| A | B |\n|---|---|\n|  |  |") == nil)
+  }
+}

--- a/graphcode/Tests/SummaryBoardPTYTests.swift
+++ b/graphcode/Tests/SummaryBoardPTYTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// What the board composer does to the machine's file descriptors, which is the failure
+/// this whole path has already had once.
+///
+/// `SummaryModelWriter` leaked a PTY per call before `ZmxSessionLauncher.loginShellInvocation`
+/// went in: `Process` never searches `PATH`, so a bare `claude` threw at launch, and the
+/// pair `openpty` had already allocated was never closed. `kern.tty.ptmx_max` is 511, so a
+/// caller whose launch reliably fails exhausts the host outright — and `graphcoded` runs for
+/// weeks, so "until the process exits" means "until the machine reboots".
+///
+/// `SummaryBoardComposer` opens a PTY on exactly the same primitive, once per finished pass
+/// per loop. These measure the three ways out of `compose` — the process answers, the
+/// process outlives the timeout, the process never launches — and assert the descriptors
+/// come back each time.
+@Suite(.serialized)
+struct SummaryBoardPTYTests {
+
+  /// How many descriptors this process currently holds.
+  ///
+  /// Counted off `/dev/fd`, which on Darwin lists the calling process's open descriptors.
+  /// Coarse — it counts every file, socket and pipe the test host has open — but a leak of
+  /// one PTY *pair* per iteration is 25 descriptors over 25 iterations, which no amount of
+  /// unrelated noise hides.
+  private func openDescriptors() -> Int {
+    (try? FileManager.default.contentsOfDirectory(atPath: "/dev/fd").count) ?? -1
+  }
+
+  /// The same shape `SummaryBoardComposer.compose` uses, so the test exercises the
+  /// arrangement rather than a simplification of it.
+  private func runOnce(
+    executable: String, arguments: [String], timeout: Duration
+  ) async -> Bool {
+    guard
+      let session = try? PTYProcessSession(
+        executable: executable, arguments: arguments, workingDirectory: nil)
+    else { return false }
+    let outcome = await withTaskGroup(of: (Bool, String)?.self) { group in
+      group.addTask { await session.waitCollectingOutput() }
+      group.addTask {
+        try? await Task.sleep(for: timeout)
+        return nil
+      }
+      let first = await group.next().flatMap { $0 }
+      group.cancelAll()
+      return first
+    }
+    session.terminate()
+    return outcome != nil
+  }
+
+  private static let iterations = 25
+  /// One pair per iteration would be 50; anything under a handful is the test host's own
+  /// churn, not a leak.
+  private static let tolerance = 6
+
+  @Test
+  func aProcessThatAnswersGivesItsDescriptorsBack() async {
+    // Warm up once: the first PTY in a process allocates machinery the rest reuse, and
+    // counting that as a leak would make the threshold meaningless.
+    _ = await runOnce(executable: "/bin/sh", arguments: ["-c", "echo hello"], timeout: .seconds(5))
+    let before = openDescriptors()
+    for _ in 0..<Self.iterations {
+      _ = await runOnce(
+        executable: "/bin/sh", arguments: ["-c", "echo hello"], timeout: .seconds(5))
+    }
+    let after = openDescriptors()
+    #expect(after - before <= Self.tolerance, "\(before) → \(after) over \(Self.iterations) runs")
+  }
+
+  /// The path that matters most: a backend that hangs. The timeout fires, `terminate()`
+  /// sends `SIGTERM`, and the descriptors have to come back — or one wedged `claude -p` per
+  /// poll per loop walks the host to 511 and stops every PTY on the machine.
+  @Test
+  func aProcessKilledByTheTimeoutGivesItsDescriptorsBack() async {
+    _ = await runOnce(
+      executable: "/bin/sh", arguments: ["-c", "sleep 30"], timeout: .milliseconds(80))
+    let before = openDescriptors()
+    for _ in 0..<Self.iterations {
+      let answered = await runOnce(
+        executable: "/bin/sh", arguments: ["-c", "sleep 30"], timeout: .milliseconds(80))
+      // And the timeout genuinely bounds the wait rather than being decoration: without
+      // this the loop would take twelve minutes rather than two seconds.
+      #expect(!answered)
+    }
+    let after = openDescriptors()
+    #expect(after - before <= Self.tolerance, "\(before) → \(after) over \(Self.iterations) runs")
+  }
+
+  /// **The original bug, kept as a test.** A launch that throws has already allocated a
+  /// pair; `PTYProcessSession`'s `catch` closes the slave and its `deinit` closes the
+  /// master. `compose` reaches this through `try?`, so a leak here would be silent.
+  @Test
+  func aLaunchThatNeverHappensGivesItsDescriptorsBack() async {
+    _ = await runOnce(
+      executable: "/nonexistent/graphcode-not-a-real-binary", arguments: [],
+      timeout: .seconds(5))
+    let before = openDescriptors()
+    for _ in 0..<Self.iterations {
+      let answered = await runOnce(
+        executable: "/nonexistent/graphcode-not-a-real-binary", arguments: [],
+        timeout: .seconds(5))
+      #expect(!answered)
+    }
+    let after = openDescriptors()
+    #expect(after - before <= Self.tolerance, "\(before) → \(after) over \(Self.iterations) runs")
+  }
+
+  /// The composer never names a bare executable, whatever the backend's own spelling is.
+  ///
+  /// This is the guard that keeps the original failure from coming back by a different
+  /// door: `Process` resolves `executableURL` as a path and never searches `PATH`, so
+  /// `claude` alone throws — every call, silently, leaking as it goes. Going through the
+  /// launcher's login shell is what makes the invocation resolvable at all.
+  @Test
+  func everyBackendIsLaunchedThroughALoginShellRatherThanABareName() {
+    for backend in CLISessionBackendKind.allCases {
+      let invocation = SummaryModelWriter.invocation(forBackend: backend, prompt: "x")
+      let launch = ZmxSessionLauncher.loginShellInvocation(
+        of: invocation[0], arguments: Array(invocation.dropFirst()))
+      #expect(launch[0].hasPrefix("/"), "\(backend) would launch \(launch[0]) as a path")
+      #expect(FileManager.default.isExecutableFile(atPath: launch[0]))
+    }
+  }
+}

--- a/graphcode/Tests/SummaryBoardTests.swift
+++ b/graphcode/Tests/SummaryBoardTests.swift
@@ -178,6 +178,28 @@ struct SummaryBoardTests {
     #expect(await store.graph.nodes.first?.board?.pass == 2)
   }
 
+  /// **The memo must not outlive the loops it is about.** It is keyed by node id and only
+  /// ever written to; without a prune, every loop ever created leaves an entry behind and a
+  /// daemon that runs for weeks accumulates one per deletion. Small each — and the PTY leak
+  /// this path already had was one descriptor each.
+  @Test
+  func theAttemptMemoIsPrunedWhenALoopIsDeleted() async {
+    let composer = Composer()
+    let doomed = node("A", passes: 3)
+    let store = store([doomed, node("B", passes: 3)], composer: composer)
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    #expect(await store.boardAttempts.count == 2)
+
+    await store.handle(.deleteNode(doomed.id))
+    await store.pollPresence()
+
+    #expect(await store.boardAttempts.keys.contains(doomed.id) == false)
+    #expect(await store.boardAttempts.count == 1)
+  }
+
   // MARK: - The type's own bounds
 
   @Test

--- a/graphcode/Tests/SummaryBoardTests.swift
+++ b/graphcode/Tests/SummaryBoardTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// What the board pipeline costs, which is the only interesting thing about it.
+///
+/// Every assertion here is about a call *not* being made. The reading behind the summary
+/// rail is free and can be taken every fifteen seconds forever; a board is a CLI process,
+/// and the three guards below — off means empty, a pass is drawn once, at most two a tick —
+/// are what keep "one call per finished pass" from being a hope.
+@Suite
+struct SummaryBoardTests {
+
+  private func node(_ title: String, passes: Int) -> LoopNode {
+    var node = LoopNode(
+      title: title, loopType: .goalBased, goal: GoalSpec(summary: "done"), state: .running)
+    node.summary = LoopSummary(
+      beats: [
+        SummaryBeat(
+          id: "\(title)-b", at: Date(timeIntervalSince1970: 10), pass: passes, kind: .editing,
+          text: "Editing the thing")
+      ],
+      passes: (1..<max(passes, 1)).map { PassSummary(pass: $0, text: "did pass \($0)") },
+      currentPass: passes)
+    return node
+  }
+
+  private func graph(_ nodes: [LoopNode]) -> LoopGraph {
+    var graph = LoopGraph(scope: LoopGraphScope(projectPath: "/tmp/p", name: "p"))
+    for node in nodes { graph.nodes.append(node) }
+    return graph
+  }
+
+  private func attach(to store: GraphStore) async -> Int32 {
+    let descriptor = open("/dev/null", O_WRONLY)
+    await store.addConnection(id: UUID(), fileDescriptor: descriptor)
+    return descriptor
+  }
+
+  /// Records which loops were drawn, so "what does a tick cost" is a number.
+  private actor Composer {
+    private(set) var asked: [String] = []
+    private var answers: [String: SummaryBoard?] = [:]
+
+    func answer(_ title: String, with board: SummaryBoard?) { answers[title] = board }
+
+    func compose(_ node: LoopNode, _ summary: LoopSummary) -> SummaryBoard? {
+      asked.append(node.title)
+      guard let answer = answers[node.title] else {
+        return SummaryBoardTests.flow(pass: summary.currentPass)
+      }
+      return answer
+    }
+
+    func reset() { asked = [] }
+  }
+
+  fileprivate static func flow(pass: Int) -> SummaryBoard {
+    SummaryBoard(
+      form: .flow,
+      nodes: [BoardNode(id: "A", text: "one"), BoardNode(id: "B", text: "two")],
+      edges: [BoardEdge(from: "A", to: "B")],
+      source: "flowchart TD\n  A[one] --> B[two]", pass: pass,
+      composedAt: Date(timeIntervalSince1970: 0))
+  }
+
+  private func store(
+    _ nodes: [LoopNode], composer: Composer, enabled: @escaping @Sendable () -> Bool = { true }
+  ) -> GraphStore {
+    GraphStore(
+      graph: graph(nodes),
+      onReadPresence: { _, _ in PresenceReading(presence: .busy, confidence: .reported) },
+      onComposeBoard: { node, summary, _ in await composer.compose(node, summary) },
+      onBoardsEnabled: enabled)
+  }
+
+  // MARK: - The three guards
+
+  @Test
+  func aPassIsDrawnOnceHoweverManyTimesThePollComesRound() async {
+    let composer = Composer()
+    let store = store([node("A", passes: 3)], composer: composer)
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    #expect(await composer.asked == ["A"])
+    #expect(await store.graph.nodes.first?.board?.pass == 3)
+
+    await store.pollPresence()
+    await store.pollPresence()
+    #expect(await composer.asked == ["A"])
+  }
+
+  /// `NONE` is the answer the composer is *told* to give for a thin pass, and most passes
+  /// get it. Without the attempt memo a declined pass would be re-asked every tick — a
+  /// model call every fifteen seconds for as long as the loop stayed on that pass.
+  @Test
+  func aDeclinedPassIsNotAskedAgainUntilTheLoopMovesOn() async {
+    let composer = Composer()
+    await composer.answer("A", with: SummaryBoard?.none)
+    let store = store([node("A", passes: 2)], composer: composer)
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    await store.pollPresence()
+    #expect(await composer.asked == ["A"])
+    #expect(await store.graph.nodes.first?.board == nil)
+  }
+
+  @Test
+  func atMostTwoLoopsAreDrawnInOneTick() async {
+    let composer = Composer()
+    let nodes = (1...5).map { node("L\($0)", passes: 4) }
+    let store = store(nodes, composer: composer)
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    #expect(await composer.asked.count == SummaryBoardComposer.maxPerTick)
+
+    // The rest are not dropped, only deferred — the candidate list is sorted by how far
+    // behind each board is, so nothing waits behind a loop that keeps finishing passes.
+    await store.pollPresence()
+    await store.pollPresence()
+    #expect(await composer.asked.count == 5)
+    #expect(Set(await composer.asked).count == 5)
+  }
+
+  @Test
+  func aLoopWithNoFinishedPassIsNeverACandidate() async {
+    let composer = Composer()
+    let store = store([node("A", passes: 1)], composer: composer)
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    #expect(await composer.asked.isEmpty)
+  }
+
+  /// The counterpart of `turningTheProducerOffEmptiesEveryNodeItFilled` in
+  /// `PresencePollingTests`: a picture left on a node for a feature nobody has switched on
+  /// is the same failure as a beat left on one.
+  @Test
+  func turningTheExperimentOffEmptiesEveryBoardItDrew() async {
+    let composer = Composer()
+    let enabled = LockedBool(true)
+    let store = store([node("A", passes: 3)], composer: composer, enabled: { enabled.value })
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    #expect(await store.graph.nodes.first?.board != nil)
+
+    enabled.value = false
+    await store.pollPresence()
+    #expect(await store.graph.nodes.first?.board == nil)
+
+    // And switching it back on draws the pass the loop is on rather than waiting for the
+    // next one — the attempt memo is forgotten along with the boards.
+    enabled.value = true
+    await store.pollPresence()
+    #expect(await store.graph.nodes.first?.board?.pass == 3)
+  }
+
+  @Test
+  func aNewPassRedrawsTheBoard() async {
+    let composer = Composer()
+    var first = node("A", passes: 2)
+    first.board = Self.flow(pass: 1)
+    let store = store([first], composer: composer)
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    #expect(await store.graph.nodes.first?.board?.pass == 2)
+  }
+
+  // MARK: - The type's own bounds
+
+  @Test
+  func aBoardIsBoundedByConstruction() {
+    let board = SummaryBoard(
+      form: .table,
+      table: BoardTable(
+        headers: (0..<9).map { "h\($0)" },
+        rows: (0..<40).map { row in (0..<9).map { "r\(row)c\($0)" } }),
+      source: "", pass: 1)
+
+    #expect(board.table?.headers.count == SummaryBoard.maxColumns)
+    #expect(board.table?.rows.count == SummaryBoard.maxRows)
+    #expect(board.table?.rows.allSatisfy { $0.count == SummaryBoard.maxColumns } == true)
+  }
+
+  /// A graph file written by a build that did not know about boards, and one written by a
+  /// build after this one, both have to load — `ProjectPersistence` turns any decode
+  /// failure into "no saved graph".
+  @Test
+  func aNodeWithoutABoardStillDecodes() throws {
+    // The key removed rather than a graph file hand-written: what is being asserted is that
+    // *this* field is optional on the way in, not that the whole encoding is stable.
+    var node = LoopNode(title: "A")
+    node.board = Self.flow(pass: 1)
+    let data = try JSONEncoder().encode(node)
+    var object = try #require(
+      try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    #expect(object["board"] != nil)
+    object.removeValue(forKey: "board")
+
+    let older = try JSONSerialization.data(withJSONObject: object)
+    #expect(try JSONDecoder().decode(LoopNode.self, from: older).board == nil)
+  }
+
+  @Test
+  func aBoardSurvivesARoundTrip() throws {
+    let board = Self.flow(pass: 4)
+    var node = LoopNode(title: "A")
+    node.board = board
+    let data = try JSONEncoder().encode(node)
+    let decoded = try JSONDecoder().decode(LoopNode.self, from: data)
+    #expect(decoded.board == board)
+  }
+}
+
+/// A `Bool` two isolation domains can share. The store reads the switch from its own actor
+/// and the test flips it from outside, which is exactly the daemon's own arrangement.
+private final class LockedBool: @unchecked Sendable {
+  private let lock = NSLock()
+  private var storage: Bool
+
+  init(_ value: Bool) { storage = value }
+
+  var value: Bool {
+    get { lock.withLock { storage } }
+    set { lock.withLock { storage = newValue } }
+  }
+}


### PR DESCRIPTION
A second experimental section under the summary rail: what a loop is doing in a sentence, and now what *shape* the work had, when it had one.

Off by default, and requires `summarisesLoops` — a board is drawn from the summary, so the picture without the reading behind it would describe a run nothing is narrating.

## Native SwiftUI, not a web view

The app ships no WebKit and no JavaScript, and this adds neither.

| Piece | File | Role |
|---|---|---|
| Source format | `SummaryBoardComposer` | the model emits **Mermaid** — portable, pastes into a PR |
| Parser | `MermaidBoardParser` | reads a documented subset into plain structs |
| Layout | `BoardPlacement` / `BoardRouting` | layered graph layout, real text measurement |
| Render | `SummaryBoardView` | SwiftUI `Canvas` for arrows, shapes for boxes |

The Mermaid stays the source of truth on `SummaryBoard.source`: copyable from the section header, and shown as code when the subset cannot draw it — the honest outcome rather than an error state.

## What it costs

Three guards, each with a test asserting a call is *not* made:

- **Once per finished pass**, not per beat. `SummaryBoard.pass` records which pass a board describes. A *declined* pass is remembered too, or `NONE` — the answer most passes get — would be re-asked every fifteen seconds for as long as the loop stayed on it.
- **At most two loops a tick**, so ten loops finishing together do not put ten CLI processes on the poll every state dot in the app rides on.
- **Off means empty**, asked fresh each tick, like the beats above it.

## The prompt was measured, not reasoned

Its first version described the flowchart first, with the only worked example, and offered `NONE` third. Against real summaries at the fast tier it produced a flowchart **every single time** — for a two-line version bump, and for four findings that were plainly a table.

The judgement now happens above the formats, as three tests applied in order. The line doing the most work is the one denying that a pass list is a flow: every session has passes in order, so "the work had an order to it" was true of everything. Re-checked against `claude -p --model haiku` on four real summaries — thin pass → `NONE`, findings → table, linear work → `NONE`, a release that hit a notarisation rejection and two failed pushes → a flowchart with both retry loops in it. That last reply is a parser fixture.

## Bugs found by rendering it

Headless snapshots caught four things the tests did not, each now covered:

- feedback arrows left the source's *side*, so the horizontal run went straight through the box beside it — and boxes draw over arrows, so the retry simply vanished
- two arrows between the same pair of boxes stacked their labels on one point
- `LR` boards were laid out top-down and transposed, which uses heights as layer spacing and widths as box extents: every box landed on the one before it
- `scaleEffect` does not change layout size, so the frame under it centred the full-size box and pushed the first box eighty points off the leading edge

## The rail

Opens at 460 points when a loop carries a board, and only while nobody has ever dragged it themselves. A diagram at 280 points is four boxes before it scrolls sideways; one drag retires the default for good. The section folds, and expands to cover the workspace.

## Gate

`1132 tests in 120 suites` pass, swiftlint clean on the new files, `swift format lint --strict` clean, all three schemes build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTbQQh7Tf4c7oaWNRcmdEm