### PR TITLE
Add Codespace… — GitHub Codespaces as remote projects, behind a ramp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ xcuserdata/
 !/docs/_layouts/
 !/docs/_includes/
 !/docs/assets/
+!/docs/ramps.json

--- a/GraphcodeKit/Sources/Domain/GhLocator.swift
+++ b/GraphcodeKit/Sources/Domain/GhLocator.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Where to find the GitHub CLI — the dial for Codespace projects
+/// (`RemoteProjectLocation.isCodespace`). Unlike `zmx`, `gh` is the human's own
+/// install, so this probes the places package managers put it rather than owning a
+/// copy: the app and daemon run with launchd's minimal `PATH`, and `Process` never
+/// searches `PATH` anyway, so an absolute path is required wherever the invocation is
+/// exec'd directly.
+public enum GhLocator {
+  static let candidates = [
+    "/opt/homebrew/bin/gh",
+    "/usr/local/bin/gh",
+    "/usr/bin/gh",
+  ]
+
+  /// The first installed candidate. Falls back to the Homebrew path when none is
+  /// found, so an invocation built while `gh` is missing still names the place it
+  /// would be — the error then reads "no such file" at a path worth installing to,
+  /// and `isInstalled` is the up-front check the add-codespace flow uses.
+  public static var executablePath: String {
+    candidates.first { FileManager.default.isExecutableFile(atPath: $0) } ?? candidates[0]
+  }
+
+  public static var isInstalled: Bool {
+    candidates.contains { FileManager.default.isExecutableFile(atPath: $0) }
+  }
+}

