### PR TITLE
fix: make the visualise experiment actually draw

### DIFF
--- a/GraphcodeKit/Sources/Domain/LoopSummary.swift
+++ b/GraphcodeKit/Sources/Domain/LoopSummary.swift
@@ -169,6 +169,19 @@ public struct SummaryReading: Equatable, Sendable {
   }
 
   public var isEmpty: Bool { beats.isEmpty && finishedPasses.isEmpty }
+
+  /// The same reading with its newest beat swapped for a better-written one.
+  ///
+  /// A method rather than a fresh `SummaryReading(beats:finishedPasses:)` at the call site,
+  /// because rebuilding this type from two of its six fields silently drops the other four.
+  /// That is not hypothetical: it dropped `closing`, and `closing` is what a board is drawn
+  /// from — so every loop lost its diagram whenever the model rewrote a sentence.
+  public func replacingNewestBeat(with beat: SummaryBeat) -> SummaryReading {
+    guard !beats.isEmpty else { return self }
+    var reading = self
+    reading.beats[reading.beats.count - 1] = beat
+    return reading
+  }
 }
 
 /// A loop's narration, bounded by construction: the current beat, the two before it, one

--- a/GraphcodeKit/Sources/Sessions/MermaidBoardParser.swift
+++ b/GraphcodeKit/Sources/Sessions/MermaidBoardParser.swift
@@ -172,34 +172,73 @@ public enum MermaidBoardParser {
     var nodes: [BoardNode] = []
     var edges: [BoardEdge] = []
     var cursor = text.startIndex
-    var previous: BoardNode?
+    /// The nodes on the left of the link being read. A *list* rather than one node because
+    /// of `&`: `A --> B & C` is two edges, and both start at whatever preceded the arrow.
+    var previous: [BoardNode] = []
     /// The link whose right-hand node has not been read yet. An edge can only be emitted
     /// once *both* its ends are known, and the link that joins them is the one before the
     /// node being read — not the one the loop is currently on.
     var pending: LinkMatch?
 
-    func close(with node: BoardNode) {
-      nodes.append(node)
-      if let from = previous, let pending {
-        edges.append(
-          BoardEdge(from: from.id, to: node.id, label: pending.label, style: pending.style))
+    func close(with side: [BoardNode]) {
+      nodes.append(contentsOf: side)
+      if let pending {
+        for from in previous {
+          for to in side {
+            edges.append(
+              BoardEdge(from: from.id, to: to.id, label: pending.label, style: pending.style))
+          }
+        }
       }
-      previous = node
+      previous = side
     }
 
     for link in links {
       // A segment that holds no identifier breaks the chain rather than silently joining
       // the boxes either side of it.
-      if let node = parseNodeToken(String(text[cursor..<link.range.lowerBound])) {
-        close(with: node)
-      } else {
-        previous = nil
-      }
+      let side = parseNodeTokens(String(text[cursor..<link.range.lowerBound]))
+      if side.isEmpty { previous = [] } else { close(with: side) }
       pending = link
       cursor = link.range.upperBound
     }
-    if let tail = parseNodeToken(String(text[cursor...])) { close(with: tail) }
+    let tail = parseNodeTokens(String(text[cursor...]))
+    if !tail.isEmpty { close(with: tail) }
     return (nodes, edges)
+  }
+
+  /// One side of a link — usually one node, and every node in it when the side is a `&`
+  /// list. Mermaid joins every node on one side to every node on the other, which is how
+  /// a fan-out is written in one line, and it is common enough in a diagram an agent wrote
+  /// that reading it as a single node produced a box labelled `Fix] & C[Test`.
+  static func parseNodeTokens(_ segment: String) -> [BoardNode] {
+    fanOutParts(of: segment).compactMap { parseNodeToken($0) }
+  }
+
+  /// Split on `&`, but only where it separates nodes: inside a label — `A[Cut & paste]`,
+  /// or an `&nbsp;` — it is text, and splitting there would cut a box in half.
+  static func fanOutParts(of segment: String) -> [String] {
+    guard segment.contains("&") else { return [segment] }
+    var parts: [String] = []
+    var current = ""
+    var depth = 0
+    var quoted = false
+    for character in segment {
+      if character == "\"" { quoted.toggle() }
+      if !quoted {
+        if "[({".contains(character) {
+          depth += 1
+        } else if "])}".contains(character) {
+          depth = max(0, depth - 1)
+        } else if character == "&", depth == 0 {
+          parts.append(current)
+          current = ""
+          continue
+        }
+      }
+      current.append(character)
+    }
+    parts.append(current)
+    return parts
   }
 
   struct LinkMatch {
@@ -335,13 +374,33 @@ public enum MermaidBoardParser {
     return board.isDrawable ? board : nil
   }
 
+  /// The cells of one row, with `\\|` read as Markdown means it: a literal pipe inside a
+  /// cell rather than the end of one. Agents write it often — a shell pipeline, a Swift
+  /// `A | B` — and splitting there gave the row more columns than the table has.
   static func cells(of row: String) -> [String] {
     var text = row
     if text.hasPrefix("|") { text = String(text.dropFirst()) }
-    if text.hasSuffix("|") { text = String(text.dropLast()) }
-    return text.components(separatedBy: "|").map {
-      $0.trimmingCharacters(in: .whitespaces)
+    if text.hasSuffix("|"), !text.hasSuffix("\\|") { text = String(text.dropLast()) }
+    var cells: [String] = []
+    var current = ""
+    var escaped = false
+    for character in text {
+      if escaped {
+        if character != "|" { current.append("\\") }
+        current.append(character)
+        escaped = false
+      } else if character == "\\" {
+        escaped = true
+      } else if character == "|" {
+        cells.append(current)
+        current = ""
+      } else {
+        current.append(character)
+      }
     }
+    if escaped { current.append("\\") }
+    cells.append(current)
+    return cells.map { $0.trimmingCharacters(in: .whitespaces) }
   }
 
   /// `|---|---:|:--:|` — what the author asked for, per column.

--- a/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryModelWriter.swift
@@ -172,8 +172,6 @@ public enum SummaryModelWriter {
       newest, backend: node.backend,
       workingDirectory: ZmxSessionLauncher.workingDirectory(
         forNode: node, projectPath: projectPath))
-    var beats = reading.beats
-    beats[beats.count - 1] = rewritten
-    return SummaryReading(beats: beats, finishedPasses: reading.finishedPasses)
+    return reading.replacingNewestBeat(with: rewritten)
   }
 }

--- a/graphcode/Tests/MermaidBoardParserTests.swift
+++ b/graphcode/Tests/MermaidBoardParserTests.swift
@@ -375,4 +375,77 @@ struct MermaidTableParserTests {
     #expect(decoded.alignments == [.unspecified, .unspecified])
     #expect(decoded.alignment(ofColumn: 5) == .unspecified)
   }
+
+  /// `A --> B & C` is Mermaid's fan-out, and a diagram an agent wrote uses it freely.
+  /// Read as one node it produced a box labelled `Fix] & C[Test` — mermaid syntax drawn
+  /// as if it were a label, which is the confidently-wrong rendering boards exist to avoid.
+  @Test
+  func anAmpersandFansOutToEveryNodeOnTheOtherSide() throws {
+    let board = try #require(
+      MermaidBoardParser.board(
+        fromReply: """
+          ```mermaid
+          flowchart TD
+            A[Read issue] --> B[Fix] & C[Test]
+            B & C --> D[Ship]
+          ```
+          """, pass: 1))
+    #expect(board.nodes.map(\.id) == ["A", "B", "C", "D"])
+    #expect(board.nodes.map(\.text) == ["Read issue", "Fix", "Test", "Ship"])
+    #expect(
+      board.edges.map { "\($0.from)\($0.to)" } == ["AB", "AC", "BD", "CD"])
+  }
+
+  /// The label the arrow carries belongs to every edge the fan-out makes.
+  @Test
+  func aFannedOutLinkKeepsItsLabelOnEveryEdge() throws {
+    let board = try #require(
+      MermaidBoardParser.board(
+        fromReply: """
+          ```mermaid
+          flowchart TD
+            A{Ready?} -->|yes| B[Build] & C[Test]
+          ```
+          """, pass: 1))
+    #expect(board.edges.count == 2)
+    #expect(board.edges.allSatisfy { $0.label == "yes" })
+  }
+
+  /// An `&` inside a label is text. Splitting there would cut a box in half.
+  @Test
+  func anAmpersandInsideALabelIsNotAFanOut() throws {
+    let board = try #require(
+      MermaidBoardParser.board(
+        fromReply: """
+          ```mermaid
+          flowchart TD
+            A[Cut & paste] --> B["Copy & keep"]
+          ```
+          """, pass: 1))
+    #expect(board.nodes.map(\.text) == ["Cut & paste", "Copy & keep"])
+    #expect(board.edges.count == 1)
+  }
+
+  /// Markdown says `\|` is a pipe in a cell, not the end of one — and a coding session
+  /// writes them: a shell pipeline, an `A | B` type. Split on, the row gained a column
+  /// the table has no header for and the cell was cut in two.
+  @Test
+  func anEscapedPipeStaysInsideItsCell() throws {
+    let board = try #require(
+      MermaidBoardParser.board(
+        fromReply: """
+          | Command | Note |
+          |---|---|
+          | `a \\| b` | pipes |
+          | plain | none |
+          """, pass: 1))
+    #expect(board.table?.headers == ["Command", "Note"])
+    #expect(board.table?.rows == [["`a | b`", "pipes"], ["plain", "none"]])
+  }
+
+  /// A backslash that is not escaping a pipe is kept — a Windows path is not syntax.
+  @Test
+  func aBackslashThatIsNotAnEscapeSurvives() {
+    #expect(MermaidBoardParser.cells(of: #"| C:\dir | windows |"#) == [#"C:\dir"#, "windows"])
+  }
 }

