### PR TITLE
fix: the four things a board still got wrong

### DIFF
--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -700,7 +700,15 @@ public actor GraphStore {
     let candidates =
       graph.nodes
       .compactMap { node -> (node: LoopNode, summary: LoopSummary, behind: Int)? in
-        guard let summary = node.summary, !summary.passes.isEmpty else { return nil }
+        // A finished pass, by either account. `passes` is the pass *lines*, which a heavy
+        // loop never has: they are built from beats read out of a 512KB tail, and a session
+        // whose single pass fills that window has no older pass in it to summarise. Its
+        // `currentPass` still counts the turns, and a loop on pass 40 has plainly finished
+        // some — so the busiest loops in a graph, which are the ones with a shape worth
+        // drawing, were the only ones never eligible to be drawn.
+        guard let summary = node.summary,
+          summary.currentPass > 1 || !summary.passes.isEmpty
+        else { return nil }
         let settled = max(node.board?.pass ?? 0, boardAttempts[node.id] ?? 0)
         let behind = summary.currentPass - settled
         guard behind > 0 else { return nil }

--- a/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
+++ b/GraphcodeKit/Sources/Sessions/SummaryBeatBuilder.swift
@@ -67,7 +67,7 @@ struct SummaryBeatBuilder {
     // **Before the guard, not after.** `condense` refuses anything that is not a sentence,
     // and an answer that is nothing but a table or a fenced diagram is exactly that — so
     // capturing after the guard dropped the very answers worth drawing.
-    latestRaw = String(raw.prefix(Self.maxClosing))
+    latestRaw = Self.clipped(raw)
     guard let text = Self.condense(raw) else { return }
     close()
     open = Open(at: date, pass: max(pass, 1), text: text)
@@ -76,7 +76,39 @@ struct SummaryBeatBuilder {
   /// How much of an answer is worth carrying. Enough for a table of a dozen rows or a plan
   /// with a branch in it; short of a whole essay, which would put more in the composer's
   /// prompt than the summary it is meant to be drawing.
-  static let maxClosing = 1_500
+  ///
+  /// **Raised from 1,500 because the two ends of this disagreed.** A closing answer is cut
+  /// from the *front* and `MermaidBoardParser` prefers the *last* fenced block, so an agent
+  /// that explained itself and then drew the diagram — the commonest shape there is — had
+  /// the diagram cut off and the explanation kept. Four thousand characters covers the long
+  /// tail of real answers; past that the cut is honest rather than silent, because
+  /// `clipped` refuses to end inside a fence.
+  static let maxClosing = 4_000
+
+  /// An answer cut to `maxClosing`, on a line boundary, never inside a fenced block.
+  ///
+  /// A cut mid-fence leaves an opening ``` with no closing one, which `lastBlock` reads as a
+  /// diagram that ran out of budget and draws as far as it got — half a flowchart presented
+  /// as the whole of one. Dropping the unterminated block loses the diagram, which is the
+  /// honest outcome: nothing is drawn, and the rail says so.
+  static func clipped(_ raw: String) -> String {
+    guard raw.count > maxClosing else { return raw }
+    var kept = String(raw.prefix(maxClosing))
+    if let boundary = kept.lastIndex(of: "\n") { kept = String(kept[..<boundary]) }
+    let lines = kept.components(separatedBy: .newlines)
+    let fences = lines.filter { line in
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      return trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~")
+    }
+    guard fences.count % 2 == 1 else { return kept }
+    guard
+      let opening = lines.lastIndex(where: { line in
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        return trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~")
+      })
+    else { return kept }
+    return lines[..<opening].joined(separator: "\n")
+  }
 
   /// One tool call, in the phrase its backend reader already speaks — `"editing
   /// Foo.swift"`, `"running make check"`.

--- a/graphcode/Sources/Features/LoopWorkspace/BoardRouting.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/BoardRouting.swift
@@ -28,6 +28,21 @@ extension BoardLayout {
     let spreads: [String: CGFloat]
     /// Where a feedback arrow climbs, outside the widest box.
     let lane: CGFloat
+    /// Every box on the board, so a route can tell whether it would cross one.
+    let boxes: [String: CGRect]
+    /// The lane assigned to each arrow that has to go round a box in its way — see
+    /// `detourLanes`.
+    let detours: [String: DetourLane]
+  }
+
+  /// Where one detour runs, and which detour it is.
+  ///
+  /// The index is carried because two lanes twenty points apart still put their labels on
+  /// top of one another — a label is wider than the gap. Each detour hangs its label at a
+  /// different height along its own lane instead.
+  struct DetourLane: Equatable {
+    let lane: CGFloat
+    let index: Int
   }
 
   static func routes(
@@ -35,16 +50,100 @@ extension BoardLayout {
   ) -> [PlacedEdge] {
     let context = RouteContext(
       frames: frames, direction: board.direction, feedback: feedback,
-      spreads: spreads(of: board.edges), lane: lane)
+      spreads: spreads(of: board.edges), lane: lane, boxes: frames,
+      detours: detourLanes(
+        of: board, frames: frames, feedback: feedback,
+        direction: board.direction))
     return board.edges.compactMap { route($0, in: context) }
+  }
+
+  /// Which arrows cannot be drawn straight, and where each one goes instead.
+  ///
+  /// **An arrow that skips a layer crosses whatever sits in the layer it skipped.** A
+  /// `C -->|no| F` beside a `C --> E --> F` leaves C's bottom and enters F's top, straight
+  /// through E — and since the boxes are drawn *over* the arrows, the line does not merely
+  /// cross E, it disappears behind it, taking its `no` label with it. A diagram that showed
+  /// a branch then showed one arm of it and no sign of the other.
+  ///
+  /// Each blocked arrow gets its own lane outside the drawing, on the opposite side from
+  /// the feedback lane, so a board with both keeps them apart and two detours do not land
+  /// on one line.
+  static func detourLanes(
+    of board: SummaryBoard, frames: [String: CGRect], feedback: Set<String>,
+    direction: BoardDirection
+  ) -> [String: DetourLane] {
+    var lanes: [String: DetourLane] = [:]
+    var taken = 0
+    for edge in board.edges
+    where !feedback.contains(edge.id) && edge.from != edge.to {
+      guard let from = frames[edge.from], let to = frames[edge.to] else { continue }
+      let start: CGPoint
+      let end: CGPoint
+      switch direction {
+      case .topDown:
+        start = CGPoint(x: from.midX, y: from.maxY)
+        end = CGPoint(x: to.midX, y: to.minY)
+      case .leftRight:
+        start = CGPoint(x: from.maxX, y: from.midY)
+        end = CGPoint(x: to.minX, y: to.midY)
+      }
+      let blocked = frames.contains { id, box in
+        id != edge.from && id != edge.to
+          && segment(from: start, to: end, crosses: box.insetBy(dx: 2, dy: 2))
+      }
+      guard blocked else { continue }
+      lanes[edge.id] = DetourLane(
+        lane: -(feedbackInset + CGFloat(taken) * detourLaneGap), index: taken)
+      taken += 1
+    }
+    return lanes
+  }
+
+  /// How far apart two detour lanes sit — an edge label's height, so two labelled detours
+  /// do not stack their chips on one another.
+  static let detourLaneGap: CGFloat = 20
+
+  /// Whether a straight run between two points passes through a box. Liang–Barsky, because
+  /// sampling the line misses a box narrower than the sample step and this has to be right
+  /// about the one case it exists for.
+  static func segment(from start: CGPoint, to end: CGPoint, crosses box: CGRect) -> Bool {
+    guard !box.isEmpty else { return false }
+    let dx = end.x - start.x
+    let dy = end.y - start.y
+    var enter: CGFloat = 0
+    var exit: CGFloat = 1
+    let checks: [(p: CGFloat, q: CGFloat)] = [
+      (-dx, start.x - box.minX), (dx, box.maxX - start.x),
+      (-dy, start.y - box.minY), (dy, box.maxY - start.y),
+    ]
+    for check in checks {
+      if check.p == 0 {
+        if check.q < 0 { return false }
+        continue
+      }
+      let ratio = check.q / check.p
+      if check.p < 0 {
+        enter = max(enter, ratio)
+      } else {
+        exit = min(exit, ratio)
+      }
+      if enter > exit { return false }
+    }
+    return true
   }
 
   static func route(_ edge: BoardEdge, in context: RouteContext) -> PlacedEdge? {
     guard let from = context.frames[edge.from], let to = context.frames[edge.to] else {
       return nil
     }
+    if edge.from == edge.to {
+      return selfRoute(edge, box: from)
+    }
     if context.feedback.contains(edge.id) {
       return feedbackRoute(edge, from: from, to: to, lane: context.lane)
+    }
+    if let detour = context.detours[edge.id] {
+      return bandRoute(edge, from: from, to: to, detour: detour, axis: context.direction)
     }
     let spread = context.spreads[edge.id] ?? 0
     let start: CGPoint
@@ -100,4 +199,81 @@ extension BoardLayout {
       // feedback route is always the drop out of the band above its target.
       isFeedback: true, spread: 0, axis: .topDown)
   }
+
+  /// A forward arrow taken out of the boxes' way — out of its source, across the empty band
+  /// under it, along a lane outside the drawing, and back in through the band above its
+  /// target.
+  ///
+  /// The same three-band shape as `feedbackRoute` and, unlike it, written for both
+  /// directions: a left-right board's empty bands run down the page rather than across it,
+  /// and a detour that assumed otherwise would step aside into the boxes it was avoiding.
+  static func bandRoute(
+    _ edge: BoardEdge, from: CGRect, to: CGRect, detour: DetourLane, axis: BoardDirection
+  ) -> PlacedEdge {
+    let lane = detour.lane
+    // Alternating heights along the lane, so two detours running past each other do not
+    // stack their labels on one point.
+    let along: CGFloat = detour.index.isMultiple(of: 2) ? 0.36 : 0.68
+    switch axis {
+    case .topDown:
+      let below = from.maxY + layerGap / 2
+      let above = to.minY - layerGap / 2
+      return PlacedEdge(
+        edge: edge,
+        start: CGPoint(x: from.midX, y: from.maxY),
+        end: CGPoint(x: to.midX, y: to.minY),
+        waypoints: [
+          CGPoint(x: from.midX, y: below),
+          CGPoint(x: lane, y: below),
+          CGPoint(x: lane, y: above),
+          CGPoint(x: to.midX, y: above),
+        ],
+        labelPoint: CGPoint(x: lane, y: below + (above - below) * along),
+        isFeedback: false, spread: 0, axis: .topDown)
+    case .leftRight:
+      let after = from.maxX + layerGap / 2
+      let before = to.minX - layerGap / 2
+      return PlacedEdge(
+        edge: edge,
+        start: CGPoint(x: from.maxX, y: from.midY),
+        end: CGPoint(x: to.minX, y: to.midY),
+        waypoints: [
+          CGPoint(x: after, y: from.midY),
+          CGPoint(x: after, y: lane),
+          CGPoint(x: before, y: lane),
+          CGPoint(x: before, y: to.midY),
+        ],
+        labelPoint: CGPoint(x: after + (before - after) * along, y: lane),
+        isFeedback: false, spread: 0, axis: .leftRight)
+    }
+  }
+
+  /// `A --> A` — a step that repeats itself.
+  ///
+  /// It has always parsed and it has never been drawn: a self-edge is a cycle, so the
+  /// feedback pass claimed it, and `feedbackRoute` then drew it out to the same lane every
+  /// other feedback arrow uses, where it landed on top of one of them and read as nothing
+  /// at all. It gets a loop of its own instead, hugging the box it belongs to, which is
+  /// what a self-edge means and where a reader looks for it.
+  static func selfRoute(_ edge: BoardEdge, box: CGRect) -> PlacedEdge {
+    let lane = box.maxX + selfLoopReach
+    let above = box.minY - selfLoopRise
+    let entry = CGPoint(x: box.midX + box.width / 4, y: box.minY)
+    return PlacedEdge(
+      edge: edge,
+      start: CGPoint(x: box.maxX, y: box.midY),
+      end: entry,
+      waypoints: [
+        CGPoint(x: lane, y: box.midY),
+        CGPoint(x: lane, y: above),
+        CGPoint(x: entry.x, y: above),
+      ],
+      labelPoint: CGPoint(x: lane + selfLoopReach, y: (above + box.midY) / 2),
+      isFeedback: true, spread: 0, axis: .topDown)
+  }
+
+  /// How far outside its box a self-loop reaches, and how far above it climbs. Both small:
+  /// the loop is a mark on one box, not a journey across the board.
+  static let selfLoopReach: CGFloat = 14
+  static let selfLoopRise: CGFloat = 16
 }

--- a/graphcode/Tests/BoardLayoutTests.swift
+++ b/graphcode/Tests/BoardLayoutTests.swift
@@ -191,4 +191,111 @@ struct BoardLayoutTests {
       ).nodes.isEmpty)
     #expect(BoardLayout(board: board([], nodes: [BoardNode(id: "A", text: "A")])).nodes.isEmpty)
   }
+
+  /// An arrow that skips a layer crosses whatever sits in the layer it skipped — and the
+  /// boxes are drawn *over* the arrows, so it does not read as a crossing, it reads as an
+  /// arrow that is not there. `C -->|no| F` beside `C --> E --> F` is the shape every
+  /// branch-and-rejoin diagram has.
+  @Test
+  func anArrowThatWouldCrossABoxGoesRoundItInstead() throws {
+    let layout = BoardLayout(
+      board: board([("A", "B"), ("B", "C"), ("A", "C")]))
+    let skipping = try #require(layout.edges.first { $0.edge.from == "A" && $0.edge.to == "C" })
+    let straight = try #require(layout.edges.first { $0.edge.from == "A" && $0.edge.to == "B" })
+
+    #expect(!skipping.waypoints.isEmpty)
+    #expect(straight.waypoints.isEmpty)
+
+    // And the way it goes round is outside every box, rather than between two of them.
+    let boxes = layout.nodes.map(\.frame)
+    for point in skipping.waypoints {
+      #expect(!boxes.contains { $0.insetBy(dx: -1, dy: -1).contains(point) })
+    }
+  }
+
+  /// The detour runs on the opposite side from the lane a retry climbs, so a board with
+  /// both does not draw them on one line.
+  @Test
+  func aDetourAndAFeedbackArrowUseOppositeSides() throws {
+    let layout = BoardLayout(
+      board: SummaryBoard(
+        form: .flow,
+        nodes: ["A", "B", "C"].map { BoardNode(id: $0, text: $0) },
+        edges: [
+          BoardEdge(from: "A", to: "B"), BoardEdge(from: "B", to: "C"),
+          BoardEdge(from: "A", to: "C"), BoardEdge(from: "C", to: "A", label: "no"),
+        ], source: "", pass: 1))
+    let detour = try #require(layout.edges.first { $0.edge.from == "A" && $0.edge.to == "C" })
+    let feedback = try #require(layout.edges.first { $0.edge.from == "C" && $0.edge.to == "A" })
+    let boxes = layout.nodes.reduce(CGRect.null) { $0.union($1.frame) }
+
+    #expect(detour.waypoints.contains { $0.x < boxes.minX })
+    #expect(feedback.waypoints.contains { $0.x > boxes.maxX })
+  }
+
+  /// Two detours are two lanes, and two labels that are not on one point.
+  @Test
+  func twoDetoursGetTheirOwnLanesAndTheirOwnLabelHeights() throws {
+    let layout = BoardLayout(
+      board: SummaryBoard(
+        form: .flow,
+        nodes: ["A", "B", "C", "D"].map { BoardNode(id: $0, text: $0) },
+        edges: [
+          BoardEdge(from: "A", to: "B"), BoardEdge(from: "B", to: "C"),
+          BoardEdge(from: "C", to: "D"),
+          BoardEdge(from: "A", to: "D", label: "fast path"),
+          BoardEdge(from: "B", to: "D", label: "skip"),
+        ], source: "", pass: 1))
+    let first = try #require(layout.edges.first { $0.edge.from == "A" && $0.edge.to == "D" })
+    let second = try #require(layout.edges.first { $0.edge.from == "B" && $0.edge.to == "D" })
+
+    #expect(first.labelPoint.x != second.labelPoint.x)
+    #expect(first.labelPoint.y != second.labelPoint.y)
+  }
+
+  /// `A --> A` parsed from the first day and drew nothing: a self-edge is a cycle, so it
+  /// was routed out to the feedback lane and landed under whichever real feedback arrow was
+  /// already there. It belongs on its own box.
+  @Test
+  func aSelfEdgeLoopsAroundItsOwnBox() throws {
+    let layout = BoardLayout(
+      board: SummaryBoard(
+        form: .flow,
+        nodes: ["A", "B"].map { BoardNode(id: $0, text: $0) },
+        edges: [BoardEdge(from: "A", to: "B"), BoardEdge(from: "A", to: "A", label: "retry")],
+        source: "", pass: 1))
+    let loop = try #require(layout.edges.first { $0.edge.from == "A" && $0.edge.to == "A" })
+    let box = try #require(layout.nodes.first { $0.id == "A" }).frame
+    let other = try #require(layout.nodes.first { $0.id == "B" }).frame
+
+    #expect(!loop.waypoints.isEmpty)
+    // It starts on its own box and ends on its own box.
+    #expect(abs(loop.start.x - box.maxX) < 0.5)
+    #expect(abs(loop.end.y - box.minY) < 0.5)
+    // And stays beside that box rather than travelling the board.
+    for point in loop.waypoints + [loop.start, loop.end] {
+      #expect(point.x < box.maxX + 3 * BoardLayout.feedbackInset)
+      #expect(!other.contains(point))
+    }
+  }
+
+  /// The geometry test under the routing: a straight run either passes through a box or it
+  /// does not, and a sampled line would miss a narrow one.
+  @Test
+  func aStraightRunKnowsWhetherItCrossesABox() {
+    let box = CGRect(x: 40, y: 40, width: 20, height: 20)
+    #expect(
+      BoardLayout.segment(
+        from: CGPoint(x: 50, y: 0), to: CGPoint(x: 50, y: 100), crosses: box))
+    #expect(
+      !BoardLayout.segment(
+        from: CGPoint(x: 10, y: 0), to: CGPoint(x: 10, y: 100), crosses: box))
+    // Ends short of it, and starts past it.
+    #expect(
+      !BoardLayout.segment(
+        from: CGPoint(x: 50, y: 0), to: CGPoint(x: 50, y: 30), crosses: box))
+    #expect(
+      !BoardLayout.segment(
+        from: CGPoint(x: 50, y: 70), to: CGPoint(x: 50, y: 100), crosses: box))
+  }
 }

