### PR TITLE
Fix Codex loop title suggestions

### DIFF
--- a/graphcode/Sources/Clients/TitleSuggestionClient.swift
+++ b/graphcode/Sources/Clients/TitleSuggestionClient.swift
@@ -79,12 +79,17 @@ extension TitleSuggestionClient: DependencyKey {
   /// `-i` as well as `-l` for the reason every other launch site gives (see
   /// `GhosttyTerminalView.agentCommand`): the agent's `PATH` usually comes from
   /// `~/.zshrc`, which zsh reads only when interactive.
-  private static func invocation(for backend: CLISessionBackendKind) -> [String]? {
+  static func invocation(for backend: CLISessionBackendKind) -> [String]? {
     let command: String
     switch backend {
     case .claudeCode: command = "exec claude -p \"$\(promptVariable)\""
     case .copilotCLI: command = "exec copilot -p \"$\(promptVariable)\""
-    case .codex: command = "exec codex exec \"$\(promptVariable)\""
+    // This is a separate headless process, so it does not inherit the permission flags
+    // from the loop session. Without Codex's unattended flag it can stop at an approval
+    // prompt and the new loop remains named "New Loop" forever.
+    case .codex:
+      command =
+        "exec codex exec --dangerously-bypass-approvals-and-sandbox \"$\(promptVariable)\""
     case .openCode: command = "exec opencode run \"$\(promptVariable)\""
     }
     return ["/bin/zsh", "-i", "-l", "-c", command]

--- a/graphcode/Tests/TitleSuggestionTests.swift
+++ b/graphcode/Tests/TitleSuggestionTests.swift
@@ -28,6 +28,13 @@ struct TitleSuggestionTests {
   }
 
   @Test
+  func codexTitleSuggestionsRunWithoutAnApprovalPrompt() throws {
+    let invocation = try #require(TitleSuggestionClient.invocation(for: .codex))
+    let command = try #require(invocation.last)
+    #expect(command.contains("codex exec --dangerously-bypass-approvals-and-sandbox"))
+  }
+
+  @Test
   func aTakenNameIsRefusedWhateverItsCase() {
     #expect(TitleSuggestionClient.accept("Deploy", taken: ["deploy"]) == nil)
     #expect(TitleSuggestionClient.accept("Deploy", taken: ["Research"]) == "Deploy")


### PR DESCRIPTION
## Summary
- run headless Codex title suggestions with `--dangerously-bypass-approvals-and-sandbox`
- prevent new Codex loops from remaining named `New Loop` when the title helper waits for approval
- add regression coverage for the Codex title invocation

## Validation
- `make test`

Claude launch and permission behavior are unchanged.