--- a/graphcode/Tests/SummaryStoreTests.swift
+++ b/graphcode/Tests/SummaryStoreTests.swift
@@ -302,6 +302,33 @@ struct SummaryStoreTests {
     #expect(deduped == reading)
   }
 
+  /// A rewritten sentence must not cost the reading everything else it carries.
+  ///
+  /// The whole board feature rides on `closing`: it is the agent's own answer, the only
+  /// field a diagram can be drawn from, and it was being dropped on exactly the poll a
+  /// board is composed on — every loop in a nineteen-loop graph read `closing: nil`, so
+  /// nothing was ever drawn.
+  @Test
+  func rewritingTheNewestBeatKeepsEverythingElseTheReadingCarries() {
+    let reading = SummaryReading(
+      beats: [beat(1, "Reading the probe", at: 1), beat(1, "Editing the parser", at: 2)],
+      finishedPasses: [PassSummary(pass: 1, text: "did pass 1")],
+      turns: [Date(timeIntervalSince1970: 5)],
+      passEndedAt: [1: Date(timeIntervalSince1970: 9)],
+      metricSamples: [MetricSample(value: 42, recordedAt: Date(timeIntervalSince1970: 7))],
+      closing: "| File | Lines |\n|---|---|\n| A.swift | 12 |")
+    let rewritten = reading.replacingNewestBeat(
+      with: beat(1, "Tightening the parser", at: 2))
+
+    #expect(rewritten.beats.last?.text == "Tightening the parser")
+    #expect(rewritten.beats.first == reading.beats.first)
+    #expect(rewritten.finishedPasses == reading.finishedPasses)
+    #expect(rewritten.turns == reading.turns)
+    #expect(rewritten.passEndedAt == reading.passEndedAt)
+    #expect(rewritten.metricSamples == reading.metricSamples)
+    #expect(rewritten.closing == reading.closing)
+  }
+
   /// A quiet loop must cost a `stat` and no read, or dropping the `busy` guard would put
   /// a tail parse per idle loop on every poll.
   @Test


