### PR TITLE
Only a handoff is a sequencing edge (fixes #194)

### DIFF
--- a/GraphcodeKit/Sources/Domain/LoopGraph.swift
+++ b/GraphcodeKit/Sources/Domain/LoopGraph.swift
@@ -146,8 +146,10 @@ public struct LoopGraph: Identifiable, Codable, Equatable, Sendable {
   /// Where the graph actually begins: nothing hands off to these, and they hand off to
   /// something. Returned in `nodes` order so the canvas doesn't reshuffle between
   /// renders.
+  public var sequencingEdges: [LoopEdge] { edges.filter { $0.kind.blocksTarget } }
+
   public var entryPoints: [UUID] {
-    let targeted = Set(edges.map(\.to))
+    let targeted = Set(sequencingEdges.map(\.to))
     let loose = unwiredNodeIDs
     return nodes.map(\.id).filter { !targeted.contains($0) && !loose.contains($0) }
   }
@@ -163,7 +165,7 @@ public struct LoopGraph: Identifiable, Codable, Equatable, Sendable {
     var reached = Set(entryPoints)
     var frontier = entryPoints
     while let current = frontier.popLast() {
-      for edge in edges where edge.from == current && !reached.contains(edge.to) {
+      for edge in sequencingEdges where edge.from == current && !reached.contains(edge.to) {
         reached.insert(edge.to)
         frontier.append(edge.to)
       }
@@ -178,7 +180,7 @@ public struct LoopGraph: Identifiable, Codable, Equatable, Sendable {
   /// and a fresh one — edgeless by construction — would otherwise claim an entry port
   /// the moment it was created.
   public var startAnchors: [UUID] {
-    let targeted = Set(edges.map(\.to))
+    let targeted = Set(sequencingEdges.map(\.to))
     let entries = nodes.filter { $0.loopType != .sketch }.map(\.id)
       .filter { !targeted.contains($0) }
 
@@ -188,7 +190,7 @@ public struct LoopGraph: Identifiable, Codable, Equatable, Sendable {
     var reached = anchored
     var frontier = entries
     while let current = frontier.popLast() {
-      for edge in edges where edge.from == current && !reached.contains(edge.to) {
+      for edge in sequencingEdges where edge.from == current && !reached.contains(edge.to) {
         reached.insert(edge.to)
         frontier.append(edge.to)
       }
@@ -198,7 +200,7 @@ public struct LoopGraph: Identifiable, Codable, Equatable, Sendable {
       var frontier = [node.id]
       reached.insert(node.id)
       while let current = frontier.popLast() {
-        for edge in edges where edge.from == current && !reached.contains(edge.to) {
+        for edge in sequencingEdges where edge.from == current && !reached.contains(edge.to) {
           reached.insert(edge.to)
           frontier.append(edge.to)
         }

--- a/graphcode/Tests/StartAnchorTests.swift
+++ b/graphcode/Tests/StartAnchorTests.swift
@@ -182,4 +182,82 @@ struct StartAnchorTests {
       nodes: [worker, sketch], edges: [LoopEdge(from: worker.id, to: sketch.id)])
     #expect(child.sidebarRoots == [worker.id])
   }
+
+  // MARK: - Only a handoff is a sequencing edge (#194)
+
+  /// **The orchestrator shape, and the bug it exposed.** A parent hands off to each child
+  /// and each child messages its result back — the pattern graphcode itself teaches, since
+  /// a child's memory is seeded at birth with the `node send <parent>` route.
+  ///
+  /// Counting the `message` return edges as sequencing made the parent "targeted", so the
+  /// whole component had no entry point and the canvas drew `cycle · no entry point` over
+  /// a graph with an obvious root. `EdgeKind.blocksTarget` had said the right rule since
+  /// the edge specs went in — "also what cycle traversal follows" — and this was the one
+  /// place that never asked it.
+  @Test
+  func aReportBackMessageDoesNotMakeTheParentTargeted() {
+    let parent = node("Orchestrator")
+    let children = (1...3).map { node("child \($0)") }
+    let wiring = children.flatMap { child in
+      [
+        LoopEdge(from: parent.id, to: child.id, kind: .handoff),
+        LoopEdge(from: child.id, to: parent.id, kind: .message),
+      ]
+    }
+    let subject = graph(nodes: [parent] + children, edges: wiring)
+
+    #expect(subject.entryPoints == [parent.id])
+    #expect(subject.cycleOnlyNodeIDs.isEmpty)
+    #expect(subject.startAnchors == [parent.id])
+  }
+
+  /// The other half of the same rule: a genuine sequencing cycle must still be one. Two
+  /// handoffs closing a ring have no entry point, and saying so is the honest answer —
+  /// `startAnchors` still picks one so nothing floats free of the start marker.
+  @Test
+  func aRingOfHandoffsIsStillACycleWithNoEntryPoint() {
+    let first = node("first")
+    let second = node("second")
+    let subject = graph(
+      nodes: [first, second],
+      edges: [
+        LoopEdge(from: first.id, to: second.id, kind: .handoff),
+        LoopEdge(from: second.id, to: first.id, kind: .handoff),
+      ])
+
+    #expect(subject.entryPoints.isEmpty)
+    #expect(subject.cycleOnlyNodeIDs == Set([first.id, second.id]))
+    #expect(subject.startAnchors.count == 1)
+  }
+
+  /// A consequence worth pinning rather than discovering. Neither kind gates its target —
+  /// a `message` peer runs concurrently and a `spawn` target is a template waiting on
+  /// nothing — so both ends of such a pair are beginnings, and the canvas draws two entry
+  /// ports. Consistent with `EdgeKind.blocksTarget`, and a visible change from when every
+  /// edge counted.
+  @Test
+  func aPairWiredOnlyByANonSequencingEdgeHasTwoBeginnings() {
+    for kind in [EdgeKind.message, .spawn] {
+      let from = node("from")
+      let to = node("to")
+      let subject = graph(
+        nodes: [from, to], edges: [LoopEdge(from: from.id, to: to.id, kind: kind)])
+
+      #expect(subject.entryPoints == [from.id, to.id], "\(kind)")
+      #expect(subject.cycleOnlyNodeIDs.isEmpty, "\(kind)")
+    }
+  }
+
+  /// And the one place that must keep counting every kind. A loop reachable only by a
+  /// `message` is wired to something — calling it loose would put it in the starburst of
+  /// accidents that `unwiredNodeIDs` exists to separate out.
+  @Test
+  func aNodeWiredOnlyByAMessageIsNotLoose() {
+    let from = node("from")
+    let to = node("to")
+    let subject = graph(
+      nodes: [from, to], edges: [LoopEdge(from: from.id, to: to.id, kind: .message)])
+
+    #expect(subject.unwiredNodeIDs.isEmpty)
+  }
 }


### PR DESCRIPTION
Fixes #194, reported by @ZekeAranyLucas. I verified every claim in the issue against the code and reproduced the behaviour — the report is accurate, the diagnosis is right, and the suggested fix is the one applied here.

## The bug

Entry-point and cycle detection unioned **every** edge kind. So the orchestration pattern graphcode itself teaches — parent `handoff`s out, child `message`s its result back — was misdiagnosed as a closed cycle:

```
parent --handoff--> child ×3        entryPoints  = []
child  --message--> parent ×3       cycleOnly    = [parent, child 1, 2, 3]
                                    startAnchors = [parent]   ← arbitrary pick

same graph, message edges removed:  entryPoints  = [parent]   cycleOnly = 0
```

The canvas drew `cycle · no entry point` over a graph with an obvious root.

## Why it was already wrong on its own terms

`EdgeKind.blocksTarget` has stated the rule since edge specs landed:

> Only a `.handoff` gates its target's readiness … **Also what cycle traversal follows, since sequencing is the relation a cycle is made of.**

Three places never asked it. `entryPoints`' own doc comment said *"nothing hands off to these"* while its code checked whether anything *pointed* at them.

## The change

`sequencingEdges` used by `entryPoints`, `cycleOnlyNodeIDs`, `startAnchors`. `unwiredNodeIDs` keeps counting every kind, exactly as the issue recommends — a loop reachable only by a `message` is wired to something, and calling it loose would put it in the starburst of accidents that property exists to separate out.

## Tests, and the deliberate split

| Test | Without the fix |
|---|---|
| `aReportBackMessageDoesNotMakeTheParentTargeted` | ❌ fails — the reported bug |
| `aPairWiredOnlyByANonSequencingEdgeHasTwoBeginnings` | ❌ fails — the side effect, pinned |
| `aRingOfHandoffsIsStillACycleWithNoEntryPoint` | ✅ passes — guards against over-fixing |
| `aNodeWiredOnlyByAMessageIsNotLoose` | ✅ passes — guards `unwiredNodeIDs` |

## One consequence worth naming

Beyond the reported case, a pair wired **only** by a `message` or `spawn` now has *two* entry points rather than one — neither kind gates its target, so both ends are beginnings. Consistent with `blocksTarget`, but a visible canvas change, so it has its own test rather than being discovered later.

## Not a regression

`LoopGraph.swift` last changed 2026-08-15; no time-based work has touched it or `EdgeKind`. This is a latent inconsistency dating to `blocksTarget` being written on 2026-07-26 and never consulted. It is also not backend-specific — `LoopGraph` is pure topology — though the pattern that trips it is seeded for every child at birth in `GraphStore.linkToCreator`, whose own comment records that Copilot prompted that seeding.

The issue predicted `StartAnchorTests`, `CreatedByLoopTests` and `GraphOverviewTests` would need updating; in fact **nothing** broke. That is good news for blast radius and also explains the month-long survival: no existing test covered handoff+message topology.

## Gate

`1201 tests in 127 suites` pass · swiftlint clean · `swift format lint --strict` clean · all three schemes build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTbQQh7Tf4c7oaWNRcmdEm