--- a/GraphcodeKit/Sources/Domain/RemoteProjectLocation.swift
+++ b/GraphcodeKit/Sources/Domain/RemoteProjectLocation.swift
@@ -148,10 +148,10 @@ public struct RemoteProjectLocation: Equatable, Sendable {
   ///
   /// A Codespace dials through `gh codespace ssh -c <name> -- <ssh-flags> <command>`
   /// instead — everything after `--` reaches gh's underlying ssh untouched, so the
-  /// keepalive posture carries over. `ControlMaster` deliberately does not: each gh run
-  /// opens its own tunnel to the codespace and exits with it, so a persisted master
-  /// would outlive the tunnel it multiplexes over and hand every later invocation a
-  /// dead connection.
+  /// keepalive posture carries over. `ControlMaster` deliberately does not: gh opens a
+  /// fresh tunnel on a random local port per run and exits with it, so a persisted
+  /// master would rarely be matched again (`%C` hashes the port) and each one left
+  /// behind would sit on a dead tunnel — orphans, not multiplexing.
   public func sshInvocation(remoteCommand: String, interactive: Bool = false) -> [String] {
     if isCodespace {
       var invocation = [GhLocator.executablePath, "codespace", "ssh", "-c", host, "--"]

--- a/GraphcodeKit/Sources/Domain/RemoteProjectLocation.swift
+++ b/GraphcodeKit/Sources/Domain/RemoteProjectLocation.swift
@@ -20,21 +20,45 @@ public struct RemoteProjectLocation: Equatable, Sendable {
   public var port: Int?
   /// Absolute path of the repository on the remote machine.
   public var remotePath: String
+  /// A GitHub Codespace rather than a host ssh can dial directly: `host` holds the
+  /// codespace *name*, user and port are meaningless (GitHub's tunnel decides both),
+  /// and every invocation goes through `gh codespace ssh`, which owns auth, key
+  /// setup, and starting a stopped codespace. Everything above the dial — sessions,
+  /// reconnects, presence — is byte-identical to any other remote host.
+  public var isCodespace: Bool
 
-  public init(user: String? = nil, host: String, port: Int? = nil, remotePath: String) {
+  public init(
+    user: String? = nil, host: String, port: Int? = nil, remotePath: String,
+    isCodespace: Bool = false
+  ) {
     self.user = user
     self.host = host
     self.port = port
     self.remotePath = remotePath
+    self.isCodespace = isCodespace
   }
 
   /// The reserved scheme. A path with this prefix is a remote project everywhere a
   /// project path travels.
   public static let scheme = "ssh"
 
+  /// The Codespace variant's scheme: `codespace://<name>/absolute/path` — same
+  /// "the path is the identity" rule, with the codespace name where a hostname
+  /// would be, so the same folder in a codespace and on a server never collide.
+  public static let codespaceScheme = "codespace"
+
   /// Parses a project path, returning `nil` for anything that isn't a remote one —
   /// which is the branch every existing call site takes for ordinary folders.
   public static func parse(projectPath: String) -> RemoteProjectLocation? {
+    if projectPath.hasPrefix("\(codespaceScheme)://") {
+      guard let components = URLComponents(string: projectPath),
+        components.scheme == codespaceScheme,
+        let name = components.host, SafeArgument.isSafeSSHComponent(name),
+        components.user == nil, components.port == nil,
+        !components.path.isEmpty, components.path.hasPrefix("/")
+      else { return nil }
+      return RemoteProjectLocation(host: name, remotePath: components.path, isCodespace: true)
+    }
     guard projectPath.hasPrefix("\(scheme)://"),
       let components = URLComponents(string: projectPath),
       components.scheme == scheme,
@@ -48,7 +72,9 @@ public struct RemoteProjectLocation: Equatable, Sendable {
 
   /// The path string this location travels as — `parse`'s inverse.
   public var projectPath: String {
-    "\(Self.scheme)://\(authority)\(remotePath)"
+    isCodespace
+      ? "\(Self.codespaceScheme)://\(host)\(remotePath)"
+      : "\(Self.scheme)://\(authority)\(remotePath)"
   }
 
   /// An absolute remote path reduced to the one spelling git will print for it, so two
@@ -119,7 +145,24 @@ public struct RemoteProjectLocation: Equatable, Sendable {
   /// `ControlPersist` keeps the master up between ticks; a dead master is redialed by
   /// whichever command comes next. If the socket directory is missing ssh just warns and
   /// dials directly, so this degrades to the old behaviour, never to a failure.
+  ///
+  /// A Codespace dials through `gh codespace ssh -c <name> -- <ssh-flags> <command>`
+  /// instead — everything after `--` reaches gh's underlying ssh untouched, so the
+  /// keepalive posture carries over. `ControlMaster` deliberately does not: each gh run
+  /// opens its own tunnel to the codespace and exits with it, so a persisted master
+  /// would outlive the tunnel it multiplexes over and hand every later invocation a
+  /// dead connection.
   public func sshInvocation(remoteCommand: String, interactive: Bool = false) -> [String] {
+    if isCodespace {
+      var invocation = [GhLocator.executablePath, "codespace", "ssh", "-c", host, "--"]
+      if interactive { invocation.append("-t") }
+      invocation += [
+        "-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
+        "-o", "ServerAliveInterval=5", "-o", "ServerAliveCountMax=3",
+      ]
+      invocation.append(remoteCommand)
+      return invocation
+    }
     var invocation = ["/usr/bin/ssh"]
     if interactive { invocation.append("-t") }
     invocation += [

--- a/GraphcodeKit/Sources/Domain/SSHReconnectLoop.swift
+++ b/GraphcodeKit/Sources/Domain/SSHReconnectLoop.swift
@@ -16,18 +16,30 @@ import Foundation
 /// too; the banner names the exit code and ssh's own error text stays visible above it.
 /// Ctrl-C during the wait is the escape hatch — the `trap` makes it deterministic, and
 /// while ssh is live the tty is raw so Ctrl-C goes to the remote side instead.
+///
+/// `retriesExitOne` is the Codespace accommodation: `gh` runs ssh but does not
+/// propagate its exit code — every nonzero exit (ssh's 255 *and* the remote scripts'
+/// deliberate `exit 255`s) surfaces as gh's own 1, with only 0 preserved. A gh dial
+/// therefore retries on 1 as well. That also redials a session that genuinely ended
+/// nonzero, which converges: the redial reattaches a live session, and a gone one
+/// takes the reconnect script's session-ended branch to a clean exit 0.
 public enum SSHReconnectLoop {
   public static let maxDelaySeconds = 15
 
-  public static func script(connect: String, reconnect: String) -> String {
-    let passExitUnless255 = "; gc_rc=$?; [ \"$gc_rc\" -ne 255 ] && exit \"$gc_rc\""
+  public static func script(
+    connect: String, reconnect: String, retriesExitOne: Bool = false
+  ) -> String {
+    let passExit =
+      retriesExitOne
+      ? "; gc_rc=$?; { [ \"$gc_rc\" -ne 255 ] && [ \"$gc_rc\" -ne 1 ]; } && exit \"$gc_rc\""
+      : "; gc_rc=$?; [ \"$gc_rc\" -ne 255 ] && exit \"$gc_rc\""
     return "trap 'exit 130' INT; "
-      + connect + passExitUnless255 + "; "
+      + connect + passExit + "; "
       + "gc_delay=1; while :; do "
-      + #"printf '\033[1;33m── Connection failed (ssh exit 255). Retrying in %ss. "#
-      + #"Press Ctrl-C to stop. ──\033[0m\r\n' "$gc_delay"; "#
+      + #"printf '\033[1;33m── Connection failed (exit %s). Retrying in %ss. "#
+      + #"Press Ctrl-C to stop. ──\033[0m\r\n' "$gc_rc" "$gc_delay"; "#
       + "sleep \"$gc_delay\"; gc_delay=$((gc_delay * 2)); "
       + "[ \"$gc_delay\" -gt \(maxDelaySeconds) ] && gc_delay=\(maxDelaySeconds); "
-      + reconnect + passExitUnless255 + "; done"
+      + reconnect + passExit + "; done"
   }
 }

--- a/GraphcodeKit/Sources/Sessions/RemoteSocketForwarder.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteSocketForwarder.swift
@@ -64,7 +64,10 @@ public actor RemoteSocketForwarder {
 
   /// The `ssh -N -R` line itself, with the remote socket path assembled around the
   /// `$H` the pre-dial captured — which is why this is a shell line and not an argv.
-  static func forwardCommandLine(for location: RemoteProjectLocation, localSocketPath: String)
+  /// Public for the tests that pin the codespace/ssh split of the dial.
+  public static func forwardCommandLine(
+    for location: RemoteProjectLocation, localSocketPath: String
+  )
     -> String
   {
     var argv: [String]

--- a/GraphcodeKit/Sources/Sessions/RemoteSocketForwarder.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteSocketForwarder.swift
@@ -67,19 +67,29 @@ public actor RemoteSocketForwarder {
   static func forwardCommandLine(for location: RemoteProjectLocation, localSocketPath: String)
     -> String
   {
-    var argv = [
-      "/usr/bin/ssh", "-N",
+    var argv: [String]
+    if location.isCodespace {
+      // gh names the destination itself; `-N` and the forward ride through as
+      // ssh-flags, past the `--`.
+      argv = [GhLocator.executablePath, "codespace", "ssh", "-c", location.host, "--"]
+    } else {
+      argv = ["/usr/bin/ssh"]
+    }
+    argv += [
+      "-N",
       "-o", "ExitOnForwardFailure=yes", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
       "-o", "ServerAliveInterval=5", "-o", "ServerAliveCountMax=3",
     ]
-    if let port = location.port { argv += ["-p", String(port)] }
-    let quoted =
+    if !location.isCodespace, let port = location.port { argv += ["-p", String(port)] }
+    var quoted =
       argv.map(RemoteProjectLocation.shellQuoted) + [
         "-R",
         "\"$H\""
           + RemoteProjectLocation.shellQuoted("/.graphcode/graphcoded.sock:" + localSocketPath),
-        RemoteProjectLocation.shellQuoted(location.sshDestination),
       ]
+    if !location.isCodespace {
+      quoted.append(RemoteProjectLocation.shellQuoted(location.sshDestination))
+    }
     return quoted.joined(separator: " ")
   }
 }

--- a/docs/ramps.json
+++ b/docs/ramps.json
@@ -1,0 +1,5 @@
+{
+  "features": {
+    "codespaces": { "beta": 100, "stable": 0 }
+  }
+}

--- a/graphcode/Sources/Clients/CodespaceClient.swift
+++ b/graphcode/Sources/Clients/CodespaceClient.swift
@@ -47,9 +47,11 @@ extension CodespaceClient: DependencyKey {
             message: "The GitHub CLI isn't installed — codespaces are reached through it. "
               + "`brew install gh`, then `gh auth login`, and try again."))
       }
+      // `--limit`: the default is 30, and the truncation is silent — a 31st codespace
+      // would simply never appear in the picker.
       let result = await run(
         GhLocator.executablePath,
-        ["codespace", "list", "--json", "name,displayName,repository,state"])
+        ["codespace", "list", "--limit", "500", "--json", "name,displayName,repository,state"])
       guard result.status == 0 else {
         let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
         return .failure(Failure(message: stderr.isEmpty ? "gh codespace list failed." : stderr))
@@ -86,13 +88,18 @@ extension CodespaceClient: DependencyKey {
 
   /// `owner/repo` from any of the ways a GitHub origin is written — https, scp-ish
   /// `git@`, or `ssh://` — and `nil` for an origin that isn't github.com, which is a
-  /// repository no codespace link can be made for, not an error.
+  /// repository no codespace link can be made for, not an error. Anchored to the
+  /// start (hosts are case-insensitive, the slug's case is kept): a bare substring
+  /// match would take `notgithub.com` too.
   static func githubRepository(fromOriginURL origin: String) -> String? {
-    var slug: Substring?
-    if let range = origin.range(of: "github.com/") ?? origin.range(of: "github.com:") {
-      slug = origin[range.upperBound...]
-    }
-    guard var slug else { return nil }
+    let origin = origin.trimmingCharacters(in: .whitespacesAndNewlines)
+    let lowered = origin.lowercased()
+    let prefixes = [
+      "https://github.com/", "http://github.com/",
+      "ssh://git@github.com/", "git://github.com/", "git@github.com:",
+    ]
+    guard let prefix = prefixes.first(where: lowered.hasPrefix) else { return nil }
+    var slug = origin.dropFirst(prefix.count)
     if slug.hasSuffix(".git") { slug = slug.dropLast(4) }
     let parts = slug.split(separator: "/")
     guard parts.count == 2,

--- a/graphcode/Sources/Clients/CodespaceClient.swift
+++ b/graphcode/Sources/Clients/CodespaceClient.swift
@@ -1,0 +1,147 @@
+import Dependencies
+import Foundation
+import GraphcodeKit
+
+/// One codespace as `gh codespace list` reports it — exactly the fields the picker
+/// shows, decoded from gh's own `--json` output so there is no scraping to drift.
+struct Codespace: Equatable, Identifiable, Sendable, Decodable {
+  var name: String
+  var displayName: String
+  /// `owner/repo`.
+  var repository: String
+  /// gh's word: `Available`, `Shutdown`, `Starting`, … Shown as-is; a stopped
+  /// codespace is still addable, because `gh codespace ssh` starts it on connect.
+  var state: String
+
+  var id: String { name }
+
+  /// Where a codespace puts its clone by default. Prefill only — the form's path
+  /// field stays editable for devcontainers that mount elsewhere.
+  var defaultWorkspacePath: String {
+    let leaf = repository.split(separator: "/").last.map(String.init) ?? repository
+    return "/workspaces/\(leaf)"
+  }
+}
+
+/// Everything the add-codespace flow asks of the GitHub CLI. All of it rides `gh`
+/// rather than the API directly: gh owns auth (keychain), the codespace scope check —
+/// whose error text carries its own fix (`gh auth refresh -h github.com -s codespace`)
+/// — and, later, the SSH tunnel every session dial uses.
+struct CodespaceClient: Sendable {
+  struct Failure: Equatable, Error {
+    var message: String
+  }
+
+  var list: @Sendable () async -> Result<[Codespace], Failure>
+  /// The GitHub repositories (`owner/repo`) behind the given local project folders —
+  /// what the sheet's "create one" links point at when there is no codespace yet.
+  var githubRepositories: @Sendable (_ projectPaths: [String]) async -> [String]
+}
+
+extension CodespaceClient: DependencyKey {
+  static let liveValue = CodespaceClient(
+    list: {
+      guard GhLocator.isInstalled else {
+        return .failure(
+          Failure(
+            message: "The GitHub CLI isn't installed — codespaces are reached through it. "
+              + "`brew install gh`, then `gh auth login`, and try again."))
+      }
+      let result = await run(
+        GhLocator.executablePath,
+        ["codespace", "list", "--json", "name,displayName,repository,state"])
+      guard result.status == 0 else {
+        let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return .failure(Failure(message: stderr.isEmpty ? "gh codespace list failed." : stderr))
+      }
+      do {
+        let codespaces = try JSONDecoder().decode(
+          [Codespace].self, from: Data(result.stdout.utf8))
+        return .success(codespaces)
+      } catch {
+        return .failure(Failure(message: "Couldn't read gh's codespace list."))
+      }
+    },
+    githubRepositories: { projectPaths in
+      var repositories: [String] = []
+      for path in projectPaths {
+        let result = await run("/usr/bin/git", ["-C", path, "remote", "get-url", "origin"])
+        guard result.status == 0,
+          let repository = githubRepository(
+            fromOriginURL: result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)),
+          !repositories.contains(repository)
+        else { continue }
+        repositories.append(repository)
+      }
+      return repositories
+    }
+  )
+
+  /// No network, no gh, no repos — the shapes the reducer tests care about are fed
+  /// through `withDependencies` instead.
+  static let testValue = CodespaceClient(
+    list: { .success([]) },
+    githubRepositories: { _ in [] }
+  )
+
+  /// `owner/repo` from any of the ways a GitHub origin is written — https, scp-ish
+  /// `git@`, or `ssh://` — and `nil` for an origin that isn't github.com, which is a
+  /// repository no codespace link can be made for, not an error.
+  static func githubRepository(fromOriginURL origin: String) -> String? {
+    var slug: Substring?
+    if let range = origin.range(of: "github.com/") ?? origin.range(of: "github.com:") {
+      slug = origin[range.upperBound...]
+    }
+    guard var slug else { return nil }
+    if slug.hasSuffix(".git") { slug = slug.dropLast(4) }
+    let parts = slug.split(separator: "/")
+    guard parts.count == 2,
+      parts.allSatisfy({ SafeArgument.isSafePathComponent(String($0)) })
+    else { return nil }
+    return parts.joined(separator: "/")
+  }
+
+  private static func run(
+    _ executable: String, _ arguments: [String]
+  ) async -> (status: Int32, stdout: String, stderr: String) {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+    // Handler wired before launch, exit awaited via the stream — the arrangement
+    // every subprocess here uses (`waitUntilExit` stalls the cooperative pool), and
+    // pipes drained concurrently so a full one can't wedge the exit.
+    let (exited, exitContinuation) = AsyncStream<Int32>.makeStream()
+    process.terminationHandler = { process in
+      exitContinuation.yield(process.terminationStatus)
+      exitContinuation.finish()
+    }
+    do {
+      try process.run()
+    } catch {
+      return (-1, "", error.localizedDescription)
+    }
+    async let outputData = readToEnd(stdout)
+    async let errorData = readToEnd(stderr)
+    let output = String(data: await outputData, encoding: .utf8) ?? ""
+    let errorOutput = String(data: await errorData, encoding: .utf8) ?? ""
+    var status: Int32 = -1
+    for await exitStatus in exited { status = exitStatus }
+    return (status, output, errorOutput)
+  }
+
+  private static func readToEnd(_ pipe: Pipe) async -> Data {
+    let handle = pipe.fileHandleForReading
+    return await Task.detached { (try? handle.readToEnd()) ?? Data() }.value
+  }
+}
+
+extension DependencyValues {
+  var codespaceClient: CodespaceClient {
+    get { self[CodespaceClient.self] }
+    set { self[CodespaceClient.self] = newValue }
+  }
+}

--- a/graphcode/Sources/Clients/FeatureRamps.swift
+++ b/graphcode/Sources/Clients/FeatureRamps.swift
@@ -1,0 +1,101 @@
+import CryptoKit
+import Foundation
+
+/// Staged rollouts ("ramps") with no backend: one static JSON on the site,
+/// `https://graphcode.app/ramps.json`, shaped
+/// `{ "features": { "codespaces": { "beta": 100, "stable": 0 } } }` — per feature,
+/// the percentage of installs it is on for, per update channel. Changing a ramp is a
+/// git push to Pages; setting a feature to 0 is the kill switch.
+///
+/// The client buckets *itself*: a stable hash of a per-install UUID, mod 100, so the
+/// same install always lands in the same bucket and a raised percent only ever turns
+/// a feature on for more installs — never off-and-on across launches. The hash is
+/// SHA-256, not `Hasher`, whose per-process random seed would reshuffle every launch.
+///
+/// The fetched configuration is cached in `UserDefaults` and read synchronously at
+/// render time; the refresh happens once per launch, in the background, and applies
+/// from the next read on. No fetch ever *blocks* a feature decision — before the
+/// first successful fetch, each feature's baked default percents answer.
+enum FeatureRamps {
+  struct Configuration: Equatable, Decodable {
+    var features: [String: [String: Int]] = [:]
+  }
+
+  enum Feature: String {
+    case codespaces
+
+    /// What answers when no ramps.json has ever been fetched (and when the fetch
+    /// fails): beta installs opted into rough edges, stable waits for the ramp.
+    var defaultPercents: [String: Int] {
+      switch self {
+      case .codespaces: return ["beta": 100, "stable": 0]
+      }
+    }
+  }
+
+  static let rampsURL = URL(string: "https://graphcode.app/ramps.json")!
+  static let configurationDefaultsKey = "rampsConfiguration"
+  static let installIDDefaultsKey = "rampsInstallID"
+
+  /// The live read the UI uses. Channel comes from the same rule updates follow
+  /// (`UpdateChannel`): the override default wins, otherwise the installed version
+  /// speaks for itself.
+  static func isEnabled(_ feature: Feature) -> Bool {
+    let version =
+      Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
+    let channel = UpdateChannel.channel(
+      for: version, override: UserDefaults.standard.string(forKey: "updateChannel"))
+    return isEnabled(
+      feature, configuration: cachedConfiguration(), channel: channel.rawValue,
+      installID: installID())
+  }
+
+  /// The pure decision, separated so tests can pin it without touching defaults,
+  /// bundles, or the network.
+  static func isEnabled(
+    _ feature: Feature, configuration: Configuration?, channel: String, installID: String
+  ) -> Bool {
+    let percents = configuration?.features[feature.rawValue] ?? feature.defaultPercents
+    let percent = percents[channel] ?? feature.defaultPercents[channel] ?? 0
+    return bucket(installID: installID) < percent
+  }
+
+  /// 0...99, stable across launches and processes for one install.
+  static func bucket(installID: String) -> Int {
+    let digest = SHA256.hash(data: Data(installID.utf8))
+    let leading = digest.withUnsafeBytes { $0.load(as: UInt32.self) }
+    return Int(leading % 100)
+  }
+
+  /// Fetch-and-cache, called once per launch. Ignores the local URL cache so a ramp
+  /// change is seen next launch, not whenever the cache expires; failures keep the
+  /// last good configuration.
+  static func refresh() async {
+    var request = URLRequest(url: rampsURL)
+    request.cachePolicy = .reloadIgnoringLocalCacheData
+    request.timeoutInterval = 10
+    guard let (data, response) = try? await URLSession.shared.data(for: request),
+      (response as? HTTPURLResponse)?.statusCode == 200,
+      (try? JSONDecoder().decode(Configuration.self, from: data)) != nil
+    else { return }
+    UserDefaults.standard.set(data, forKey: configurationDefaultsKey)
+  }
+
+  static func cachedConfiguration() -> Configuration? {
+    guard let data = UserDefaults.standard.data(forKey: configurationDefaultsKey)
+    else { return nil }
+    return try? JSONDecoder().decode(Configuration.self, from: data)
+  }
+
+  /// Created on first read, then permanent — the identity the bucket is derived
+  /// from. Nothing about the install rides along; it exists only so the bucket is
+  /// stable.
+  static func installID() -> String {
+    if let existing = UserDefaults.standard.string(forKey: installIDDefaultsKey) {
+      return existing
+    }
+    let fresh = UUID().uuidString
+    UserDefaults.standard.set(fresh, forKey: installIDDefaultsKey)
+    return fresh
+  }
+}

--- a/graphcode/Sources/Clients/RemoteRepositoryClient.swift
+++ b/graphcode/Sources/Clients/RemoteRepositoryClient.swift
@@ -21,12 +21,16 @@ extension RemoteRepositoryClient: DependencyKey {
     // otherwise read as "not a repository", which sends someone debugging the wrong
     // thing. BatchMode in `sshInvocation` means a password-only host fails here, fast —
     // key auth is a requirement, not a preference, since nothing later has a tty either.
+    let reachFailure =
+      location.isCodespace
+      ? "Can't reach the codespace — check it still exists and that "
+        + "`gh codespace ssh -c \(location.host)` works from a terminal. Stopped "
+        + "codespaces are started by the connection, but only while gh is signed in "
+        + "with the `codespace` scope."
+      : "Can't reach \(location.sshDestination) — check the host, and that key "
+        + "authentication works (`ssh \(location.sshDestination)` from a terminal)."
     let checks: [(command: String, failure: String)] = [
-      (
-        "true",
-        "Can't reach \(location.sshDestination) — check the host, and that key "
-          + "authentication works (`ssh \(location.sshDestination)` from a terminal)."
-      ),
+      ("true", reachFailure),
       (
         "test -d \(quoted(location.remotePath))",
         "\(location.remotePath) doesn't exist on \(location.host)."
@@ -34,6 +38,13 @@ extension RemoteRepositoryClient: DependencyKey {
       (
         "git -C \(quoted(location.remotePath)) rev-parse --is-inside-work-tree",
         "\(location.remotePath) isn't a git repository."
+      ),
+      (
+        // Before the login-shell checks: they run through `zsh -l -i`, so on a host
+        // without zsh they all fail with a message blaming the wrong tool.
+        "command -v zsh",
+        "zsh isn't installed on \(location.host) — remote sessions launch through "
+          + "it. Install it there and try again."
       ),
       (
         location.remoteLoginShellCommand("command -v zmx"),

--- a/graphcode/Sources/Clients/RemoteRepositoryClient.swift
+++ b/graphcode/Sources/Clients/RemoteRepositoryClient.swift
@@ -26,7 +26,8 @@ extension RemoteRepositoryClient: DependencyKey {
       ? "Can't reach the codespace — check it still exists and that "
         + "`gh codespace ssh -c \(location.host)` works from a terminal. Stopped "
         + "codespaces are started by the connection, but only while gh is signed in "
-        + "with the `codespace` scope."
+        + "with the `codespace` scope — and the codespace image needs an SSH server "
+        + "(the default image has one; minimal devcontainers add the sshd feature)."
       : "Can't reach \(location.sshDestination) — check the host, and that key "
         + "authentication works (`ssh \(location.sshDestination)` from a terminal)."
     let checks: [(command: String, failure: String)] = [

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -658,15 +658,18 @@ extension AppFeature {
       // Quietly ask whether there's a newer build, so the sidebar banner can offer
       // it without waiting for someone to open the menu. Silent on failure and on
       // "up to date" — a launch must never raise an alert about updates.
+      // Ramps refresh once per launch, silently — the cached copy answers reads
+      // until this lands, and a failure keeps the last good configuration.
+      .run { _ in await FeatureRamps.refresh() },
       .send(.checkForUpdatesInBackground)
     )
   }
 
-  /// Notes that one of Welcome's four ways to open a folder — picked, recent, freshly
-  /// cloned, remote — has just sent an `.openProject`, so the snapshot it comes back as
-  /// is recognisable as this app's own doing (see the `graphChanged` handler). Every
-  /// case that sends one is listed here; a fifth would have to be added, which is why
-  /// the `switch` is exhaustive rather than a `default`.
+  /// Notes that one of Welcome's five ways to open a folder — picked, recent, freshly
+  /// cloned, remote, codespace — has just sent an `.openProject`, so the snapshot it
+  /// comes back as is recognisable as this app's own doing (see the `graphChanged`
+  /// handler). Every case that sends one is listed here; a sixth would have to be
+  /// added, which is why the `switch` is exhaustive rather than a `default`.
   private func recordPendingOpen(_ action: WelcomeFeature.Action, into state: inout State) {
     let path: String?
     switch action {
@@ -674,10 +677,14 @@ extension AppFeature {
     case .recentProjectTapped(let project): path = project.path
     case .cloneFinished(let clonedPath): path = clonedPath
     case .remoteValidated(let projectPath): path = projectPath
+    case .codespaceValidated(let projectPath): path = projectPath
     case .binding, .openFolderButtonTapped, .folderPickerResult(.failure), .openProjectFailed,
       .setOpenPanelPresented, .cloneRepositoryButtonTapped, .cloneLocationPicked, .cloneSubmitted,
       .cloneCancelled, .cloneProgress, .cloneFailed, .addRemoteRepositoryButtonTapped,
-      .remoteConnectionRequested, .remoteSubmitted, .remoteCancelled, .remoteValidationFailed:
+      .remoteConnectionRequested, .remoteSubmitted, .remoteCancelled, .remoteValidationFailed,
+      .addCodespaceButtonTapped, .codespacesLoaded, .codespaceRepositorySuggestionsLoaded,
+      .codespaceListRetryTapped, .codespaceSelected, .codespaceSubmitted,
+      .codespaceValidationFailed, .codespaceCancelled:
       path = nil
     }
     guard let path else { return }

--- a/graphcode/Sources/Features/App/AppSidebarView.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView.swift
@@ -26,6 +26,11 @@ struct AppSidebarView: View {
   /// here as data and the toggle still propagates through `AppView`'s re-render.
   var sharesLoops: Bool = SettingsModel.shared.settings.sharesLoops
 
+  /// Whether the add menu offers Add Codespace… — the `codespaces` ramp
+  /// (`FeatureRamps`), read once at construction for the same reason as
+  /// `sharesLoops`. A ramp change applies from the next re-render.
+  var offersCodespaces: Bool = FeatureRamps.isEnabled(.codespaces)
+
   // Several of the stored properties and the selection type below are not `private`
   // because the project/node row machinery lives in `AppSidebarView+Rows.swift`, and
   // Swift scopes `private` to a file — same arrangement as `ProjectCanvasView`'s drag
@@ -237,19 +242,10 @@ struct AppSidebarView: View {
       }
       // A GitHub Codespace — the same remote model with `gh` as the dial. The open
       // local projects ride along so an empty codespace list can offer creating one
-      // for a repository already being worked in.
-      Button {
-        store.send(
-          .welcome(
-            .addCodespaceButtonTapped(
-              localProjectPaths: store.projects
-                .filter {
-                  !$0.graph.isGlobal
-                    && RemoteProjectLocation.parse(projectPath: $0.id) == nil
-                }
-                .map(\.id))))
-      } label: {
-        Label("Add Codespace…", systemImage: "cloud")
+      // for a repository already being worked in. Behind the `codespaces` ramp:
+      // beta first, prod when ramps.json says so.
+      if offersCodespaces {
+        addCodespaceItem
       }
       if !store.welcome.recentProjects.isEmpty {
         Divider()
@@ -497,6 +493,28 @@ struct AppSidebarView: View {
           }
         }
       }
+    }
+  }
+}
+
+extension AppSidebarView {
+  /// The add menu's codespace entry, out of the struct body for the same budget
+  /// reason the row machinery lives in `+Rows`. The open local projects ride along
+  /// so an empty codespace list can offer creating one for a repository already
+  /// being worked in.
+  var addCodespaceItem: some View {
+    Button {
+      store.send(
+        .welcome(
+          .addCodespaceButtonTapped(
+            localProjectPaths: store.projects
+              .filter {
+                !$0.graph.isGlobal
+                  && RemoteProjectLocation.parse(projectPath: $0.id) == nil
+              }
+              .map(\.id))))
+    } label: {
+      Label("Add Codespace…", systemImage: "cloud")
     }
   }
 }

--- a/graphcode/Sources/Features/App/AppSidebarView.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView.swift
@@ -235,6 +235,22 @@ struct AppSidebarView: View {
       } label: {
         Label("Add Remote Repository…", systemImage: "network")
       }
+      // A GitHub Codespace — the same remote model with `gh` as the dial. The open
+      // local projects ride along so an empty codespace list can offer creating one
+      // for a repository already being worked in.
+      Button {
+        store.send(
+          .welcome(
+            .addCodespaceButtonTapped(
+              localProjectPaths: store.projects
+                .filter {
+                  !$0.graph.isGlobal
+                    && RemoteProjectLocation.parse(projectPath: $0.id) == nil
+                }
+                .map(\.id))))
+      } label: {
+        Label("Add Codespace…", systemImage: "cloud")
+      }
       if !store.welcome.recentProjects.isEmpty {
         Divider()
         ForEach(store.welcome.recentProjects) { project in

--- a/graphcode/Sources/Features/App/AppView.swift
+++ b/graphcode/Sources/Features/App/AppView.swift
@@ -70,6 +70,14 @@ struct AppView: View {
     ) {
       RemoteRepositoryFormView(store: store.scope(state: \.welcome, action: \.welcome))
     }
+    .sheet(
+      isPresented: Binding(
+        get: { store.welcome.codespaceDraft != nil },
+        set: { if !$0 { store.send(.welcome(.codespaceCancelled)) } }
+      )
+    ) {
+      CodespaceFormView(store: store.scope(state: \.welcome, action: \.welcome))
+    }
     // The window's own backdrop, and the glass every `Theme` scrim is layered over —
     // this is what makes the whole window translucent rather than only the sidebar.
     // A material here (rather than a color) is what lets the window sample the desktop

--- a/graphcode/Sources/Features/Welcome/CodespaceFormView.swift
+++ b/graphcode/Sources/Features/Welcome/CodespaceFormView.swift
@@ -1,0 +1,168 @@
+import ComposableArchitecture
+import GraphcodeKit
+import SwiftUI
+
+/// The add-codespace sheet — a GitHub Codespace as a remote project, with
+/// `gh codespace ssh` as the dial. The picker is `gh codespace list`'s answer, so the
+/// sheet is only ever offering codespaces that actually exist; when there are none,
+/// it points at GitHub's create page instead — for the repositories already open in
+/// GraphCode when it can, generically otherwise.
+struct CodespaceFormView: View {
+  @Bindable var store: StoreOf<WelcomeFeature>
+
+  private static let createURL = URL(string: "https://github.com/codespaces/new")!
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Text("Add Codespace").font(.headline)
+
+      content
+
+      Text(
+        "Loops run in the codespace; this Mac steers them. Needs zmx installed in the "
+          + "codespace, and gh signed in with the codespace scope. A stopped codespace "
+          + "is started by the connection."
+      )
+      .font(.caption2)
+      .foregroundStyle(.secondary)
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      if let failure = store.codespaceDraft?.failureMessage {
+        Text(failure)
+          .font(.caption)
+          .foregroundStyle(.red)
+          .textSelection(.enabled)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+
+      HStack {
+        Button("Cancel") { store.send(.codespaceCancelled) }
+        Spacer()
+        if store.codespaceDraft?.isValidating == true {
+          ProgressView().controlSize(.small).padding(.trailing, 4)
+        }
+        Button("Add") { store.send(.codespaceSubmitted) }
+          .keyboardShortcut(.defaultAction)
+          .disabled(store.codespaceDraft?.canSubmit != true)
+      }
+    }
+    .padding(24)
+    .frame(width: 460)
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    if let failure = store.codespaceDraft?.listFailure {
+      // gh's own words, selectable: the missing-scope error carries its fix
+      // (`gh auth refresh -h github.com -s codespace`) and deserves copying verbatim.
+      Text(failure)
+        .font(.caption)
+        .foregroundStyle(.red)
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+      Button("Try Again") { store.send(.codespaceListRetryTapped) }
+    } else if let codespaces = store.codespaceDraft?.codespaces {
+      if codespaces.isEmpty {
+        emptyState
+      } else {
+        picker(codespaces)
+        pathField
+        createLinks(compact: true)
+      }
+    } else {
+      ProgressView("Asking gh for your codespaces…")
+        .controlSize(.small)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+    }
+  }
+
+  private var emptyState: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("No codespaces yet.")
+        .foregroundStyle(.secondary)
+      Text("Create one on GitHub, then come back here to add it:")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      createLinks(compact: false)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.vertical, 8)
+  }
+
+  /// The create page, repository-first: one link per GitHub repository already open
+  /// in GraphCode (`codespaces.new/owner/repo` — the badge quick-start URL), then the
+  /// generic picker for everything else.
+  private func createLinks(compact: Bool) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      ForEach(store.codespaceDraft?.repositorySuggestions ?? [], id: \.self) { repository in
+        if let url = URL(string: "https://codespaces.new/\(repository)") {
+          Link("Create a codespace for \(repository)…", destination: url)
+        }
+      }
+      Link(
+        compact ? "Create a new codespace on GitHub…" : "Create a codespace on GitHub…",
+        destination: Self.createURL)
+    }
+    .font(compact ? .caption : .body)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private func picker(_ codespaces: [Codespace]) -> some View {
+    ScrollView {
+      VStack(spacing: 0) {
+        ForEach(codespaces) { codespace in
+          row(codespace)
+        }
+      }
+    }
+    .frame(maxHeight: 160)
+    .background(.black.opacity(0.15), in: RoundedRectangle(cornerRadius: 6))
+  }
+
+  private func row(_ codespace: Codespace) -> some View {
+    let isSelected = store.codespaceDraft?.selectedName == codespace.name
+    return Button {
+      store.send(.codespaceSelected(codespace.name))
+    } label: {
+      HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 1) {
+          Text(codespace.displayName.isEmpty ? codespace.name : codespace.displayName)
+            .lineLimit(1)
+          Text("\(codespace.repository) · \(codespace.state)")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+        Spacer()
+        if isSelected {
+          Image(systemName: "checkmark")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+      .contentShape(Rectangle())
+      .padding(.horizontal, 10)
+      .padding(.vertical, 6)
+      .background(isSelected ? Color.white.opacity(0.08) : .clear)
+    }
+    .buttonStyle(.plain)
+  }
+
+  private var pathField: some View {
+    TextField(
+      "Path",
+      text: Binding(
+        get: { store.codespaceDraft?.remotePath ?? "" },
+        set: { newValue in
+          guard var draft = store.codespaceDraft else { return }
+          draft.remotePath = newValue
+          store.send(.binding(.set(\.codespaceDraft, draft)))
+        }
+      ),
+      prompt: Text("/workspaces/repo — absolute")
+    )
+    .autocorrectionDisabled()
+    .font(.system(.body, design: .monospaced))
+  }
+}

--- a/graphcode/Sources/Features/Welcome/RemoteRepositoryFormView.swift
+++ b/graphcode/Sources/Features/Welcome/RemoteRepositoryFormView.swift
@@ -20,7 +20,12 @@ struct RemoteRepositoryFormView: View {
       Text(isInspecting ? "Remote Connection" : "Add Remote Repository").font(.headline)
 
       Form {
-        if isInspecting {
+        if store.remoteDraft?.inspectsCodespace == true {
+          // A codespace's dial is `gh codespace ssh -c <name>` — there is no user or
+          // port of ours to show, and pretending ssh's defaults were them would lie.
+          LabeledContent("Codespace") { value(\.server) }
+          LabeledContent("Path") { value(\.remotePath) }
+        } else if isInspecting {
           LabeledContent("Server") { value(\.server) }
           LabeledContent("User") { value(\.user) }
           LabeledContent("Port") { value(\.port) }

--- a/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
+++ b/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
@@ -127,43 +127,6 @@ struct WelcomeFeature {
     var canSubmit: Bool { location != nil && !isValidating && !isInspecting }
   }
 
-  /// What the add-codespace sheet is collecting: gh's list, one pick, and the path the
-  /// repository lives at inside it. Validation is the remote form's — a codespace that
-  /// passes is one whose sessions can start — with `gh codespace ssh` as the dial.
-  struct CodespaceDraft: Equatable {
-    /// `nil` while `gh codespace list` is still running.
-    var codespaces: [Codespace]?
-    /// Why the list couldn't load — gh missing, or gh's own words (which carry the
-    /// fix when the token lacks the `codespace` scope).
-    var listFailure: String?
-    var selectedName: String?
-    var remotePath = ""
-    /// `owner/repo` for the open local projects, so an empty list can offer "create
-    /// one for the repository you're already working in".
-    var repositorySuggestions: [String] = []
-    var isValidating = false
-    var failureMessage: String?
-
-    var selected: Codespace? {
-      guard let selectedName, let codespaces else { return nil }
-      return codespaces.first { $0.name == selectedName }
-    }
-
-    /// Same normalization rules as the remote form's `location`; the name reaches
-    /// `gh -c` as an argument, so it passes the same door check a hostname does.
-    var location: RemoteProjectLocation? {
-      let path = remotePath.trimmingCharacters(in: .whitespaces)
-      guard let name = selectedName, SafeArgument.isSafeSSHComponent(name),
-        path.hasPrefix("/")
-      else { return nil }
-      return RemoteProjectLocation(
-        host: name, remotePath: RemoteProjectLocation.normalizedPath(path),
-        isCodespace: true)
-    }
-
-    var canSubmit: Bool { location != nil && !isValidating }
-  }
-
   @ObservableState
   struct State: Equatable {
     var recentProjects: [ProjectRef] = []
@@ -392,7 +355,10 @@ struct WelcomeFeature {
 
       case .addCodespaceButtonTapped(let localProjectPaths):
         state.codespaceDraft = CodespaceDraft()
-        return .merge(
+        // Sequenced, not merged: the suggestions only matter once the list has
+        // answered (they render in its empty state), and a fixed order keeps the
+        // flow deterministic.
+        return .concatenate(
           loadCodespaces(),
           .run { send in
             await send(
@@ -471,12 +437,6 @@ struct WelcomeFeature {
     }
   }
 
-  private func loadCodespaces() -> Effect<Action> {
-    .run { send in
-      await send(.codespacesLoaded(codespaceClient.list()))
-    }
-    .cancellable(id: CancelID.codespaceList, cancelInFlight: true)
-  }
 
   /// Ask the daemon to open a folder, and *say so* when it can't be reached. This was a
   /// silent `try?` — on a machine where the daemon never came up (a fresh install whose
@@ -494,5 +454,53 @@ struct WelcomeFeature {
               + "(\(String(describing: error))). Try quitting and reopening GraphCode."))
       }
     }
+  }
+}
+
+// The codespace half lives in the extension — the reducer above is at the struct-size
+// budget, and these are exactly the "trailing helpers" the lint rule wants out of it.
+extension WelcomeFeature {
+  /// What the add-codespace sheet is collecting: gh's list, one pick, and the path the
+  /// repository lives at inside it. Validation is the remote form's — a codespace that
+  /// passes is one whose sessions can start — with `gh codespace ssh` as the dial.
+  struct CodespaceDraft: Equatable {
+    /// `nil` while `gh codespace list` is still running.
+    var codespaces: [Codespace]?
+    /// Why the list couldn't load — gh missing, or gh's own words (which carry the
+    /// fix when the token lacks the `codespace` scope).
+    var listFailure: String?
+    var selectedName: String?
+    var remotePath = ""
+    /// `owner/repo` for the open local projects, so an empty list can offer "create
+    /// one for the repository you're already working in".
+    var repositorySuggestions: [String] = []
+    var isValidating = false
+    var failureMessage: String?
+
+    var selected: Codespace? {
+      guard let selectedName, let codespaces else { return nil }
+      return codespaces.first { $0.name == selectedName }
+    }
+
+    /// Same normalization rules as the remote form's `location`; the name reaches
+    /// `gh -c` as an argument, so it passes the same door check a hostname does.
+    var location: RemoteProjectLocation? {
+      let path = remotePath.trimmingCharacters(in: .whitespaces)
+      guard let name = selectedName, SafeArgument.isSafeSSHComponent(name),
+        path.hasPrefix("/")
+      else { return nil }
+      return RemoteProjectLocation(
+        host: name, remotePath: RemoteProjectLocation.normalizedPath(path),
+        isCodespace: true)
+    }
+
+    var canSubmit: Bool { location != nil && !isValidating }
+  }
+
+  func loadCodespaces() -> Effect<Action> {
+    .run { send in
+      await send(.codespacesLoaded(codespaceClient.list()))
+    }
+    .cancellable(id: CancelID.codespaceList, cancelInFlight: true)
   }
 }

--- a/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
+++ b/graphcode/Sources/Features/Welcome/WelcomeFeature.swift
@@ -84,6 +84,9 @@ struct WelcomeFeature {
     /// its `ssh://` path, so changing a field here would name a different project rather
     /// than edit this one.
     var inspectedProjectPath: String?
+    /// The inspected project is a codespace — `server` holds its name, and the user
+    /// and port rows have nothing true to say (gh's tunnel owns both).
+    var inspectsCodespace = false
 
     var isInspecting: Bool { inspectedProjectPath != nil }
 
@@ -95,7 +98,8 @@ struct WelcomeFeature {
         port: location.port.map(String.init) ?? "22",
         user: location.user ?? "",
         remotePath: location.remotePath,
-        inspectedProjectPath: projectPath)
+        inspectedProjectPath: projectPath,
+        inspectsCodespace: location.isCodespace)
     }
 
     /// The location the fields currently describe, or `nil` while they don't describe
@@ -123,6 +127,43 @@ struct WelcomeFeature {
     var canSubmit: Bool { location != nil && !isValidating && !isInspecting }
   }
 
+  /// What the add-codespace sheet is collecting: gh's list, one pick, and the path the
+  /// repository lives at inside it. Validation is the remote form's — a codespace that
+  /// passes is one whose sessions can start — with `gh codespace ssh` as the dial.
+  struct CodespaceDraft: Equatable {
+    /// `nil` while `gh codespace list` is still running.
+    var codespaces: [Codespace]?
+    /// Why the list couldn't load — gh missing, or gh's own words (which carry the
+    /// fix when the token lacks the `codespace` scope).
+    var listFailure: String?
+    var selectedName: String?
+    var remotePath = ""
+    /// `owner/repo` for the open local projects, so an empty list can offer "create
+    /// one for the repository you're already working in".
+    var repositorySuggestions: [String] = []
+    var isValidating = false
+    var failureMessage: String?
+
+    var selected: Codespace? {
+      guard let selectedName, let codespaces else { return nil }
+      return codespaces.first { $0.name == selectedName }
+    }
+
+    /// Same normalization rules as the remote form's `location`; the name reaches
+    /// `gh -c` as an argument, so it passes the same door check a hostname does.
+    var location: RemoteProjectLocation? {
+      let path = remotePath.trimmingCharacters(in: .whitespaces)
+      guard let name = selectedName, SafeArgument.isSafeSSHComponent(name),
+        path.hasPrefix("/")
+      else { return nil }
+      return RemoteProjectLocation(
+        host: name, remotePath: RemoteProjectLocation.normalizedPath(path),
+        isCodespace: true)
+    }
+
+    var canSubmit: Bool { location != nil && !isValidating }
+  }
+
   @ObservableState
   struct State: Equatable {
     var recentProjects: [ProjectRef] = []
@@ -130,6 +171,7 @@ struct WelcomeFeature {
     var errorMessage: String?
     var cloneDraft: CloneDraft?
     var remoteDraft: RemoteDraft?
+    var codespaceDraft: CodespaceDraft?
     /// The clone sheet's own folder picker, for choosing `locationPath`. A sibling of
     /// `isOpenPanelPresented` rather than a reuse of it: that one's `fileImporter`
     /// opens a project, and a location pick must not.
@@ -156,6 +198,15 @@ struct WelcomeFeature {
     case remoteCancelled
     case remoteValidated(projectPath: String)
     case remoteValidationFailed(String)
+    case addCodespaceButtonTapped(localProjectPaths: [String])
+    case codespacesLoaded(Result<[Codespace], CodespaceClient.Failure>)
+    case codespaceRepositorySuggestionsLoaded([String])
+    case codespaceListRetryTapped
+    case codespaceSelected(String)
+    case codespaceSubmitted
+    case codespaceValidated(projectPath: String)
+    case codespaceValidationFailed(String)
+    case codespaceCancelled
   }
 
   /// Remembers the last clone location across launches, so a burst of clones doesn't
@@ -166,11 +217,14 @@ struct WelcomeFeature {
   private enum CancelID {
     case clone
     case remoteValidation
+    case codespaceList
+    case codespaceValidation
   }
 
   @Dependency(\.orchestratorClient) var orchestratorClient
   @Dependency(\.gitClient) var gitClient
   @Dependency(\.remoteRepositoryClient) var remoteRepositoryClient
+  @Dependency(\.codespaceClient) var codespaceClient
 
   var body: some ReducerOf<Self> {
     BindingReducer()
@@ -184,6 +238,10 @@ struct WelcomeFeature {
 
       case .binding(\.remoteDraft):
         state.remoteDraft?.failureMessage = nil
+        return .none
+
+      case .binding(\.codespaceDraft):
+        state.codespaceDraft?.failureMessage = nil
         return .none
 
       case .binding:
@@ -331,8 +389,93 @@ struct WelcomeFeature {
       case .remoteCancelled:
         state.remoteDraft = nil
         return .cancel(id: CancelID.remoteValidation)
+
+      case .addCodespaceButtonTapped(let localProjectPaths):
+        state.codespaceDraft = CodespaceDraft()
+        return .merge(
+          loadCodespaces(),
+          .run { send in
+            await send(
+              .codespaceRepositorySuggestionsLoaded(
+                codespaceClient.githubRepositories(localProjectPaths)))
+          }
+        )
+
+      case .codespacesLoaded(.success(let codespaces)):
+        state.codespaceDraft?.codespaces = codespaces
+        state.codespaceDraft?.listFailure = nil
+        return .none
+
+      case .codespacesLoaded(.failure(let failure)):
+        state.codespaceDraft?.listFailure = failure.message
+        return .none
+
+      case .codespaceRepositorySuggestionsLoaded(let repositories):
+        state.codespaceDraft?.repositorySuggestions = repositories
+        return .none
+
+      case .codespaceListRetryTapped:
+        guard state.codespaceDraft != nil else { return .none }
+        state.codespaceDraft?.codespaces = nil
+        state.codespaceDraft?.listFailure = nil
+        return loadCodespaces()
+
+      case .codespaceSelected(let name):
+        guard var draft = state.codespaceDraft else { return .none }
+        draft.selectedName = name
+        draft.failureMessage = nil
+        // Prefill only when the human hasn't typed a path of their own — switching
+        // picks refreshes a default, never overwrites an edit for another codespace
+        // of the same repository.
+        let defaults = (draft.codespaces ?? []).map(\.defaultWorkspacePath)
+        if draft.remotePath.isEmpty || defaults.contains(draft.remotePath) {
+          draft.remotePath = draft.selected?.defaultWorkspacePath ?? ""
+        }
+        state.codespaceDraft = draft
+        return .none
+
+      case .codespaceSubmitted:
+        guard var draft = state.codespaceDraft, let location = draft.location,
+          draft.canSubmit
+        else { return .none }
+        draft.isValidating = true
+        draft.failureMessage = nil
+        state.codespaceDraft = draft
+        return .run { send in
+          if let failure = await remoteRepositoryClient.validate(location) {
+            await send(.codespaceValidationFailed(failure))
+          } else {
+            await send(.codespaceValidated(projectPath: location.projectPath))
+          }
+        }
+        .cancellable(id: CancelID.codespaceValidation, cancelInFlight: true)
+
+      case .codespaceValidated(let projectPath):
+        // Same as a validated remote: the codespace:// path is the project's identity.
+        state.codespaceDraft = nil
+        return .run { _ in
+          try? await orchestratorClient.send(.openProject(path: projectPath))
+        }
+
+      case .codespaceValidationFailed(let message):
+        state.codespaceDraft?.isValidating = false
+        state.codespaceDraft?.failureMessage = message
+        return .none
+
+      case .codespaceCancelled:
+        state.codespaceDraft = nil
+        return .merge(
+          .cancel(id: CancelID.codespaceList),
+          .cancel(id: CancelID.codespaceValidation))
       }
     }
+  }
+
+  private func loadCodespaces() -> Effect<Action> {
+    .run { send in
+      await send(.codespacesLoaded(codespaceClient.list()))
+    }
+    .cancellable(id: CancelID.codespaceList, cancelInFlight: true)
   }
 
   /// Ask the daemon to open a folder, and *say so* when it can't be reached. This was a

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
@@ -43,7 +43,11 @@ extension GhosttyTerminalView {
       remoteCommand: location.remoteLoginShellCommand(script), interactive: true)
     let reconnect = location.sshCommandLine(
       remoteCommand: location.remoteLoginShellCommand(reconnectScript), interactive: true)
-    return ["/bin/sh", "-c", SSHReconnectLoop.script(connect: connect, reconnect: reconnect)]
+    return [
+      "/bin/sh", "-c",
+      SSHReconnectLoop.script(
+        connect: connect, reconnect: reconnect, retriesExitOne: location.isCodespace),
+    ]
   }
 
   /// An agent surface's connect and reconnect scripts, built from fragments computed

--- a/graphcode/Tests/CodespaceTests.swift
+++ b/graphcode/Tests/CodespaceTests.swift
@@ -1,0 +1,240 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// GitHub Codespaces as remote projects: the `codespace://` identity, the
+/// `gh codespace ssh` dial every remote effect rides, and the add form's
+/// list-pick-validate flow. Everything above the dial is the ssh remote machinery,
+/// covered by `RemoteRepositoryTests` — these tests pin down only what differs.
+@Suite
+struct CodespaceTests {
+  private let location = RemoteProjectLocation(
+    host: "dev-widget-x5jq4w", remotePath: "/workspaces/widget", isCodespace: true)
+
+  // MARK: - Identity
+
+  @Test
+  func theCodespacePathRoundTripsThroughParse() {
+    let path = location.projectPath
+    #expect(path == "codespace://dev-widget-x5jq4w/workspaces/widget")
+    #expect(RemoteProjectLocation.parse(projectPath: path) == location)
+  }
+
+  @Test
+  func onlyRealCodespacePathsParse() {
+    // No name, no absolute path, or an option-shaped name (`gh -c <name>` must never
+    // read a stored name as a flag) — all take the local branch.
+    #expect(RemoteProjectLocation.parse(projectPath: "codespace://") == nil)
+    #expect(RemoteProjectLocation.parse(projectPath: "codespace://name") == nil)
+    #expect(RemoteProjectLocation.parse(projectPath: "codespace://-x/srv/repo") == nil)
+    // A user or port has no meaning gh would honour; refusing them keeps one spelling
+    // per codespace, which is what "the path is the identity" needs.
+    #expect(RemoteProjectLocation.parse(projectPath: "codespace://a@name/srv/repo") == nil)
+    #expect(RemoteProjectLocation.parse(projectPath: "codespace://name:22/srv/repo") == nil)
+  }
+
+  @Test
+  func theDisplayNameCarriesTheCodespaceName() {
+    #expect(location.displayName == "widget @ dev-widget-x5jq4w")
+  }
+
+  // MARK: - The dial
+
+  @Test
+  func codespaceInvocationsDialThroughGh() throws {
+    let invocation = location.sshInvocation(remoteCommand: "true")
+    #expect(invocation.first == GhLocator.executablePath)
+    #expect(
+      Array(invocation.dropFirst().prefix(5))
+        == ["codespace", "ssh", "-c", "dev-widget-x5jq4w", "--"])
+    // The ssh posture rides through past the `--`, and the command stays last.
+    #expect(invocation.contains("BatchMode=yes"))
+    #expect(invocation.contains("ServerAliveInterval=5"))
+    #expect(invocation.contains("ServerAliveCountMax=3"))
+    #expect(invocation.last == "true")
+    // No ControlMaster: each gh run opens its own tunnel and exits with it, so a
+    // persisted master would multiplex later dials over a dead connection.
+    #expect(!invocation.contains { $0.contains("ControlMaster") })
+    #expect(!invocation.contains { $0.contains("ControlPersist") })
+
+    // Interactive (a terminal surface) allocates a tty; queries must not.
+    #expect(!invocation.contains("-t"))
+    let interactive = location.sshInvocation(remoteCommand: "x", interactive: true)
+    let dashT = try #require(interactive.firstIndex(of: "-t"))
+    let separator = try #require(interactive.firstIndex(of: "--"))
+    #expect(dashT > separator)
+  }
+
+  @Test
+  func theSocketForwarderDialsThroughGhToo() {
+    let line = RemoteSocketForwarder.forwardCommandLine(
+      for: location, localSocketPath: "/tmp/graphcoded.sock")
+    #expect(line.contains("'codespace' 'ssh' '-c' 'dev-widget-x5jq4w' '--'"))
+    #expect(line.contains("'-N'"))
+    #expect(line.contains("ExitOnForwardFailure=yes"))
+    // gh names the destination itself: the forward spec must be the last word, not a
+    // destination gh would read as the remote command.
+    #expect(line.hasSuffix("'/.graphcode/graphcoded.sock:/tmp/graphcoded.sock'"))
+
+    // The plain-ssh line is untouched: destination last, no gh anywhere.
+    let ssh = RemoteSocketForwarder.forwardCommandLine(
+      for: RemoteProjectLocation(user: "dev", host: "box", remotePath: "/srv/repo"),
+      localSocketPath: "/tmp/graphcoded.sock")
+    #expect(ssh.hasPrefix("'/usr/bin/ssh'"))
+    #expect(ssh.hasSuffix("'dev@box'"))
+  }
+
+  // MARK: - The add form
+
+  @Test
+  func pickingACodespacePrefillsItsWorkspacePath() {
+    let widget = Codespace(
+      name: "dev-widget-x5jq4w", displayName: "upbeat widget", repository: "dev/widget",
+      state: "Available")
+    let gadget = Codespace(
+      name: "dev-gadget-9k2m1p", displayName: "gadget", repository: "dev/gadget",
+      state: "Shutdown")
+    var draft = WelcomeFeature.CodespaceDraft(codespaces: [widget, gadget])
+    #expect(!draft.canSubmit)
+
+    #expect(widget.defaultWorkspacePath == "/workspaces/widget")
+
+    draft.selectedName = widget.name
+    draft.remotePath = widget.defaultWorkspacePath
+    #expect(draft.canSubmit)
+    #expect(
+      draft.location
+        == RemoteProjectLocation(
+          host: "dev-widget-x5jq4w", remotePath: "/workspaces/widget", isCodespace: true))
+
+    // The devcontainer can mount elsewhere, so the path stays editable — but it must
+    // stay absolute, for the same reason the remote form refuses `~`.
+    draft.remotePath = "~/widget"
+    #expect(draft.location == nil)
+    draft.remotePath = "/workspaces/widget/"
+    #expect(draft.location?.remotePath == "/workspaces/widget")
+  }
+
+  @Test
+  @MainActor
+  func aValidatedCodespaceOpensAsAProject() async {
+    let widget = Codespace(
+      name: "dev-widget-x5jq4w", displayName: "upbeat widget", repository: "dev/widget",
+      state: "Available")
+    let opened = OpenedCodespaceProjectsBox()
+    let store = TestStore(initialState: WelcomeFeature.State()) {
+      WelcomeFeature()
+    } withDependencies: {
+      $0.codespaceClient.list = { .success([widget]) }
+      $0.codespaceClient.githubRepositories = { _ in [] }
+      $0.remoteRepositoryClient.validate = { _ in nil }
+      $0.orchestratorClient.send = { command in
+        if case .openProject(let path) = command { await opened.append(path) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.addCodespaceButtonTapped(localProjectPaths: []))
+    await store.receive(\.codespacesLoaded)
+    await store.send(.codespaceSelected("dev-widget-x5jq4w"))
+    #expect(store.state.codespaceDraft?.remotePath == "/workspaces/widget")
+    await store.send(.codespaceSubmitted)
+    await store.receive(\.codespaceValidated)
+    await store.finish()
+
+    #expect(store.state.codespaceDraft == nil)
+    #expect(await opened.paths == ["codespace://dev-widget-x5jq4w/workspaces/widget"])
+  }
+
+  @Test
+  @MainActor
+  func aFailedListKeepsTheSheetOpenWithGhsOwnWords() async {
+    // The words matter: gh's missing-scope error carries its own fix
+    // (`gh auth refresh -h github.com -s codespace`), so it reaches the sheet verbatim.
+    let store = TestStore(initialState: WelcomeFeature.State()) {
+      WelcomeFeature()
+    } withDependencies: {
+      $0.codespaceClient.list = {
+        .failure(.init(message: "gh auth refresh -h github.com -s codespace"))
+      }
+      $0.codespaceClient.githubRepositories = { _ in [] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.addCodespaceButtonTapped(localProjectPaths: []))
+    await store.receive(\.codespacesLoaded)
+    await store.finish()
+
+    #expect(store.state.codespaceDraft?.listFailure?.contains("codespace") == true)
+    #expect(store.state.codespaceDraft?.canSubmit != true)
+  }
+
+  @Test
+  @MainActor
+  func anEmptyListOffersCreatingOneForTheOpenRepositories() async {
+    let store = TestStore(initialState: WelcomeFeature.State()) {
+      WelcomeFeature()
+    } withDependencies: {
+      $0.codespaceClient.list = { .success([]) }
+      $0.codespaceClient.githubRepositories = { paths in
+        paths == ["/Users/dev/widget"] ? ["dev/widget"] : []
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.addCodespaceButtonTapped(localProjectPaths: ["/Users/dev/widget"]))
+    await store.receive(\.codespacesLoaded)
+    await store.receive(\.codespaceRepositorySuggestionsLoaded)
+    await store.finish()
+
+    #expect(store.state.codespaceDraft?.codespaces == [])
+    #expect(store.state.codespaceDraft?.repositorySuggestions == ["dev/widget"])
+  }
+
+  @Test
+  func everyGitHubOriginSpellingYieldsTheSameRepository() {
+    let expected = "dev/widget"
+    for origin in [
+      "https://github.com/dev/widget.git",
+      "https://github.com/dev/widget",
+      "git@github.com:dev/widget.git",
+      "ssh://git@github.com/dev/widget.git",
+    ] {
+      #expect(CodespaceClient.githubRepository(fromOriginURL: origin) == expected)
+    }
+    // Not GitHub, not a repository slug, or option-shaped — no link to offer.
+    #expect(CodespaceClient.githubRepository(fromOriginURL: "https://gitlab.com/dev/widget") == nil)
+    #expect(CodespaceClient.githubRepository(fromOriginURL: "https://github.com/dev") == nil)
+    #expect(CodespaceClient.githubRepository(fromOriginURL: "git@github.com:-x/widget") == nil)
+  }
+
+  // MARK: - Connection info
+
+  @Test
+  @MainActor
+  func connectionInfoShowsTheCodespaceNotAFakeDial() async {
+    let store = TestStore(initialState: WelcomeFeature.State()) {
+      WelcomeFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .remoteConnectionRequested(
+        projectPath: "codespace://dev-widget-x5jq4w/workspaces/widget"))
+
+    let draft = store.state.remoteDraft
+    #expect(draft?.inspectsCodespace == true)
+    #expect(draft?.server == "dev-widget-x5jq4w")
+    #expect(draft?.remotePath == "/workspaces/widget")
+    #expect(draft?.isInspecting == true)
+    #expect(draft?.canSubmit == false)
+  }
+}
+
+private actor OpenedCodespaceProjectsBox {
+  var paths: [String] = []
+  func append(_ path: String) { paths.append(path) }
+}

--- a/graphcode/Tests/CodespaceTests.swift
+++ b/graphcode/Tests/CodespaceTests.swift
@@ -200,15 +200,41 @@ struct CodespaceTests {
     for origin in [
       "https://github.com/dev/widget.git",
       "https://github.com/dev/widget",
+      "https://GitHub.com/dev/widget.git",
       "git@github.com:dev/widget.git",
       "ssh://git@github.com/dev/widget.git",
     ] {
       #expect(CodespaceClient.githubRepository(fromOriginURL: origin) == expected)
     }
-    // Not GitHub, not a repository slug, or option-shaped — no link to offer.
+    // Not GitHub (including a host that merely *contains* github.com), not a
+    // repository slug, or option-shaped — no link to offer.
     #expect(CodespaceClient.githubRepository(fromOriginURL: "https://gitlab.com/dev/widget") == nil)
+    #expect(
+      CodespaceClient.githubRepository(fromOriginURL: "https://notgithub.com/dev/widget") == nil)
     #expect(CodespaceClient.githubRepository(fromOriginURL: "https://github.com/dev") == nil)
     #expect(CodespaceClient.githubRepository(fromOriginURL: "git@github.com:-x/widget") == nil)
+  }
+
+  // MARK: - Reconnect
+
+  @Test
+  func aCodespaceSurfaceRetriesGhsFlattenedExitCode() throws {
+    // gh runs ssh but reports every nonzero exit as its own 1 — ssh's 255 included —
+    // so a codespace dial that only retried 255 would never retry at all. Exit 0
+    // still closes the pane like a clean shell exit.
+    let view = GhosttyTerminalView(
+      surfaceID: UUID(), sessionName: "graphcode-s", launchesClaudeCode: false,
+      initialPrompt: nil, workingDirectory: location.projectPath,
+      projectPath: location.projectPath, onProcessExited: { _ in })
+    let script = try #require(view.remoteCommand(at: location, settings: GraphcodeSettings()).last)
+    #expect(script.contains(#"[ "$gc_rc" -ne 255 ] && [ "$gc_rc" -ne 1 ]"#))
+
+    // A plain ssh remote keeps the strict contract: only 255 retries.
+    let sshLocation = RemoteProjectLocation(user: "dev", host: "box", remotePath: "/srv/repo")
+    let sshScript = try #require(
+      view.remoteCommand(at: sshLocation, settings: GraphcodeSettings()).last)
+    #expect(!sshScript.contains(#"[ "$gc_rc" -ne 255 ] && [ "$gc_rc" -ne 1 ]"#))
+    #expect(sshScript.contains(#"[ "$gc_rc" -ne 255 ] && exit "$gc_rc""#))
   }
 
   // MARK: - Connection info

--- a/graphcode/Tests/FeatureRampsTests.swift
+++ b/graphcode/Tests/FeatureRampsTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import graphcode
+
+/// The no-backend rollout ramp: `ramps.json` on the site, decoded and answered
+/// per-install. What matters is determinism — the same install must get the same
+/// answer every launch, and a raised percent must only ever add installs.
+@Suite
+struct FeatureRampsTests {
+  @Test
+  func theBucketIsStableAndCoversTheRange() {
+    let id = "6E7F4C2A-9B1D-4E3F-8A5C-2D0B9F714E68"
+    let bucket = FeatureRamps.bucket(installID: id)
+    // Stable across calls (and, because it is SHA-256 rather than `Hasher`, across
+    // launches — Hasher's per-process seed was the trap here).
+    #expect(FeatureRamps.bucket(installID: id) == bucket)
+    #expect((0..<100).contains(bucket))
+    // Different installs spread: a hundred UUIDs should not all share one bucket.
+    let buckets = Set((0..<100).map { _ in FeatureRamps.bucket(installID: UUID().uuidString) })
+    #expect(buckets.count > 10)
+  }
+
+  @Test
+  func percentEdgesAreAbsolute() {
+    let off = FeatureRamps.Configuration(features: ["codespaces": ["beta": 0, "stable": 0]])
+    let on = FeatureRamps.Configuration(features: ["codespaces": ["beta": 100, "stable": 100]])
+    for _ in 0..<20 {
+      let id = UUID().uuidString
+      #expect(
+        !FeatureRamps.isEnabled(.codespaces, configuration: off, channel: "beta", installID: id))
+      #expect(
+        FeatureRamps.isEnabled(.codespaces, configuration: on, channel: "stable", installID: id))
+    }
+  }
+
+  @Test
+  func rampsJSONDecodesAndDrivesTheDecision() throws {
+    // The exact shape docs/ramps.json ships — beta on, stable off.
+    let json = #"{ "features": { "codespaces": { "beta": 100, "stable": 0 } } }"#
+    let configuration = try JSONDecoder().decode(
+      FeatureRamps.Configuration.self, from: Data(json.utf8))
+    let id = UUID().uuidString
+    #expect(
+      FeatureRamps.isEnabled(
+        .codespaces, configuration: configuration, channel: "beta", installID: id))
+    #expect(
+      !FeatureRamps.isEnabled(
+        .codespaces, configuration: configuration, channel: "stable", installID: id))
+  }
+
+  @Test
+  func missingConfigurationFallsBackToTheBakedDefaults() {
+    // Before any fetch (and after a failed one): beta has the feature, stable waits.
+    let id = UUID().uuidString
+    #expect(
+      FeatureRamps.isEnabled(.codespaces, configuration: nil, channel: "beta", installID: id))
+    #expect(
+      !FeatureRamps.isEnabled(.codespaces, configuration: nil, channel: "stable", installID: id))
+    // A fetched file that omits a channel falls back per-channel, not per-file.
+    let partial = FeatureRamps.Configuration(features: ["codespaces": ["stable": 100]])
+    #expect(
+      FeatureRamps.isEnabled(.codespaces, configuration: partial, channel: "beta", installID: id))
+    #expect(
+      FeatureRamps.isEnabled(.codespaces, configuration: partial, channel: "stable", installID: id))
+  }
+
+  @Test
+  func anUnknownChannelIsOff() {
+    // A garbage override can't turn a ramp on: no percent for the channel and no
+    // baked default means 0.
+    let configuration = FeatureRamps.Configuration(features: ["codespaces": ["beta": 100]])
+    #expect(
+      !FeatureRamps.isEnabled(
+        .codespaces, configuration: configuration, channel: "nightly",
+        installID: UUID().uuidString))
+  }
+}


### PR DESCRIPTION
## Add Codespace… — GitHub Codespaces as remote projects

Alongside Add Folder / Clone Repository / Add Remote Repository, the sidebar's ⊕ menu
gains **Add Codespace…**: pick one of your codespaces (via `gh codespace list`),
validate it like any remote, and open it as a project. Everything rides the existing
remote machinery — the only new thing is the dial:
`gh codespace ssh -c <name> -- <ssh-flags> <command>`.

### How

- **Identity** `codespace://<name>/absolute/path` (`RemoteProjectLocation.isCodespace`);
  user/port are refused in the URI — gh's tunnel owns both.
- **Dial** ssh-flags ride past `--` (keepalives kept); ControlMaster dropped on purpose
  (gh's per-run random-port tunnel would leave orphaned masters). `GhLocator` resolves
  an absolute `gh` path for launchd-context processes.
- **Exit codes** gh reports every nonzero ssh exit as its own 1, so `SSHReconnectLoop`
  gains `retriesExitOne` for codespace dials — without it codespace surfaces would
  never auto-reconnect (verified against cli/cli v2.87.0 source by the review loop).
- **Socket forwarder** `-N -R` rides past `--` with no destination token (a trailing
  destination would be read as the remote command).
- **Form** list via `gh codespace list --limit 500 --json …`; a pick prefills
  `/workspaces/<repo>` (editable); validation reuses the remote checks + a new zsh
  check; gh's errors surface verbatim (the missing-scope one carries its own fix:
  `gh auth refresh -h github.com -s codespace`).
- **No codespaces yet?** The sheet links the create page — `codespaces.new/owner/repo`
  per GitHub repository already open in GraphCode, generic `github.com/codespaces/new`
  otherwise.

### Rollout ramp (no backend)

`FeatureRamps` fetches `https://graphcode.app/ramps.json` (in `docs/`, served by
Pages/Cloudflare) once per launch, caches it, and buckets the install deterministically
(SHA-256 of a per-install UUID, mod 100) per update channel. **codespaces ships beta
100 / stable 0**; a git push to `docs/ramps.json` ramps prod or kills the feature.

### Verified

- 1234-test suite; 37 tests across CodespaceTests / FeatureRampsTests /
  RemoteRepositoryTests pin the new behavior.
- `make check` — the two remaining serious violations pre-exist on main
  (GraphcodeCommandTests type length; CopilotBackendTests codex-approvals test also
  fails on main when user settings are YOLO).
- Adversarial review by a child loop against gh 2.87.0 help + cli/cli source: flag
  order, forwarder destination omission, JSON fields, URLs, scope-fix text all
  confirmed; its two findings (exit-code flattening, list `--limit`) are fixed here.

### Not verifiable statically (needs a live codespace)

- sshd StreamLocal `-R` forwarding allowed inside a real codespace (daemon-socket
  forward for the remote CLI shim).
- gh keychain token readable from graphcoded's launchd context.
- Pre-existing, inherited: a remotePath containing spaces round-trips badly through
  URLComponents (same for ssh:// paths) — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KksdmxG5msob9WmC9gzqLp
