### PR TITLE
Keep non-web link opens on libghostty's own opener

### DIFF
--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -158,17 +158,25 @@ final class GhosttyRuntime: @unchecked Sendable {
   ///
   /// May be called off the main thread; `remoteLocation` is a plain property written
   /// on main during `apply` — a torn read costs one un-forwarded click, not a crash.
-  private static func handleAction(
+  ///
+  /// Everything that is not a scheme-carrying `.unknown` URL returns false, keeping
+  /// libghostty's opener byte-identical to pre-interception behavior: `.text`/`.html`
+  /// come from scrollback dumps and open in an editor there, and a clicked *file
+  /// path* (Ghostty resolves `./relative` links to bare absolute paths) parses as a
+  /// scheme-less `URL` that `NSWorkspace` won't open but `/usr/bin/open` will. Both
+  /// click gestures land here — ⇧ only bypasses a TUI's mouse capture — so these
+  /// guards are what keep ⌘⇧-click on local folders exactly as it was.
+  static func handleAction(
     target: ghostty_target_s, action: ghostty_action_s
   ) -> Bool {
     guard action.tag == GHOSTTY_ACTION_OPEN_URL else { return false }
     let openUrl = action.action.open_url
+    guard openUrl.kind == GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN else { return false }
     guard let urlPointer = openUrl.url, openUrl.len > 0 else { return false }
     let urlString = String(
       decoding: UnsafeRawBufferPointer(start: urlPointer, count: Int(openUrl.len)),
       as: UTF8.self)
-    // Not parseable as a URL — let libghostty's own opener have its chance.
-    guard let url = URL(string: urlString) else { return false }
+    guard let url = URL(string: urlString), url.scheme != nil else { return false }
     if target.tag == GHOSTTY_TARGET_SURFACE, let surface = target.target.surface,
       let location = view(from: ghostty_surface_userdata(surface))?.remoteLocation
     {

--- a/graphcode/Tests/AuthPortForwardingTests.swift
+++ b/graphcode/Tests/AuthPortForwardingTests.swift
@@ -1,6 +1,9 @@
 import Foundation
+import GhosttyKit
 import GraphcodeKit
 import Testing
+
+@testable import graphcode
 
 /// A remote session's browser sign-in: the loopback callback port is read out of the
 /// clicked URL and forwarded into the machine the session runs on, so `az login`,
@@ -69,6 +72,36 @@ struct AuthPortForwardingTests {
     // gh names the destination itself; a trailing one would be read as the command.
     #expect(invocation.last != "dev-widget-x5jq4w")
     #expect(invocation.contains("ExitOnForwardFailure=yes"))
+  }
+
+  /// Drives `GhosttyRuntime.handleAction` with a real C action struct, the way
+  /// libghostty does. App-targeted so no surface (and no runtime) is needed.
+  private func linkOpenHandled(
+    _ url: String, kind: ghostty_action_open_url_kind_e = GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN
+  ) -> Bool {
+    url.withCString { pointer in
+      var action = ghostty_action_s()
+      action.tag = GHOSTTY_ACTION_OPEN_URL
+      action.action.open_url = ghostty_action_open_url_s(
+        kind: kind, url: pointer, len: UInt(url.utf8.count))
+      var target = ghostty_target_s()
+      target.tag = GHOSTTY_TARGET_APP
+      return GhosttyRuntime.handleAction(target: target, action: action)
+    }
+  }
+
+  @Test
+  func onlySchemeCarryingUnknownURLsAreIntercepted() {
+    // ⌘⇧-click on a local folder's surface must not regress: a clicked *file path*
+    // (Ghostty hands over a bare absolute path for resolved links) and the
+    // editor-opening scrollback kinds return false, so libghostty's own opener runs
+    // exactly as it did before interception existed.
+    #expect(!linkOpenHandled("/Users/dev/notes.txt"))
+    #expect(!linkOpenHandled("https://example.com/dump", kind: GHOSTTY_ACTION_OPEN_URL_KIND_TEXT))
+    #expect(!linkOpenHandled("https://example.com/dump", kind: GHOSTTY_ACTION_OPEN_URL_KIND_HTML))
+    // A real link is ours — the interception the forwarder rides on. A test-only
+    // scheme, so the open attempt resolves to no application.
+    #expect(linkOpenHandled("x-graphcode-test://sign-in"))
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #208, guarding the two local-folder flows the interception would have changed: clicked **file paths** (scheme-less URLs that `NSWorkspace` won't open but `/usr/bin/open` will) and the **.text/.html scrollback-dump kinds** (opened in an editor by `internal_os.open`). Both return `false` now, so libghostty's fallback runs byte-identical to pre-interception behavior — for ⌘-click and the ⌘⇧-click mouse-capture bypass alike (both gestures funnel through the same `openUrl`, verified in the vendored Surface.zig). Only scheme-carrying `.unknown` URLs are intercepted — the only shape auth-port forwarding ever needed.

Tests drive `handleAction` with real C action structs: file path → false, text/html kinds → false, web-ish URL → intercepted. Full suite 1247/1247; `make check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KksdmxG5msob9WmC9gzqLp