### PR DESCRIPTION
Verification of the summary-board (visualise) feature shipped in 0.1.52-beta1..beta3, and the three defects it found.

## What was wrong

**Nothing was ever drawn.** Nineteen loops in the live graph, `summarisesLoops` and `visualisesSummaries` both on, the shipping build installed — and not one node carried a board. The cause is not in any file the feature added:

`SummaryModelWriter.applied` rebuilt its result as `SummaryReading(beats:finishedPasses:)` — two of that type's six fields — dropping `turns`, `passEndedAt`, `metricSamples` and `closing` on every poll carrying a new beat, which is exactly the poll a board is composed on. `closing` is the agent's own answer and the only thing a diagram can be drawn from.

Measured, not reasoned: every one of the nineteen read `closing: nil` through `CLISessionBackend.readSummary`, while the same transcripts read directly returned 31–1500 characters. With the field carried through, **15 of the 19 draw a board immediately** — every one a table the session had already written, at zero model calls.

**`A --> B & C` drew a box labelled `Fix] & C[Test`.** Mermaid's fan-out was read as one node, and on the left (`A & B --> C`) it lost a node outright. A side of a link is now a list, joined pairwise; the arrow's label goes on each edge; an `&` inside a label stays text.

**`\|` split a table cell.** Markdown says it is a literal pipe; a coding session writes them (a shell pipeline, an `A | B` type). The row gained a column the table has no header for.

## What was checked and is correct

- The parser against 33 real-world Mermaid and Markdown inputs — quoted labels, `%%{init}` directives, `subgraph`, `classDef`, chained and unfenced diagrams, all four link styles, caps, both alignment spellings. Everything outside the subset falls through to the source view rather than to a wrong drawing.
- The renderer against ten boards, drawn headless and looked at: branch-and-retry, feedback routing, fork/join, wide fan-out, duplicate edges, long labels, mixed tables with verdict pills and diffstats.
- Off means inert, a pass is drawn once, at most two loops a tick — the existing 72 board tests still hold.

## Known, not fixed here

- An edge that skips a layer (`C -->|no| F` where `E` sits between) routes straight through the box in between, hiding its label.
- `A --> A` is parsed and then not drawn.

Full suite: 1184 tests, all passing. `make check` clean.