--- a/graphcode/Tests/ClosingAnswerTests.swift
+++ b/graphcode/Tests/ClosingAnswerTests.swift
@@ -124,4 +124,37 @@ struct ClosingAnswerTests {
       SummaryBeatBuilder.condense("Here is the gate:\n\n```mermaid\nflowchart TD\n```")
         == "Here is the gate")
   }
+
+  /// **The two ends of the cap disagreed.** An answer is cut from the front and the parser
+  /// prefers the *last* fenced block, so an agent that explained itself and then drew the
+  /// diagram — which is what an agent asked for a diagram does — had the diagram cut off
+  /// and the explanation kept. Four thousand characters is what covers that shape.
+  @Test
+  func aLongAnswerKeepsTheDiagramItEndsWith() {
+    var builder = SummaryBeatBuilder()
+    let diagram = "```mermaid\nflowchart TD\n  A[One] --> B[Two]\n```"
+    let answer =
+      String(repeating: "Explaining the work in some detail. ", count: 90) + "\n\n"
+      + diagram
+    #expect(answer.count < SummaryBeatBuilder.maxClosing)
+    builder.noteNarration(answer, at: at(1))
+    builder.noteTurnEnd()
+
+    let kept = builder.closingAnswer()
+    #expect(kept?.hasSuffix("```") == true)
+    #expect(MermaidBoardParser.board(fromReply: kept ?? "", pass: 1)?.nodes.count == 2)
+  }
+
+  /// Half a flowchart drawn as a whole one is worse than no flowchart: a cut that lands
+  /// inside a fence drops the fence rather than leaving it hanging open.
+  @Test
+  func aCutThatLandsInsideAFenceDropsTheFence() {
+    let prose = String(repeating: "Line of explanation.\n", count: 260)
+    let clipped = SummaryBeatBuilder.clipped(
+      prose + "```mermaid\nflowchart TD\n" + String(repeating: "  A --> B\n", count: 400) + "```")
+    #expect(clipped.count <= SummaryBeatBuilder.maxClosing)
+    #expect(!clipped.contains("```"))
+    // And it stops on a line boundary rather than mid-sentence.
+    #expect(clipped.hasSuffix("Line of explanation."))
+  }
 }

