### PR TITLE
fix: draw one table, without its markup, and copy it as Markdown

### DIFF
--- a/GraphcodeKit/Sources/Sessions/MermaidBoardParser.swift
+++ b/GraphcodeKit/Sources/Sessions/MermaidBoardParser.swift
@@ -353,24 +353,36 @@ public enum MermaidBoardParser {
   /// containing a pipe — legal, if rare — parses as a one-row table, and a board that
   /// draws the wrong form is worse than one that draws nothing.
   static func table(from block: String, pass: Int, now: Date) -> SummaryBoard? {
-    let rows =
-      block
-      .components(separatedBy: .newlines)
+    let lines = block.components(separatedBy: .newlines)
       .map { $0.trimmingCharacters(in: .whitespaces) }
-      .filter { $0.hasPrefix("|") }
-    guard rows.count >= 3 else { return nil }
-    let headers = cells(of: rows[0])
-    guard !headers.isEmpty, isSeparator(rows[1]), cells(of: rows[1]).count == headers.count
+    // **The first table, not every pipe in the reply.** Filtering the whole block for lines
+    // beginning with `|` reads two tables under one heading as one table, with the second
+    // one's header and `---` separator drawn as data rows. A real answer has two tables in
+    // it often enough — a summary and then a breakdown — and the merged grid was the
+    // confidently-wrong drawing this feature is meant not to produce.
+    guard
+      let start = lines.indices.dropLast().first(where: { index in
+        let header = lines[index]
+        guard header.hasPrefix("|") else { return false }
+        let separator = lines[index + 1]
+        return separator.hasPrefix("|") && isSeparator(separator)
+          && cells(of: separator).count == cells(of: header).count
+      })
     else { return nil }
-    let body = rows.dropFirst(2).map { cells(of: $0) }.filter { row in
-      row.contains { !$0.isEmpty }
-    }
+    let headers = cells(of: lines[start])
+    guard !headers.isEmpty else { return nil }
+    let rows = Array(lines[(start + 2)...].prefix { $0.hasPrefix("|") })
+    let body = rows.map { cells(of: $0) }.filter { row in row.contains { !$0.isEmpty } }
     guard !body.isEmpty else { return nil }
     let board = SummaryBoard(
       form: .table,
       table: BoardTable(
-        headers: headers, rows: body, alignments: alignments(ofSeparator: rows[1])),
-      source: block, pass: pass, composedAt: now)
+        headers: headers, rows: body,
+        alignments: alignments(ofSeparator: lines[start + 1])),
+      // The table alone rather than the answer it sat in. This is what the header's copy
+      // button puts on the pasteboard, and prose above a table is not part of the table.
+      source: (Array(lines[start...(start + 1)]) + rows).joined(separator: "\n"),
+      pass: pass, composedAt: now)
     return board.isDrawable ? board : nil
   }
 
@@ -400,7 +412,28 @@ public enum MermaidBoardParser {
     }
     if escaped { current.append("\\") }
     cells.append(current)
-    return cells.map { $0.trimmingCharacters(in: .whitespaces) }
+    return cells.map { unemphasised($0.trimmingCharacters(in: .whitespaces)) }
+  }
+
+  /// A cell without its Markdown emphasis — `**461**` is the number 461, and `` `.dmg` ``
+  /// is `.dmg`.
+  ///
+  /// The rail draws a table in its own type, so the markers have nothing to render *as*:
+  /// left in, they printed literally in a 100-point column, and they cost the column its
+  /// meaning as well as its looks — `**461**` is not a number, so a column an agent
+  /// bolded lost its right alignment and its bars. Agents bold the figure that moved in
+  /// almost every table they write.
+  static func unemphasised(_ text: String) -> String {
+    var body = text
+    for marker in ["**", "__", "`"] {
+      body = body.replacingOccurrences(of: marker, with: "")
+    }
+    if body.count > 1, let first = body.first, let last = body.last, first == last,
+      first == "*" || first == "_"
+    {
+      body = String(body.dropFirst().dropLast())
+    }
+    return body.trimmingCharacters(in: .whitespaces)
   }
 
   /// `|---|---:|:--:|` — what the author asked for, per column.

