### PR TITLE
fix: imported unattended loops start on arrival, so remote imports work

### DIFF
--- a/GraphcodeKit/Sources/Domain/GraphImport.swift
+++ b/GraphcodeKit/Sources/Domain/GraphImport.swift
@@ -189,9 +189,11 @@ public enum GraphImportPlanner {
 
   /// A structural copy under a new id, keeping the fields that are the loop's history.
   ///
-  /// `state` lands `.idle` for every type: an imported loop has no session yet, and a
-  /// card that said RUNNING the moment it arrived would be claiming work nobody
-  /// started. Opening the loop (or a goal poller resolving it) takes it from there.
+  /// A resolved loop keeps its verdict: the bundle *is* the loop's history, and a
+  /// succeeded loop reborn `.idle` looked unstarted to every ensure path — on a remote
+  /// project the liveness sweep re-ran finished work on a host nobody was watching.
+  /// Everything else lands `.idle`, and the daemon starts the unattended ones the
+  /// moment they arrive (`GraphStore.importNodes`), exactly as `createNode` would.
   /// `presence`/`activity` stay nil for the same reason they aren't persisted.
   private static func reIdentify(
     _ node: LoopNode, as newID: UUID, identities: [UUID: UUID]
@@ -215,6 +217,7 @@ public enum GraphImportPlanner {
       loopType: node.loopType,
       checkDescription: node.checkDescription,
       triggerPrompt: node.triggerPrompt,
+      heartbeatIntervalSeconds: node.heartbeatIntervalSeconds,
       firstInstruction: node.firstInstruction,
       pausesBeforeWritesOnly: node.pausesBeforeWritesOnly,
       goal: node.goal,
@@ -231,7 +234,7 @@ public enum GraphImportPlanner {
       // Custody only survives when the custodian came along in the same bundle;
       // otherwise the reference would dangle at a node the target graph never had.
       createdBy: node.createdBy.flatMap { identities[$0] },
-      state: .idle,
+      state: node.isResolved ? node.state : .idle,
       createdAt: Date()
     )
   }

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -1203,6 +1203,23 @@ public actor GraphStore {
       }
       recordMemory(newID, "imported into \(graph.project.path) with a fresh identity")
     }
+    // What creation gives an unattended loop, import gives it too: a session, its goal
+    // poller, its heartbeat, and a state that says so. Landing everything `.idle` and
+    // starting nothing read as "dormant until opened", but wasn't: every ensure path
+    // treats an unresolved unattended node as one that should be alive, so on a remote
+    // project the liveness sweep started imported loops within a minute anyway — with
+    // no poller to ever resolve them, a card still claiming IDLE, and a pane that
+    // could only say "waiting for graphcoded". Sub-graph imports stay template-idle
+    // the same way created ones do: the child store's ensure hook is deliberately nil,
+    // and piloting is what starts those.
+    for newID in plan.idMapping.values {
+      guard let node = graph.nodes[id: newID], node.runsUnattended, !node.isResolved
+      else { continue }
+      if subGraphDepth == 0 { graph.nodes[id: newID]?.state = .running }
+      ensureSession(node)
+      if node.loopType == .goalBased { armGoalPoller(for: node) }
+      armHeartbeat(for: node)
+    }
   }
 
   // MARK: - Deletion

