### PR TITLE
fix: a blocked attended loop opens on a human tap, and a refusal says why

### DIFF
--- a/GraphcodeKit/Sources/Domain/LoopGraph.swift
+++ b/GraphcodeKit/Sources/Domain/LoopGraph.swift
@@ -148,6 +148,14 @@ public struct LoopGraph: Identifiable, Codable, Equatable, Sendable {
   /// renders.
   public var sequencingEdges: [LoopEdge] { edges.filter { $0.kind.blocksTarget } }
 
+  /// The titles of the loops a node is still waiting on — the sources of its unfired
+  /// sequencing edges, in `nodes` order. What a surface names when it has to say *why*
+  /// a blocked loop is blocked, rather than leaving the state word to explain itself.
+  public func unfiredUpstreamTitles(of nodeID: UUID) -> [String] {
+    let sources = Set(sequencingEdges.filter { $0.to == nodeID && !$0.fired }.map(\.from))
+    return nodes.filter { sources.contains($0.id) }.map(\.title)
+  }
+
   public var entryPoints: [UUID] {
     let targeted = Set(sequencingEdges.map(\.to))
     let loose = unwiredNodeIDs

--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -315,6 +315,27 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     }
   }
 
+  /// Whether a human's tap may open this loop's workspace right now — the one rule
+  /// behind every gesture that opens a loop (a card tap, a sidebar row, ⇧⌘]'s walk,
+  /// history's Back), so click and keyboard cannot come to disagree.
+  ///
+  /// Three ways to qualify, in the order they decide:
+  /// - Not `.blocked`: nothing is holding it, opening is plainly fine.
+  /// - A live session: creation starts an unattended child's session before a
+  ///   follow-up hand-off edge marks it blocked, and a terminal that exists must be
+  ///   reachable.
+  /// - Attended: a turn-based or sketch loop only ever runs because a human opened
+  ///   it, so the human's tap *is* the authorization the hand-off was guarding.
+  ///   Refusing it left a hand-off-wired child unreachable by every gesture the app
+  ///   has, silently, until its parent resolved (#194's orchestration shape).
+  ///
+  /// What stays gated: a blocked *unattended* loop with no session, where opening
+  /// would start sequenced work the graph says must wait — and the daemon would start
+  /// it itself the moment the hand-off fires anyway.
+  public var opensOnHumanTap: Bool {
+    state != .blocked || presenceShowsLiveSession || !runsUnattended
+  }
+
   /// A backend that reports nothing leaves `presence` nil and this returns `state`
   /// untouched, which is exactly the behaviour every surface had before presence existed.
   public var displayState: LoopState {

--- a/graphcode/Sources/Features/App/AppFeature+History.swift
+++ b/graphcode/Sources/Features/App/AppFeature+History.swift
@@ -63,9 +63,9 @@ extension AppFeature {
   /// launch, and a history that erased itself on a transient miss would be worse than
   /// no history.
   ///
-  /// The blocked-node rule is the one `.nodeTapped` applies, repeated rather than shared
-  /// because the two differ in what they do when it fails: a tap on a blocked loop is
-  /// ignored, a Back onto one keeps walking.
+  /// The blocked-node rule is the one `.nodeTapped` applies
+  /// (`LoopNode.opensOnHumanTap`); the two differ only in what they do when it fails —
+  /// a tap on a gated loop raises the notice alert, a Back onto one keeps walking.
   private func canResolve(_ state: State) -> (LoopVisit) -> Bool {
     { visit in
       switch visit {
@@ -73,7 +73,7 @@ extension AppFeature {
         guard let node = state.projects[id: projectPath]?.graph.nodes[id: nodeID] else {
           return false
         }
-        return node.state != .blocked || node.presenceShowsLiveSession
+        return node.opensOnHumanTap
       case .quickChat(let id):
         return state.quickChats[id: id] != nil
       }

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -100,6 +100,12 @@ struct AppFeature {
     /// not persisted: a queue position is about this sitting, not about this graph.
     var lastReviewedNodeID: UUID?
 
+    /// The explanation up for a tap `.nodeTapped` refused — a blocked unattended loop
+    /// with no session to attach to (see `LoopNode.opensOnHumanTap`). A tap that does
+    /// nothing at all is indistinguishable from a broken canvas; this is the alert
+    /// that says why instead.
+    var blockedLoopNotice: BlockedLoopNotice?
+
     /// ⌘K's jump palette — see `AppFeature+JumpPalette.swift`.
     var isJumpPresented = false
     var jumpQuery = ""
@@ -217,6 +223,8 @@ struct AppFeature {
     case historyForwardTapped
     /// The stop/kill affordance docs/05-orchestrator.md asks the monitor for.
     case stopNodeTapped(projectPath: String, nodeID: UUID)
+    /// Dismisses the "why didn't that open" alert — see `State.blockedLoopNotice`.
+    case blockedLoopNoticeDismissed
     /// The first-launch terminology primer — see `OnboardingView`.
     case onboardingRequested
     case onboardingDismissed
@@ -518,28 +526,10 @@ struct AppFeature {
           .projects(.element(id: path, action: .addNodeButtonTapped(parentBackend: parentBackend))))
 
       case .projects(.element(id: let path, action: .nodeTapped(let nodeID))):
-        // Every loop type opens the same way. A time-based node used to be excluded
-        // because it only existed as a headless `claude -p` the daemon fired on a timer;
-        // now its recurrence runs inside an ordinary interactive session (see
-        // `LoopNode.triggerPrompt`), so there's a real terminal to attach to — which is
-        // the point, since watching and steering a running loop is most of its value.
-        // A blocked node with a *live session* still opens: creation starts an
-        // unattended child's session before a follow-up hand-off edge marks it
-        // blocked, so blocked-but-running is a state people actually meet — and a
-        // terminal that exists must be reachable. What stays gated is the blocked
-        // node with no session, where opening would *start* sequenced work early.
-        guard let node = state.projects[id: path]?.graph.nodes[id: nodeID],
-          node.state != .blocked || node.presenceShowsLiveSession
-        else { return .none }
-        let layout = terminalLayoutStore.load(forNode: nodeID) ?? .defaultLayout(forNode: nodeID)
-        state.openLoop = LoopWorkspaceFeature.State(
-          node: node,
-          graph: state.projects[id: path]?.graph ?? LoopGraph(scope: .global),
-          layout: layout,
-          projectPath: path,
-          projectName: state.projects[id: path]?.graph.project.name ?? path)
-        state.selectedProjectPath = path
-        recordVisit(.loop(projectPath: path, nodeID: nodeID), &state)
+        return openNode(nodeID, in: path, &state)
+
+      case .blockedLoopNoticeDismissed:
+        state.blockedLoopNotice = nil
         return .none
 
       // A loop's own primary Claude Code session exiting *is* its resolution — no
@@ -684,16 +674,46 @@ extension AppFeature {
     state.pendingOpenPaths.insert(ProjectRegistry.canonicalize(path))
   }
 
+  /// `.nodeTapped`'s body. Every loop type opens the same way. A time-based node used
+  /// to be excluded because it only existed as a headless `claude -p` the daemon fired
+  /// on a timer; now its recurrence runs inside an ordinary interactive session (see
+  /// `LoopNode.triggerPrompt`), so there's a real terminal to attach to — which is
+  /// the point, since watching and steering a running loop is most of its value.
+  /// The blocked-node rule is `LoopNode.opensOnHumanTap` — blocked attended loops
+  /// and blocked-but-live ones open, a blocked unattended loop with no session
+  /// doesn't. The refusal raises the notice alert rather than doing nothing: a
+  /// silent dead click reads as a broken canvas, not a rule (#194 follow-up).
+  private func openNode(_ nodeID: UUID, in path: String, _ state: inout State) -> Effect<Action> {
+    guard let node = state.projects[id: path]?.graph.nodes[id: nodeID]
+    else { return .none }
+    guard node.opensOnHumanTap else {
+      state.blockedLoopNotice = BlockedLoopNotice(
+        node: node, graph: state.projects[id: path]?.graph)
+      return .none
+    }
+    let layout = terminalLayoutStore.load(forNode: nodeID) ?? .defaultLayout(forNode: nodeID)
+    state.openLoop = LoopWorkspaceFeature.State(
+      node: node,
+      graph: state.projects[id: path]?.graph ?? LoopGraph(scope: .global),
+      layout: layout,
+      projectPath: path,
+      projectName: state.projects[id: path]?.graph.project.name ?? path)
+    state.selectedProjectPath = path
+    recordVisit(.loop(projectPath: path, nodeID: nodeID), &state)
+    return .none
+  }
+
   /// Steps the open workspace to another loop, in the order the sidebar draws them —
-  /// every open project's nodes, flattened — wrapping at the ends and skipping blocked
-  /// nodes, the same rule a direct `.nodeTapped` applies. With no workspace open it
-  /// lands on the first (or last) loop, so the shortcut also *opens* a loop from a
-  /// canvas. Routes through `.nodeTapped` rather than setting `openLoop` itself, so
-  /// keyboard and click cannot come to open a workspace two different ways.
+  /// every open project's nodes, flattened — wrapping at the ends and skipping loops a
+  /// tap couldn't open (`LoopNode.opensOnHumanTap`, the same rule a direct
+  /// `.nodeTapped` applies). With no workspace open it lands on the first (or last)
+  /// loop, so the shortcut also *opens* a loop from a canvas. Routes through
+  /// `.nodeTapped` rather than setting `openLoop` itself, so keyboard and click cannot
+  /// come to open a workspace two different ways.
   private func stepOpenLoop(_ state: State, by offset: Int) -> Effect<Action> {
     let loops = state.projects.flatMap { project in
       project.graph.nodes
-        .filter { $0.state != .blocked }
+        .filter(\.opensOnHumanTap)
         .map { (projectPath: project.id, nodeID: $0.id) }
     }
     guard !loops.isEmpty else { return .none }
@@ -782,5 +802,26 @@ extension AppFeature {
     if state.selectedProjectPath == path {
       state.selectedProjectPath = state.projects.first?.id
     }
+  }
+}
+
+/// What the alert for a refused loop tap says — built at the moment of refusal, so it
+/// can name the upstream loops the graph is actually waiting on. Top-level rather than
+/// nested in `AppFeature`, which is at swiftlint's body-length limit.
+struct BlockedLoopNotice: Equatable {
+  var title: String
+  var message: String
+
+  init(node: LoopNode, graph: LoopGraph?) {
+    title = "“\(node.title)” is waiting its turn"
+    let upstream = graph?.unfiredUpstreamTitles(of: node.id) ?? []
+    let waitingOn =
+      upstream.isEmpty
+      ? "a hand-off that hasn't fired yet"
+      : upstream.map { "“\($0)”" }.joined(separator: " and ") + " to finish"
+    // "Released", not "its session starts": firing unblocks the loop and stages the
+    // hand-off nudge, but the daemon relaunches a dead unattended session at boot and
+    // on the liveness sweep, not at the moment of firing — don't promise more.
+    message = "It's waiting on \(waitingOn) — the hand-off will release it automatically."
   }
 }

--- a/graphcode/Sources/Features/App/AppView.swift
+++ b/graphcode/Sources/Features/App/AppView.swift
@@ -228,6 +228,9 @@ struct AppView: View {
     // The sweeper and a folder's settings — same hosting rule, own modifier for the
     // same type-checker reason. See `WorktreeDialogs`.
     .modifier(WorktreeDialogs(store: store))
+    // Why a tap on a gated loop did nothing — same hosting rule again: the tap can
+    // come from the sidebar or ⇧⌘] while any detail pane is up.
+    .modifier(BlockedLoopDialog(store: store))
   }
 
   /// Folders past their worktree notice threshold, for the titlebar chip. Policies
@@ -338,6 +341,27 @@ struct AppView: View {
 
   private func selectedProjectStore(_ path: String) -> StoreOf<ProjectFeature>? {
     store.scope(state: \.projects[id: path], action: \.projects[id: path])
+  }
+}
+
+/// The one alert `.nodeTapped`'s refusal raises — see `BlockedLoopNotice`.
+/// A modifier of its own for the dialog chain's type-checker reason, like the rest.
+private struct BlockedLoopDialog: ViewModifier {
+  let store: StoreOf<AppFeature>
+
+  func body(content: Content) -> some View {
+    content
+      .alert(
+        store.blockedLoopNotice?.title ?? "",
+        isPresented: Binding(
+          get: { store.blockedLoopNotice != nil },
+          set: { if !$0 { store.send(.blockedLoopNoticeDismissed) } }
+        )
+      ) {
+        Button("OK") { store.send(.blockedLoopNoticeDismissed) }
+      } message: {
+        Text(store.blockedLoopNotice?.message ?? "")
+      }
   }
 }
 

--- a/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
@@ -23,10 +23,11 @@ extension ProjectCanvasView {
   /// The card itself is `LoopCardView`, shared with the Graph overview — see there for
   /// what it draws. What stays here is what only a project's own canvas has: the tap
   /// that opens the loop, the context menu, and the hover-revealed connector handle.
+  @ViewBuilder
   private func nodeCard(
     for node: LoopNode, reason: AttentionReason?, role: CardEntryRole, now: Date
   ) -> some View {
-    LoopCardView(
+    let card = LoopCardView(
       node: node,
       reason: reason,
       now: now,
@@ -49,6 +50,23 @@ extension ProjectCanvasView {
     }
     .contextMenu { nodeMenu(for: node) }
     // The hover-revealed + handle is `HoverRevealingCard`'s job — see `nodesLayer`.
+    // A blocked card's pill says *that* it waits; hovering says on *what*, before a
+    // click has to find out.
+    if let waiting = blockedHelp(for: node) {
+      card.help(waiting)
+    } else {
+      card
+    }
+  }
+
+  private func blockedHelp(for node: LoopNode) -> String? {
+    guard node.state == .blocked else { return nil }
+    let upstream = store.canvasGraph.unfiredUpstreamTitles(of: node.id)
+    guard !upstream.isEmpty else {
+      return "Blocked — waiting on a hand-off that hasn't fired yet"
+    }
+    return "Blocked — waiting on "
+      + upstream.map { "“\($0)”" }.joined(separator: " and ") + " to finish"
   }
 
   @ViewBuilder

--- a/graphcode/Tests/AppFeatureTests.swift
+++ b/graphcode/Tests/AppFeatureTests.swift
@@ -161,27 +161,8 @@ struct AppFeatureTests {
     #expect(store.state.projects[id: Self.projectA.path]?.graph.nodes.count == 1)
   }
 
-  @Test
-  @MainActor
-  func blockedNodeCannotBeOpened() async {
-    var blockedNode = LoopNode(title: "Implement", checkDescription: "Correct?")
-    blockedNode.state = .blocked
-    var state = AppFeature.State()
-    state.projects.append(
-      ProjectFeature.State(graph: LoopGraph(project: Self.projectA, nodes: [blockedNode])))
-    state.selectedProjectPath = Self.projectA.path
-
-    let store = TestStore(initialState: state) {
-      AppFeature()
-    } withDependencies: {
-      $0.terminalLayoutStore = makeTerminalLayoutStore()
-    }
-    store.exhaustivity = .off
-
-    await store.send(
-      .projects(.element(id: Self.projectA.path, action: .nodeTapped(blockedNode.id))))
-    #expect(store.state.openLoop == nil)
-  }
+  // The blocked-loop open gate itself — both sides of it, and the refusal notice — is
+  // covered in `BlockedLoopGateTests`.
 
   @Test
   @MainActor
@@ -406,13 +387,16 @@ struct AppFeatureTests {
   }
 
   /// ⇧⌘]/⇧⌘[ walk the same flattened list the sidebar draws — across projects, skipping
-  /// blocked loops, wrapping at the ends — and go through `.nodeTapped` rather than a
-  /// path of their own, so what the shortcut opens is exactly what a click would.
+  /// loops a tap couldn't open (`opensOnHumanTap`), wrapping at the ends — and go
+  /// through `.nodeTapped` rather than a path of their own, so what the shortcut opens
+  /// is exactly what a click would. The gated loop here is unattended: a blocked
+  /// *turn-based* loop opens on a tap now, so it is no longer skipped.
   @Test
   @MainActor
-  func loopCycleShortcutStepsAcrossProjectsSkippingBlockedLoops() async {
+  func loopCycleShortcutStepsAcrossProjectsSkippingGatedLoops() async {
     let first = LoopNode(title: "First", checkDescription: "c")
-    var blocked = LoopNode(title: "Blocked", checkDescription: "c")
+    var blocked = LoopNode(
+      title: "Blocked", loopType: .goalBased, goal: GoalSpec(summary: "g"))
     blocked.state = .blocked
     let last = LoopNode(title: "Last", checkDescription: "c")
     var state = AppFeature.State()

--- a/graphcode/Tests/BlockedLoopGateTests.swift
+++ b/graphcode/Tests/BlockedLoopGateTests.swift
@@ -1,0 +1,125 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// The open gate for blocked loops — `LoopNode.opensOnHumanTap` and what `.nodeTapped`
+/// does on each side of it. Its own suite because the rule spans the domain (who may
+/// open) and the app (what a refusal says), and because the #194 follow-up that
+/// created it is exactly the kind of behavior a later fix could quietly regress.
+@Suite
+struct BlockedLoopGateTests {
+  private static let projectA = ProjectRef(path: "/tmp/project-a", name: "project-a")
+
+  private func makeTerminalLayoutStore() -> TerminalLayoutStore {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("graphcode-tests-\(UUID().uuidString)", isDirectory: true)
+    return TerminalLayoutStore(baseDirectory: directory)
+  }
+
+  /// The whole gate, per loop type. An attended loop (turn-based, sketch) opens even
+  /// blocked — a human's tap is what runs it, so the tap is the authorization. An
+  /// unattended one needs a live session; without one, opening would start sequenced
+  /// work the graph says must wait.
+  @Test
+  func opensOnHumanTapFollowsAttendanceAndPresence() {
+    func node(_ type: LoopType, _ state: LoopState, presence: Presence? = nil) -> LoopNode {
+      LoopNode(
+        title: "N", loopType: type,
+        presence: presence.map { PresenceReading(presence: $0, confidence: .reported) },
+        state: state)
+    }
+    #expect(node(.turnBased, .blocked).opensOnHumanTap)
+    #expect(node(.sketch, .blocked).opensOnHumanTap)
+    #expect(!node(.goalBased, .blocked).opensOnHumanTap)
+    #expect(!node(.timeBased, .blocked).opensOnHumanTap)
+    #expect(node(.goalBased, .blocked, presence: .busy).opensOnHumanTap)
+    #expect(node(.timeBased, .blocked, presence: .idle).opensOnHumanTap)
+    #expect(node(.goalBased, .running).opensOnHumanTap)
+    #expect(node(.turnBased, .idle).opensOnHumanTap)
+  }
+
+  /// What the refusal alert and the blocked card's tooltip name: the sources of the
+  /// unfired sequencing edges into a node — never a `message` edge's, and never one
+  /// that already fired.
+  @Test
+  func unfiredUpstreamTitlesNamesOnlyUnfiredSequencingSources() {
+    let parent = LoopNode(title: "Parent", checkDescription: "c")
+    let sibling = LoopNode(title: "Sibling", checkDescription: "c")
+    let child = LoopNode(title: "Child", checkDescription: "c")
+    let graph = LoopGraph(
+      project: Self.projectA,
+      nodes: [parent, sibling, child],
+      edges: [
+        LoopEdge(from: parent.id, to: child.id),
+        LoopEdge(from: sibling.id, to: child.id, fireCount: 1),
+        LoopEdge(from: child.id, to: parent.id, kind: .message),
+      ])
+    #expect(graph.unfiredUpstreamTitles(of: child.id) == ["Parent"])
+    #expect(graph.unfiredUpstreamTitles(of: parent.id).isEmpty)
+  }
+
+  /// The #194 orchestration shape, from the human's side: a turn-based child wired in
+  /// by a hand-off is `.blocked` with no session, and a turn-based loop only ever runs
+  /// because a human opened it — so the tap is the authorization, not a violation of
+  /// the sequencing. Refusing it left the child unreachable by every gesture the app
+  /// has until its parent resolved.
+  @Test
+  @MainActor
+  func blockedTurnBasedNodeOpensOnTap() async {
+    var blockedNode = LoopNode(title: "Implement", checkDescription: "Correct?")
+    blockedNode.state = .blocked
+    var state = AppFeature.State()
+    state.projects.append(
+      ProjectFeature.State(graph: LoopGraph(project: Self.projectA, nodes: [blockedNode])))
+    state.selectedProjectPath = Self.projectA.path
+
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalLayoutStore = makeTerminalLayoutStore()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .projects(.element(id: Self.projectA.path, action: .nodeTapped(blockedNode.id))))
+    #expect(store.state.openLoop?.node.id == blockedNode.id)
+    #expect(store.state.blockedLoopNotice == nil)
+  }
+
+  /// What stays gated: a blocked *unattended* loop with no session, where opening
+  /// would start sequenced work early. The refusal must say so — a silent dead click
+  /// is indistinguishable from a broken canvas — and name what the loop waits on.
+  @Test
+  @MainActor
+  func blockedUnattendedNodeStaysGatedAndExplains() async {
+    let parent = LoopNode(title: "Parent", checkDescription: "Done?")
+    var blockedNode = LoopNode(
+      title: "Fetch", loopType: .goalBased, goal: GoalSpec(summary: "fetch it"))
+    blockedNode.state = .blocked
+    var state = AppFeature.State()
+    state.projects.append(
+      ProjectFeature.State(
+        graph: LoopGraph(
+          project: Self.projectA, nodes: [parent, blockedNode],
+          edges: [LoopEdge(from: parent.id, to: blockedNode.id)])))
+    state.selectedProjectPath = Self.projectA.path
+
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalLayoutStore = makeTerminalLayoutStore()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .projects(.element(id: Self.projectA.path, action: .nodeTapped(blockedNode.id))))
+    #expect(store.state.openLoop == nil)
+    #expect(store.state.blockedLoopNotice?.message.contains("“Parent”") == true)
+
+    await store.send(.blockedLoopNoticeDismissed)
+    #expect(store.state.blockedLoopNotice == nil)
+  }
+}

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -417,6 +417,9 @@ struct ProjectFeatureTests {
     #expect(!node(.unknown).presenceShowsLiveSession)
     #expect(!node(nil).presenceShowsLiveSession)
   }
+
+  // The full open gate built on this reading — `opensOnHumanTap`, per loop type, and
+  // the refusal notice — is covered in `BlockedLoopGateTests`.
 }
 
 private actor SentGraphCommandsBox {


### PR DESCRIPTION
Follow-up to #194. The entry-point/cycle fix (#195) corrected the canvas *labeling*, but the orchestration shape it diagnosed — parent `handoff`→ child, child `message`→ parent — still left every turn-based child unreachable: an unfired inbound handoff marks it `.blocked`, turn-based loops have no session until opened, and the workspace gate refused a blocked node without a live session **silently**.

For an attended loop that gate was self-defeating: a human opening it is the only way it ever runs.

## What changed

- **`LoopNode.opensOnHumanTap`** — the one rule for every open gesture (card tap, sidebar, Graph overview, ⌘K palette, activity strip, ⇧⌘] walk, history Back): opens unless it is a blocked *unattended* loop with no live session. Blocked attended loops (turn-based, sketch) now open — the tap is the authorization the hand-off was guarding.
- **A refusal explains itself** — the still-gated case raises an alert (`BlockedLoopNotice`) naming the unfired upstream hand-offs via `LoopGraph.unfiredUpstreamTitles(of:)`, instead of a dead click. It says the hand-off will *release* the loop — deliberately not "start its session", since firing unblocks and stages the nudge while dead unattended sessions relaunch at daemon boot/liveness sweep.
- **Blocked cards get a hover tooltip** — "Blocked — waiting on “Parent” to finish".

## Tests

New `BlockedLoopGateTests`: blocked turn-based opens on tap (the repro shape), blocked goal-based stays gated and the notice names its upstream, the `opensOnHumanTap` matrix across all five loop types, and upstream-title selection (sequencing edges only, unfired only). The ⇧⌘] walk test now gates on `opensOnHumanTap`. 62 tests across the five affected suites pass.

## Noted, out of scope

`MessageBus.deliverability` treats any `.blocked` node as `targetNotLive`, so a blocked child opened early with a live session still refuses mid-flight messages (staged to memory instead). Pre-existing — already true for #140's blocked-but-live children — and worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sVUbFuRoHXL7JcxS1czBC