### PR TITLE
Add Codex YOLO mode by default

### DIFF
--- a/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
+++ b/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
@@ -154,16 +154,19 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
   public enum CodexApprovals: String, Codable, CaseIterable, Sendable {
     /// Codex's own default: it decides when to ask, and a human answers.
     case ask
-    /// graphcode's default — never stops to ask, and may write inside its workspace.
+    /// Never stops to ask, and may write inside its workspace.
     case workspace
     /// `--dangerously-bypass-approvals-and-sandbox`, which is exactly what it says.
     case unsandboxed
+    /// Codex's YOLO mode: bypass approvals and the sandbox entirely.
+    case yolo
 
     public var displayName: String {
       switch self {
       case .ask: return "Ask when unsure"
       case .workspace: return "Workspace (recommended)"
       case .unsandboxed: return "No sandbox"
+      case .yolo: return "YOLO (recommended)"
       }
     }
 
@@ -176,6 +179,9 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
       case .unsandboxed:
         return "Skips every approval and the sandbox entirely — a loop can do anything "
           + "you can, anywhere."
+      case .yolo:
+        return "Codex's --dangerously-bypass-approvals-and-sandbox: a loop can do anything "
+          + "you can, anywhere."
       }
     }
 
@@ -184,6 +190,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
       case .ask: return []
       case .workspace: return ["--ask-for-approval", "never", "--sandbox", "workspace-write"]
       case .unsandboxed: return ["--dangerously-bypass-approvals-and-sandbox"]
+      case .yolo: return ["--dangerously-bypass-approvals-and-sandbox"]
       }
     }
 
@@ -384,7 +391,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
 
   public init(
     defaultBackend: CLISessionBackendKind = .claudeCode,
-    codexApprovals: CodexApprovals = .workspace,
+    codexApprovals: CodexApprovals = .yolo,
     openCodePermissions: OpenCodePermissions = .auto,
     claudePermissionMode: ClaudePermissionMode = .auto,
     copilotPermissions: CopilotPermissions = .allowEverything,
@@ -426,7 +433,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
       ?? .claudeCode
     defaultBackend = storedBackend.isSpiked ? storedBackend : .claudeCode
     codexApprovals =
-      try container.decodeIfPresent(CodexApprovals.self, forKey: .codexApprovals) ?? .workspace
+      try container.decodeIfPresent(CodexApprovals.self, forKey: .codexApprovals) ?? .yolo
     openCodePermissions =
       try container.decodeIfPresent(OpenCodePermissions.self, forKey: .openCodePermissions)
       ?? .auto

--- a/graphcode/Tests/GraphcodeSettingsTests.swift
+++ b/graphcode/Tests/GraphcodeSettingsTests.swift
@@ -19,6 +19,7 @@ struct GraphcodeSettingsTests {
     let settings = GraphcodeSettings()
     #expect(settings.defaultBackend == .claudeCode)
     #expect(settings.claudePermissionMode == .auto)
+    #expect(settings.codexApprovals == .yolo)
     #expect(settings.copilotPermissions == .allowEverything)
     #expect(settings.briefsSessionsAboutTheGraph)
   }

--- a/graphcode/Tests/SessionBriefingTests.swift
+++ b/graphcode/Tests/SessionBriefingTests.swift
@@ -267,8 +267,7 @@ struct SessionBriefingTests {
     let codex = try #require(
       ZmxSessionLauncher.arguments(
         forNode: node(backend: .codex), projectPath: Self.project, settings: defaults))
-    let approval = try #require(codex.firstIndex(of: "--ask-for-approval"))
-    #expect(codex[approval + 1] == "never")
+    #expect(codex.contains("--dangerously-bypass-approvals-and-sandbox"))
   }
 
   @Test
@@ -287,6 +286,10 @@ struct SessionBriefingTests {
     let copilot = CLISessionBackendKind.copilotCLI.launchArguments(
       prompt: "go", tier: .standard, settings: GraphcodeSettings())
     #expect(copilot.contains("--yolo"))
+
+    let codex = CLISessionBackendKind.codex.launchArguments(
+      prompt: "go", tier: .standard, settings: GraphcodeSettings())
+    #expect(codex.contains("--dangerously-bypass-approvals-and-sandbox"))
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add a first-class Codex YOLO permission mode
- emit `--dangerously-bypass-approvals-and-sandbox` for YOLO sessions
- make YOLO the default for new and missing settings while preserving explicit choices
- update launch coverage

## Validation
- `make test`

Claude permission modes and launch behavior are unchanged.