### PR TITLE
Forward remote sign-in callbacks on link click

### DIFF
--- a/GraphcodeKit/Sources/Domain/AuthCallbackPorts.swift
+++ b/GraphcodeKit/Sources/Domain/AuthCallbackPorts.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The loopback ports a browser-based sign-in URL will call back to.
+///
+/// Every CLI that authenticates through a browser — `az login`, `gcloud auth login`,
+/// `claude`, `codex login` — binds a localhost port and encodes it in the URL it
+/// prints: either the URL itself is `http://localhost:<port>/…`, or the provider URL
+/// carries it as a `redirect_uri`-style query parameter. That port is on the machine
+/// running the CLI; when that machine is a remote project, the Mac's browser needs the
+/// same port carried over (`RemoteAuthPortForwarder`) before the redirect can land.
+/// Reading the port out of the URL is what makes the forward generic: no per-CLI port
+/// list, and random ports (az picks one per login) work the same as fixed ones.
+public enum AuthCallbackPorts {
+  static let loopbackHosts: Set<String> = ["localhost", "127.0.0.1", "::1"]
+
+  /// Unprivileged loopback ports named by the URL, in the order found: the URL's own
+  /// authority first, then any query-parameter value that is itself a URL (the
+  /// `redirect_uri` shape — `URLComponents` has already percent-decoded it once).
+  public static func extract(fromURLString urlString: String) -> [Int] {
+    guard let components = URLComponents(string: urlString) else { return [] }
+    var ports: [Int] = []
+    func appendLoopbackPort(of components: URLComponents) {
+      guard let host = components.host?.lowercased(), loopbackHosts.contains(host),
+        let port = components.port, (1024...65535).contains(port),
+        !ports.contains(port)
+      else { return }
+      ports.append(port)
+    }
+    appendLoopbackPort(of: components)
+    for item in components.queryItems ?? [] {
+      guard let value = item.value, value.contains("://"),
+        let nested = URLComponents(string: value)
+      else { continue }
+      appendLoopbackPort(of: nested)
+    }
+    return ports
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/RemoteAuthPortForwarder.swift
+++ b/GraphcodeKit/Sources/Sessions/RemoteAuthPortForwarder.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Carries a remote sign-in's localhost callback home: one `ssh -N -L` per
+/// `(host, port)`, started when a link from that host's terminal names the port
+/// (`AuthCallbackPorts`) and the Mac's browser is about to be opened on it.
+///
+/// The `-L` twin of `RemoteSocketForwarder`'s `-R`: a CLI in the remote session
+/// (`az login`, `claude`, `codex login`) binds `localhost:<port>` *there* and waits
+/// for the OAuth redirect; the browser completing that redirect runs *here*. Without
+/// the forward the redirect dies on the Mac's own loopback and the CLI waits forever
+/// — the whole sign-in reads as hung.
+///
+/// No retry loop, unlike the socket forwarder: a sign-in is interactive and brief,
+/// and the human's next click on the link re-ensures the forward. `ExitOnForwardFailure`
+/// makes a local bind conflict (something already on that port here) exit rather than
+/// sit connected and useless. Forwards are kept for the app's lifetime — a handful of
+/// idle ssh processes at most, and a second sign-in on the same port reuses the first's.
+public actor RemoteAuthPortForwarder {
+  public static let shared = RemoteAuthPortForwarder()
+
+  private var forwards: [String: Process] = [:]
+
+  public func ensureForwarding(port: Int, to location: RemoteProjectLocation) {
+    let key = "\(location.authority):\(port)"
+    if let existing = forwards[key], existing.isRunning { return }
+    let invocation = Self.forwardInvocation(port: port, to: location)
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: invocation[0])
+    process.arguments = Array(invocation.dropFirst())
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    do {
+      try process.run()
+      forwards[key] = process
+    } catch {}
+  }
+
+  /// The dial: gh for a codespace (the forward rides past `--` as ssh-flags, no
+  /// destination — gh names it), plain ssh otherwise. Same keepalive posture as every
+  /// other dial, so a dropped link dies visibly instead of at the TCP timeout.
+  public static func forwardInvocation(
+    port: Int, to location: RemoteProjectLocation
+  ) -> [String] {
+    let spec = "\(port):localhost:\(port)"
+    let options = [
+      "-N", "-L", spec,
+      "-o", "ExitOnForwardFailure=yes", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
+      "-o", "ServerAliveInterval=5", "-o", "ServerAliveCountMax=3",
+    ]
+    if location.isCodespace {
+      return [GhLocator.executablePath, "codespace", "ssh", "-c", location.host, "--"]
+        + options
+    }
+    var invocation = ["/usr/bin/ssh"] + options
+    if let sshPort = location.port { invocation += ["-p", String(sshPort)] }
+    invocation.append(location.sshDestination)
+    return invocation
+  }
+}

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -1,5 +1,6 @@
 import AppKit
 import GhosttyKit
+import GraphcodeKit
 import os
 
 /// The one process-wide `ghostty_app_t`. There's exactly one of these for the whole
@@ -59,7 +60,9 @@ final class GhosttyRuntime: @unchecked Sendable {
       userdata: nil,
       supports_selection_clipboard: false,
       wakeup_cb: { _ in GhosttyRuntime.wakeup() },
-      action_cb: { _, _, _ in false },
+      action_cb: { _, target, action in
+        GhosttyRuntime.handleAction(target: target, action: action)
+      },
       read_clipboard_cb: { userdata, _, state in
         GhosttyRuntime.readClipboard(userdata, state: state)
       },
@@ -140,6 +143,41 @@ final class GhosttyRuntime: @unchecked Sendable {
   private static func view(from userdata: UnsafeMutableRawPointer?) -> GhosttyTerminalNSView? {
     guard let userdata else { return nil }
     return Unmanaged<GhosttyTerminalNSView>.fromOpaque(userdata).takeUnretainedValue()
+  }
+
+  /// The one action graphcode handles: a ⌘-clicked link. Everything else returns
+  /// false and libghostty's defaults apply — the same posture as before, just no
+  /// longer for URLs, because who opens a link is where remote sign-ins are won.
+  ///
+  /// A CLI in a remote session (`az login`, `claude`, `codex login`) prints an auth
+  /// URL whose OAuth callback is a localhost port on *that* machine; the browser is
+  /// on this one. Before opening the browser, any loopback port the URL names
+  /// (`AuthCallbackPorts` — the URL's own authority, or a `redirect_uri` parameter)
+  /// is forwarded into the clicked surface's remote host, so the redirect the
+  /// provider makes lands on the CLI that is waiting for it.
+  ///
+  /// May be called off the main thread; `remoteLocation` is a plain property written
+  /// on main during `apply` — a torn read costs one un-forwarded click, not a crash.
+  private static func handleAction(
+    target: ghostty_target_s, action: ghostty_action_s
+  ) -> Bool {
+    guard action.tag == GHOSTTY_ACTION_OPEN_URL else { return false }
+    let openUrl = action.action.open_url
+    guard let urlPointer = openUrl.url, openUrl.len > 0 else { return false }
+    let urlString = String(
+      decoding: UnsafeRawBufferPointer(start: urlPointer, count: Int(openUrl.len)),
+      as: UTF8.self)
+    // Not parseable as a URL — let libghostty's own opener have its chance.
+    guard let url = URL(string: urlString) else { return false }
+    if target.tag == GHOSTTY_TARGET_SURFACE, let surface = target.target.surface,
+      let location = view(from: ghostty_surface_userdata(surface))?.remoteLocation
+    {
+      for port in AuthCallbackPorts.extract(fromURLString: urlString) {
+        Task { await RemoteAuthPortForwarder.shared.ensureForwarding(port: port, to: location) }
+      }
+    }
+    DispatchQueue.main.async { NSWorkspace.shared.open(url) }
+    return true
   }
 
   private static func readClipboard(

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import GhosttyKit
+import GraphcodeKit
 
 /// A real terminal surface, rendered by `GhosttyKit` itself — not a placeholder. This
 /// is graphcode's own integration, adapted from the pattern in
@@ -37,6 +38,12 @@ final class GhosttyTerminalNSView: NSView {
   /// panes coming up at once whichever one happened to win the race would report itself
   /// as the user's choice. A click is the only signal that can't be anything else.
   var onFocusRequested: (() -> Void)?
+
+  /// Where this surface's session actually runs, when that is another machine — what
+  /// lets a ⌘-clicked sign-in link carry its localhost callback home first (see
+  /// `GhosttyRuntime.handleAction`). Pushed by `GhosttyTerminalView.apply` like the
+  /// other view-owned state; read from the action callback's thread, torn-read benign.
+  var remoteLocation: RemoteProjectLocation?
 
   private var markedText: String = ""
 

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -117,6 +117,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
   private func apply(to view: GhosttyTerminalNSView) {
     view.isActive = isActive
     view.isVisible = isVisible
+    view.remoteLocation = remoteLocation
     view.onFocusRequested = onFocusRequested
     view.onExitAcknowledged = onExitAcknowledged
     view.onProcessExited = onProcessExited

--- a/graphcode/Tests/AuthPortForwardingTests.swift
+++ b/graphcode/Tests/AuthPortForwardingTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import GraphcodeKit
+import Testing
+
+/// A remote session's browser sign-in: the loopback callback port is read out of the
+/// clicked URL and forwarded into the machine the session runs on, so `az login`,
+/// `claude`, or `codex login` inside a codespace or ssh remote completes against the
+/// Mac's browser. Generic on purpose — the port comes from the URL, never a per-CLI
+/// list, which is what makes az's random port work at all.
+@Suite
+struct AuthPortForwardingTests {
+  @Test
+  func theCallbackPortIsReadFromTheURLItself() {
+    // codex's shape: the printed URL *is* the localhost server.
+    #expect(
+      AuthCallbackPorts.extract(fromURLString: "http://localhost:1455/auth/callback?x=1")
+        == [1455])
+    #expect(
+      AuthCallbackPorts.extract(fromURLString: "http://127.0.0.1:54545/callback") == [54545])
+  }
+
+  @Test
+  func theCallbackPortIsReadFromARedirectURIParameter() {
+    // az's shape: a provider URL carrying a percent-encoded localhost redirect with a
+    // port chosen at random for this one login.
+    let az =
+      "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize"
+      + "?client_id=x&response_type=code"
+      + "&redirect_uri=http%3A%2F%2Flocalhost%3A8400%2F&scope=openid"
+    #expect(AuthCallbackPorts.extract(fromURLString: az) == [8400])
+
+    // claude's shape: console URL with an explicit localhost redirect_uri.
+    let claude =
+      "https://console.anthropic.com/oauth/authorize?client_id=x"
+      + "&redirect_uri=http%3A%2F%2Flocalhost%3A54545%2Fcallback&state=s"
+    #expect(AuthCallbackPorts.extract(fromURLString: claude) == [54545])
+  }
+
+  @Test
+  func onlyLoopbackUnprivilegedPortsCount() {
+    // A page that merely links elsewhere must not open tunnels: non-loopback hosts,
+    // privileged ports, and portless URLs all extract nothing.
+    #expect(AuthCallbackPorts.extract(fromURLString: "https://github.com/login/device") == [])
+    #expect(
+      AuthCallbackPorts.extract(
+        fromURLString: "https://x.test/?redirect_uri=https%3A%2F%2Fapp.x.test%2Fcb") == [])
+    #expect(AuthCallbackPorts.extract(fromURLString: "http://localhost/cb") == [])
+    #expect(AuthCallbackPorts.extract(fromURLString: "http://localhost:80/cb") == [])
+    #expect(AuthCallbackPorts.extract(fromURLString: "not a url") == [])
+    // Deduplicated when the URL and its redirect_uri agree.
+    #expect(
+      AuthCallbackPorts.extract(
+        fromURLString: "http://localhost:9005/?redirect_uri=http%3A%2F%2Flocalhost%3A9005%2F")
+        == [9005])
+  }
+
+  @Test
+  func aCodespaceForwardDialsThroughGh() {
+    let location = RemoteProjectLocation(
+      host: "dev-widget-x5jq4w", remotePath: "/workspaces/widget", isCodespace: true)
+    let invocation = RemoteAuthPortForwarder.forwardInvocation(port: 8400, to: location)
+    #expect(invocation.first == GhLocator.executablePath)
+    #expect(
+      Array(invocation.dropFirst().prefix(5))
+        == ["codespace", "ssh", "-c", "dev-widget-x5jq4w", "--"])
+    #expect(invocation.contains("-N"))
+    let forward = invocation.firstIndex(of: "-L").map { invocation[$0 + 1] }
+    #expect(forward == "8400:localhost:8400")
+    // gh names the destination itself; a trailing one would be read as the command.
+    #expect(invocation.last != "dev-widget-x5jq4w")
+    #expect(invocation.contains("ExitOnForwardFailure=yes"))
+  }
+
+  @Test
+  func anSSHForwardCarriesTheDialAndDestination() {
+    let location = RemoteProjectLocation(
+      user: "dev", host: "build-box", port: 2222, remotePath: "/home/dev/widget")
+    let invocation = RemoteAuthPortForwarder.forwardInvocation(port: 8400, to: location)
+    #expect(invocation.first == "/usr/bin/ssh")
+    let forward = invocation.firstIndex(of: "-L").map { invocation[$0 + 1] }
+    #expect(forward == "8400:localhost:8400")
+    #expect(invocation.contains("2222"))
+    #expect(invocation.last == "dev@build-box")
+  }
+}


### PR DESCRIPTION
## Generic auth-callback port forwarding for remote projects

Any browser-based CLI login run inside a codespace or ssh remote — `az login`, `gcloud auth login`, `claude`, `codex login` — binds a localhost callback port **on the remote machine** and prints an auth URL that encodes it (the URL's own authority, or a `redirect_uri` query parameter). The browser runs on the Mac, so the OAuth redirect used to die on the Mac's loopback while the CLI waited forever.

### How
- **`GhosttyRuntime.action_cb` now handles `GHOSTTY_ACTION_OPEN_URL`** (we returned `false` for everything; libghostty was falling back to its default opener with a logged warning). GraphCode owns the link-open.
- **`AuthCallbackPorts`** reads loopback ports (1024–65535, localhost/127.0.0.1/::1) out of the clicked URL — authority first, then any URL-shaped query value. Generic by construction: az's random per-login port works exactly like codex's fixed 1455 or claude's 54545. Non-loopback and privileged ports extract nothing, so ordinary links never open tunnels.
- **`RemoteAuthPortForwarder`** (the `-L` twin of `RemoteSocketForwarder`) keeps one `ssh -N -L port:localhost:port` per (host, port) — `gh codespace ssh -c <name> -- …` for codespaces, destination omitted since gh names it. `ExitOnForwardFailure` so a local bind conflict exits instead of sitting useless; the next click re-ensures.
- The clicked surface knows its host: `GhosttyTerminalNSView.remoteLocation`, pushed in `apply` like the other view-owned state.

### Verified
Full suite 1246/1246 green; `make check` exit 0. New `AuthPortForwardingTests` pin the az/claude/codex URL shapes, the loopback/privileged filters, and both dial argvs.

### Not verifiable statically
The end-to-end flow needs a live remote login to smoke-test (browser → forwarded port → CLI). Forward setup races the human's auth (seconds vs. the gh tunnel's spin-up) — acceptable; a retry is one click on the same link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KksdmxG5msob9WmC9gzqLp