--- a/graphcode-cli/Sources/main.swift
+++ b/graphcode-cli/Sources/main.swift
@@ -419,7 +419,12 @@ do {
     }
     if case .errorOccurred(let message) = verdict { fail(message) }
     if case .graphChanged(let graph) = verdict {
-      let resumable = bundle.sessionsByNodeID.values.filter { $0.backend.supportsResume }
+      // A remote target gets no transplants — the sessions live on the remote host, so
+      // `SessionTransplant.restore` skips them — and promising a resume there would be
+      // a lie the loop's fresh first pass immediately exposes.
+      let resumable =
+        RemoteProjectLocation.parse(projectPath: projectPath) == nil
+        ? bundle.sessionsByNodeID.values.filter { $0.backend.supportsResume } : []
       print(
         "imported \(bundle.graphSnapshot.nodes.count) loop(s) "
           + "and \(bundle.graphSnapshot.edges.count) edge(s) with fresh identities"

--- a/graphcode/Tests/GraphImportStartTests.swift
+++ b/graphcode/Tests/GraphImportStartTests.swift
@@ -1,0 +1,88 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+/// What `GraphCommand.importNodes` does *after* the merge: imported unattended loops
+/// get exactly what created ones get — a session, and a state that says so. Import
+/// used to land everything `.idle` and start nothing, which every ensure path read as
+/// "should be alive anyway": on a remote project the liveness sweep launched imported
+/// loops within a minute with no goal poller to ever resolve them and a card still
+/// claiming IDLE. The merge itself is covered where it lives, in `GraphImportPlanner`.
+@Suite
+struct GraphImportStartTests {
+  private func snapshot(of nodes: [LoopNode], edges: [LoopEdge] = []) -> LoopGraph {
+    LoopGraph(
+      project: ProjectRef(path: "/tmp/exported", name: "exported"),
+      nodes: IdentifiedArray(uniqueElements: nodes),
+      edges: IdentifiedArray(uniqueElements: edges))
+  }
+
+  @Test
+  func importingAGoalLoopStartsItsSessionAndMarksItRunning() async {
+    let started = LockIsolated<[LoopNode]>([])
+    let store = GraphStore(onEnsureSession: { node, _ in started.withValue { $0.append(node) } })
+    let exported = LoopNode(
+      title: "Green build", loopType: .goalBased,
+      goal: GoalSpec(summary: "CI passes"), state: .running)
+
+    await store.handle(.importNodes(GraphImportRequest(snapshot: snapshot(of: [exported]))))
+
+    let graph = await store.graph
+    #expect(graph.nodes.count == 1)
+    #expect(graph.nodes[0].state == .running)
+    #expect(graph.nodes[0].id != exported.id)
+    #expect(started.value.map(\.id) == [graph.nodes[0].id])
+  }
+
+  @Test
+  func importedResolvedLoopsKeepTheirVerdictAndStayUnstarted() async {
+    // The bundle is the loop's history. Reborn `.idle`, a succeeded loop looked
+    // unstarted to the remote liveness sweep, which re-ran the finished work.
+    let started = LockIsolated<[LoopNode]>([])
+    let store = GraphStore(onEnsureSession: { node, _ in started.withValue { $0.append(node) } })
+    let done = LoopNode(
+      title: "Shipped", loopType: .goalBased,
+      goal: GoalSpec(summary: "released"), state: .succeeded)
+
+    await store.handle(.importNodes(GraphImportRequest(snapshot: snapshot(of: [done]))))
+
+    let graph = await store.graph
+    #expect(graph.nodes.count == 1)
+    #expect(graph.nodes[0].state == .succeeded)
+    #expect(started.value.isEmpty)
+  }
+
+  @Test
+  func importedTurnBasedLoopsStayIdleForAHumanToOpen() async {
+    let started = LockIsolated<[LoopNode]>([])
+    let store = GraphStore(onEnsureSession: { node, _ in started.withValue { $0.append(node) } })
+    let exported = LoopNode(
+      title: "Review", loopType: .turnBased, checkDescription: "Sound?",
+      firstInstruction: "Work", state: .running)
+
+    await store.handle(.importNodes(GraphImportRequest(snapshot: snapshot(of: [exported]))))
+
+    let graph = await store.graph
+    #expect(graph.nodes.count == 1)
+    #expect(graph.nodes[0].state == .idle)
+    #expect(started.value.isEmpty)
+  }
+
+  @Test
+  func reIdentifiedSnapshotsPreserveResolutionAndHeartbeats() {
+    let succeeded = LoopNode(
+      title: "Done", loopType: .goalBased, goal: GoalSpec(summary: "met"), state: .succeeded)
+    let ticking = LoopNode(
+      title: "Watcher", loopType: .timeBased, triggerPrompt: "check reports",
+      heartbeatIntervalSeconds: 3600, state: .running)
+
+    let prepared = GraphImportPlanner.reIdentified(
+      GraphImportRequest(snapshot: snapshot(of: [succeeded, ticking])))
+
+    let nodes = prepared?.request.snapshot.nodes
+    #expect(nodes?.first(where: { $0.title == "Done" })?.state == .succeeded)
+    #expect(nodes?.first(where: { $0.title == "Watcher" })?.state == .idle)
+    #expect(nodes?.first(where: { $0.title == "Watcher" })?.heartbeatIntervalSeconds == 3600)
+  }
+}


### PR DESCRIPTION
## Problem

**Import loop is broken when imported into remote repositories.** Importing a bundle landed every loop `.idle` and started nothing — but every ensure path in the daemon treats an unresolved unattended node as one that should be alive:

- On a remote project the 60s liveness sweep (`ensureUnattendedSessionsAlive`) force-started imported goal/time loops within a minute — with **no goal poller armed** (import never arms one, the sweep deliberately doesn't), so a predicate goal could never resolve, the card stayed **IDLE while an agent ran** on the remote host, and edges never fired.
- Opening the imported loop showed *"Loop session is not running; waiting for graphcoded to start it"* for up to a minute, since the pane defers unattended remote loops to the daemon.
- The sweep also **re-ran imported loops that had already succeeded** at their source: re-identification wiped resolution to `.idle`.

Reproduced end to end against a loopback sshd with an isolated `$HOME`: import → status `idle`, session appears only at the next sweep tick (dial log `ensure fresh` exactly 59s after import), state never leaves idle.

## Fix

- `GraphStore.importNodes` now gives an unattended import exactly what `createNode` gives a created loop: its session, its goal poller, its heartbeat, and a `.running` state that says so. Sub-graph imports stay template-idle (the child store's ensure hook is deliberately nil; piloting starts those).
- `GraphImportPlanner.reIdentify` preserves a resolved loop's verdict — finished work arrives finished instead of being re-run on a host nobody is watching — and keeps `heartbeatIntervalSeconds`, which it silently dropped.
- The CLI stops printing "N will resume their exported conversations" for a remote target, where `SessionTransplant.restore` deliberately installs nothing.

## Verification

- 1253 tests in 137 suites pass, including the new `GraphImportStartTests` (4 tests: unattended import starts + runs, resolved stays resolved and unstarted, turn-based stays idle for a human, planner preserves resolution + heartbeat).
- swiftlint 0 errors, swift-format strict clean.
- E2E after fix: import reports `running` immediately and the remote zmx session exists ~7s later (one ssh dial), instead of after the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBq4d5KckYx7RnkwkQPkau