### PR TITLE
fix: rule a table's columns, and stop drawing a heading row nobody wrote

### DIFF
--- a/graphcode/Sources/Features/LoopWorkspace/BoardTablePresentation.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/BoardTablePresentation.swift
@@ -51,6 +51,14 @@ struct BoardTablePresentation: Equatable {
   let columns: [Column]
   let rows: [[Cell]]
 
+  /// Whether this table has a heading row worth drawing.
+  ///
+  /// `| | |` over a `|---|---|` is how an agent writes a two-column layout when the columns
+  /// need no names — a label beside a value. Drawing the band anyway leaves an empty stripe
+  /// and a rule above the first row, which reads as a header that failed to load rather than
+  /// as one nobody wrote.
+  var hasHeaders: Bool { columns.contains { !$0.header.isEmpty } }
+
   /// Below this a numeric column is a pair of figures to read, not a series to compare.
   static let minimumRowsForBars = 3
 

--- a/graphcode/Sources/Features/LoopWorkspace/BoardTableView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/BoardTableView.swift
@@ -10,32 +10,64 @@ struct TableBoardView: View {
   let board: SummaryBoard
   let ceiling: CGFloat?
 
+  /// One grid cell: a column's contents, or the rule between two columns.
+  ///
+  /// Interleaved into an explicit list rather than branched inside the row builder, because
+  /// a `GridRow` counts the views it is handed and a conditional that sometimes emits two
+  /// makes the header's columns and the body's stop lining up.
+  private enum Slot: Hashable {
+    case column(Int)
+    case rule(Int)
+  }
+
+  private func slots(_ count: Int) -> [Slot] {
+    (0..<count).flatMap { index -> [Slot] in
+      index == 0 ? [.column(index)] : [.rule(index), .column(index)]
+    }
+  }
+
   var body: some View {
     if let table = board.table {
       let presentation = BoardTablePresentation(table: table)
+      let slots = slots(presentation.columns.count)
       // Horizontally scrollable rather than squeezed: five columns at the rail's folded
       // width is 40 points each, which is a column of ellipses.
       ScrollView([.horizontal, .vertical]) {
-        Grid(alignment: .leading, horizontalSpacing: 14, verticalSpacing: 0) {
-          GridRow {
-            ForEach(Array(presentation.columns.enumerated()), id: \.offset) { _, column in
-              Text(column.header)
-                .font(.system(size: 9.5, weight: .bold))
-                .tracking(0.5)
-                .foregroundStyle(.white.opacity(0.45))
-                .frame(maxWidth: .infinity, alignment: column.frameAlignment)
+        // Half the spacing it used to have, because there is now a rule in the middle of
+        // each gutter and the two halves add back up to the gap the table had before.
+        Grid(alignment: .leading, horizontalSpacing: 7, verticalSpacing: 0) {
+          if presentation.hasHeaders {
+            GridRow {
+              ForEach(slots, id: \.self) { slot in
+                switch slot {
+                case .rule: rule
+                case .column(let index):
+                  let column = presentation.columns[index]
+                  Text(column.header)
+                    .font(.system(size: 9.5, weight: .bold))
+                    .tracking(0.5)
+                    .foregroundStyle(.white.opacity(0.45))
+                    .frame(maxWidth: .infinity, alignment: column.frameAlignment)
+                }
+              }
             }
+            .padding(.vertical, 5)
           }
-          .padding(.vertical, 5)
           // Ruled, not striped. A `GridRow` background is applied to each *cell*, not
           // across the row, so alternating fills came out as a ragged block behind each
           // piece of text rather than as a band — worse than the plain rules it was meant
           // to improve on.
           ForEach(Array(presentation.rows.enumerated()), id: \.offset) { _, row in
-            Divider().overlay(.white.opacity(0.07)).gridCellUnsizedAxes(.horizontal)
+            Divider().overlay(.white.opacity(0.07))
+              .gridCellUnsizedAxes(.horizontal)
+              .gridCellColumns(slots.count)
             GridRow {
-              ForEach(Array(row.enumerated()), id: \.offset) { index, cell in
-                BoardCellView(cell: cell, column: presentation.columns[index])
+              ForEach(slots, id: \.self) { slot in
+                switch slot {
+                case .rule: rule
+                case .column(let index):
+                  BoardCellView(cell: row[index], column: presentation.columns[index])
+                }
               }
             }
             .padding(.vertical, 5)
@@ -48,6 +80,19 @@ struct TableBoardView: View {
     } else {
       BoardSourceView(source: board.source)
     }
+  }
+
+  /// The line between two columns.
+  ///
+  /// Fainter than the rules between rows, and deliberately so: a row rule separates one
+  /// fact from the next, where a column rule only says where a cell stops. Drawn at the
+  /// same weight it competes with the text either side of it, and a five-column board reads
+  /// as a spreadsheet rather than as a summary.
+  private var rule: some View {
+    Rectangle()
+      .fill(.white.opacity(0.05))
+      .frame(width: 1)
+      .gridCellUnsizedAxes(.vertical)
   }
 }
 

--- a/graphcode/Tests/BoardTablePresentationTests.swift
+++ b/graphcode/Tests/BoardTablePresentationTests.swift
@@ -134,4 +134,17 @@ struct BoardTablePresentationTests {
       SummaryBoardSection.pasteboardText(for: flow)
         == "```mermaid\nflowchart TD\n  A --> B\n```")
   }
+
+  /// `| | |` over a `|---|---|` is a label-and-value layout, not a table missing its
+  /// headings — the band and its rule would draw as an empty stripe above the first row.
+  @Test
+  func aTableWithNoHeadingsDrawsNoHeadingRow() {
+    let unnamed = BoardTablePresentation(
+      table: BoardTable(headers: ["", ""], rows: [["Loop", "Beta6 Release"]]))
+    #expect(!unnamed.hasHeaders)
+
+    let named = BoardTablePresentation(
+      table: BoardTable(headers: ["File", ""], rows: [["A.swift", "438"]]))
+    #expect(named.hasHeaders)
+  }
 }


### PR DESCRIPTION
Two rendering defects you can only see once a real board is on screen.

| Was | Now |
|---|---|
| Rules between rows, nothing between columns — unreadable at four columns, and no clue where a long cell ends | A hairline in every gutter, fainter than the row rules; horizontal spacing halved so the gutter stays the same width |
| `\| \| \|` (a label-and-value layout an agent writes when the columns need no names) drew an empty heading band and a rule above the first row | A table with nothing in any heading starts at its first row |

The rules are interleaved as an explicit list of slots rather than branched inside the row builder: a `GridRow` counts the views it is handed, and a conditional that sometimes emits two makes the heading row and the body stop lining up.

Verified by rendering the live graph's own table boards headless — including the headerless one this session produced — and looking at them.

Full suite: 1202 tests, all passing. `make check` clean.