--- a/graphcode/Sources/Features/LoopWorkspace/SummaryBoardSection.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/SummaryBoardSection.swift
@@ -75,7 +75,7 @@ struct SummaryBoardSection: View {
       }
       Spacer(minLength: 0)
       if let board = presentation.board, !isFolded {
-        iconButton("doc.on.doc", help: "Copy the Mermaid") { copy(board.source) }
+        iconButton("doc.on.doc", help: copyHelp(board)) { copy(board) }
         if board.form == .flow {
           iconButton("square.and.arrow.down", help: "Export for Excalidraw") { export(board) }
         }
@@ -116,10 +116,27 @@ struct SummaryBoardSection: View {
   /// The source, not a rendering. A board's whole portability is that it is Mermaid — it
   /// pastes into a pull request, an issue or anywhere else that draws one, and graphcode
   /// happens to be a place that draws it natively.
-  private func copy(_ source: String) {
+  private func copy(_ board: SummaryBoard) {
     let pasteboard = NSPasteboard.general
     pasteboard.clearContents()
-    pasteboard.setString("```mermaid\n\(source)\n```", forType: .string)
+    pasteboard.setString(Self.pasteboardText(for: board), forType: .string)
+  }
+
+  /// What a board is portable *as*, which is not one answer for both forms.
+  ///
+  /// A flow is Mermaid and belongs in a fenced `mermaid` block, where a pull request or an
+  /// issue draws it. A table is GitHub-flavoured Markdown and is already a table anywhere
+  /// it is pasted — wrapping it in a Mermaid fence made it render as a failed diagram in
+  /// every one of those places.
+  static func pasteboardText(for board: SummaryBoard) -> String {
+    switch board.form {
+    case .flow: return "```mermaid\n\(board.source)\n```"
+    case .table: return board.source
+    }
+  }
+
+  private func copyHelp(_ board: SummaryBoard) -> LocalizedStringKey {
+    board.form == .flow ? "Copy the Mermaid" : "Copy the Markdown"
   }
 
   /// The same diagram, somewhere it can be rearranged by hand.

--- a/graphcode/Tests/BoardTablePresentationTests.swift
+++ b/graphcode/Tests/BoardTablePresentationTests.swift
@@ -117,4 +117,21 @@ struct BoardTablePresentationTests {
     #expect(BoardTablePresentation.number(from: "3 files") == nil)
     #expect(BoardTablePresentation.number(from: "") == nil)
   }
+
+  /// A table is Markdown wherever it is pasted; a Mermaid fence around one makes every
+  /// reader draw it as a failed diagram.
+  @Test
+  func aTableIsCopiedAsMarkdownAndAFlowAsMermaid() {
+    let table = SummaryBoard(
+      form: .table, table: BoardTable(headers: ["A"], rows: [["1"]]),
+      source: "| A |\n|---|\n| 1 |", pass: 1)
+    #expect(SummaryBoardSection.pasteboardText(for: table) == "| A |\n|---|\n| 1 |")
+
+    let flow = SummaryBoard(
+      form: .flow, nodes: [BoardNode(id: "A", text: "One"), BoardNode(id: "B", text: "Two")],
+      edges: [BoardEdge(from: "A", to: "B")], source: "flowchart TD\n  A --> B", pass: 1)
+    #expect(
+      SummaryBoardSection.pasteboardText(for: flow)
+        == "```mermaid\nflowchart TD\n  A --> B\n```")
+  }
 }

--- a/graphcode/Tests/MermaidBoardParserTests.swift
+++ b/graphcode/Tests/MermaidBoardParserTests.swift
@@ -440,12 +440,73 @@ struct MermaidTableParserTests {
           | plain | none |
           """, pass: 1))
     #expect(board.table?.headers == ["Command", "Note"])
-    #expect(board.table?.rows == [["`a | b`", "pipes"], ["plain", "none"]])
+    #expect(board.table?.rows == [["a | b", "pipes"], ["plain", "none"]])
   }
 
   /// A backslash that is not escaping a pipe is kept — a Windows path is not syntax.
   @Test
   func aBackslashThatIsNotAnEscapeSurvives() {
     #expect(MermaidBoardParser.cells(of: #"| C:\dir | windows |"#) == [#"C:\dir"#, "windows"])
+  }
+
+  /// Two tables in one answer are two tables. Read as one, the second one's header and
+  /// `---` row were drawn as data — a grid whose rows come from different tables, under a
+  /// heading belonging to only one of them.
+  @Test
+  func onlyTheFirstTableInAnAnswerIsDrawn() throws {
+    let board = try #require(
+      MermaidBoardParser.board(
+        fromReply: """
+          Downloads are up.
+
+          | Metric | Now |
+          |---|---:|
+          | Total | 461 |
+          | Stable | 307 |
+
+          And by version:
+
+          | Version | Count |
+          |---|---:|
+          | v0.1.43 | 20 |
+          """, pass: 1))
+    #expect(board.table?.headers == ["Metric", "Now"])
+    #expect(board.table?.rows == [["Total", "461"], ["Stable", "307"]])
+    #expect(board.source == "| Metric | Now |\n|---|---:|\n| Total | 461 |\n| Stable | 307 |")
+  }
+
+  /// The prose a table sat in is not part of the table — the copy button puts this on the
+  /// pasteboard.
+  @Test
+  func aTablesSourceIsTheTableAndNothingAroundIt() throws {
+    let board = try #require(
+      MermaidBoardParser.board(
+        fromReply: """
+          Here is what I found, and I will fix it next:
+
+          | File | Lines |
+          |---|---:|
+          | A.swift | 438 |
+
+          Let me know.
+          """, pass: 1))
+    #expect(board.source == "| File | Lines |\n|---|---:|\n| A.swift | 438 |")
+  }
+
+  /// An agent bolds the figure that moved. Left in, the markers printed literally *and*
+  /// cost the column its alignment, because `**461**` is not a number.
+  @Test
+  func aCellKeepsItsValueAndLosesItsMarkdownEmphasis() throws {
+    let board = try #require(
+      MermaidBoardParser.board(
+        fromReply: """
+          | Metric | Now | Note |
+          |---|---:|---|
+          | Stable `.dmg` | **461** | *climbing* |
+          | Beta | 154 | __steady__ |
+          """, pass: 1))
+    #expect(board.table?.headers == ["Metric", "Now", "Note"])
+    #expect(
+      board.table?.rows == [["Stable .dmg", "461", "climbing"], ["Beta", "154", "steady"]])
   }
 }


### PR DESCRIPTION
Follow-up to #191. With boards drawing on the live graph for the first time, three defects showed up in the rendering of real answers — none of them visible against hand-written test input.

| Defect | What it drew | Now |
|---|---|---|
| Two tables in one answer | One grid, with the second table's header and `---` row as data | The first table, ending where it ends |
| `**461**`, `` `.dmg` `` | Printed literally, and the column lost its numeric alignment and bars | `461`, `.dmg` — markers off before classification |
| Copy on a table board | Markdown wrapped in a ```` ```mermaid ```` fence | The Markdown table itself |

`SummaryBoard.source` for a table board narrows to the table, so the copy button no longer carries the prose the table sat in.

Found by rendering the eleven boards the live daemon composed after #191 landed and looking at them.

Full suite: 1188 tests, all passing. `make check` clean.