--- a/graphcode/Tests/SummaryBoardTests.swift
+++ b/graphcode/Tests/SummaryBoardTests.swift
@@ -270,6 +270,51 @@ struct SummaryBoardTests {
     let decoded = try JSONDecoder().decode(LoopNode.self, from: data)
     #expect(decoded.board == board)
   }
+  /// **The busiest loops were the only ones never eligible.** A pass *line* is built from
+  /// beats read out of a 512KB tail, so a session whose current pass fills that window has
+  /// no older pass in it to summarise and `passes` stays empty however long it runs — while
+  /// `currentPass`, counted from turns and carried across polls, says forty. Requiring the
+  /// lines meant a loop with a shape worth drawing was skipped for being too busy.
+  @Test
+  func aLoopWhoseWindowHoldsNoPassLineIsStillDrawnOnceItHasFinishedAPass() async {
+    let composer = Composer()
+    var node = LoopNode(title: "Heavy", loopType: .goalBased, state: .running)
+    node.summary = LoopSummary(
+      beats: [
+        SummaryBeat(
+          id: "heavy-b", at: Date(timeIntervalSince1970: 10), pass: 40, kind: .editing,
+          text: "Editing the thing")
+      ],
+      passes: [], currentPass: 40)
+    let store = store([node], composer: composer)
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    #expect(await composer.asked == ["Heavy"])
+    #expect(await store.graph.nodes.first?.board != nil)
+  }
+
+  /// A loop on its first pass has finished nothing, and a board is an account of work that
+  /// happened.
+  @Test
+  func aLoopOnItsFirstPassIsNotACandidate() async {
+    let composer = Composer()
+    var node = LoopNode(title: "New", loopType: .goalBased, state: .running)
+    node.summary = LoopSummary(
+      beats: [
+        SummaryBeat(
+          id: "new-b", at: Date(timeIntervalSince1970: 10), pass: 1, kind: .reading,
+          text: "Reading the goal")
+      ],
+      passes: [], currentPass: 1)
+    let store = store([node], composer: composer)
+    let descriptor = await attach(to: store)
+    defer { close(descriptor) }
+
+    await store.pollPresence()
+    #expect(await composer.asked.isEmpty)
+  }
 }
 
 /// A `Bool` two isolation domains can share. The store reads the switch from its own actor


### PR DESCRIPTION
The four findings left open after #191 and #192, fixed and drawn.

| Finding | Was | Now |
|---|---|---|
| An arrow that skips a layer | Drawn straight through the box between, and *behind* it — line and label invisible | Routed out to its own lane, opposite the feedback lane, through the bands between layers |
| `A --> A` | Parsed, then routed to the shared feedback lane and drawn under another arrow | A loop of its own against its box |
| The closing answer's cap | First 1,500 chars, while the parser prefers the *last* fenced block — an answer that ended in a diagram lost it | 4,000, cut on a line boundary, never ending inside a fence |
| Board candidacy | Required pass *lines*, which a session whose pass fills the 512KB tail never has — the busiest loops were the only ineligible ones | A finished pass by either account (`currentPass > 1`) |

Blocked-ness is Liang–Barsky against every other box, not points sampled along the line: a sampled line steps over a narrow box.

Verified by rendering the boards headless and looking at them — fork/join with a rejoin arm, a self-loop beside a real retry, an `LR` skip, two skips at once, and the plain branch-and-retry board unchanged.

Full suite: 1197 tests, all passing. `make check` clean.