### PR TITLE
feat: imported loops resume their conversations on remote hosts too

### DIFF
--- a/GraphcodeKit/Sources/GraphExportBundle.swift
+++ b/GraphcodeKit/Sources/GraphExportBundle.swift
@@ -108,23 +108,40 @@ extension GraphExportBundle {
 
   /// The full client half of an import: re-identify the snapshot here (so the fresh
   /// ids are known before anything is sent), install each carried session under its
-  /// loop's fresh id, and hand back the request the daemon should splice verbatim.
+  /// loop's fresh id, and hand back the request the daemon should splice verbatim —
+  /// plus how many of those sessions were actually installed, so the caller can say
+  /// "N will resume" and mean it.
   ///
   /// Session installation happens client-side on purpose: transcripts run to
   /// megabytes and belong on disk, not inside a socket frame — and every path they're
   /// written to (`~/.claude`, `~/.copilot`, `~/.graphcode/sessions`) is read fresh at
-  /// launch time, so there is no daemon-held copy to race.
+  /// launch time, so there is no daemon-held copy to race. A remote target gets the
+  /// same installation on *its* disk, delivered over the ssh dial
+  /// (`SessionTransplant.restoreRemote`) — which is why this is async, and why it must
+  /// finish before the import command is sent: the daemon ensures an imported loop's
+  /// session the moment it arrives, and the resume id has to already be banked on the
+  /// host by then.
   public func preparedImportRequest(
     asChildOf parent: UUID? = nil, projectPath: String
-  ) -> GraphImportRequest? {
+  ) async -> (request: GraphImportRequest, resumingSessions: Int)? {
     guard
       let (request, idMapping) = GraphImportPlanner.reIdentified(
         importRequest(asChildOf: parent))
     else { return nil }
+    let remote = RemoteProjectLocation.parse(projectPath: projectPath)
+    var resuming = 0
     for (oldID, artifact) in sessionsByNodeID {
       guard let newID = idMapping[oldID] else { continue }
-      SessionTransplant.restore(artifact, forNodeID: newID, projectPath: projectPath)
+      let installed: String?
+      if let remote {
+        installed = await SessionTransplant.restoreRemote(
+          artifact, forNodeID: newID, at: remote)
+      } else {
+        installed = SessionTransplant.restore(
+          artifact, forNodeID: newID, projectPath: projectPath)
+      }
+      if installed != nil { resuming += 1 }
     }
-    return request
+    return (request, resuming)
   }
 }

--- a/GraphcodeKit/Sources/Sessions/SessionTransplant.swift
+++ b/GraphcodeKit/Sources/Sessions/SessionTransplant.swift
@@ -103,17 +103,18 @@ public enum SessionTransplant {
   /// project would otherwise leave two loops banked against one conversation, both
   /// appending to it.
   ///
-  /// Returns the fresh session id, or nil when nothing was installed (remote target,
-  /// empty artifact, unwritable destination). Codex returns nil by design — its
-  /// rollout is installed for `codex`'s own history pickers, but nothing is banked
-  /// because nothing graphcode launches can resume it.
+  /// Returns the fresh session id, or nil when nothing was installed (remote target —
+  /// which `restoreRemote` handles instead — empty artifact, unwritable destination).
+  /// Codex returns nil by design — its rollout is installed for `codex`'s own history
+  /// pickers, but nothing is banked because nothing graphcode launches can resume it.
   @discardableResult
   public static func restore(
     _ artifact: Artifact, forNodeID nodeID: UUID, projectPath: String
   ) -> String? {
     guard !artifact.files.isEmpty else { return nil }
     // A remote project's sessions live on the remote machine; state written into this
-    // Mac's home directory would never be found there.
+    // Mac's home directory would never be found there. `restoreRemote` is the path
+    // that reaches that machine.
     guard RemoteProjectLocation.parse(projectPath: projectPath) == nil else { return nil }
 
     switch artifact.backend {
@@ -154,6 +155,117 @@ public enum SessionTransplant {
     }
     SessionIDStore.save(freshID, forNodeID: nodeID)
     return freshID
+  }
+
+  // MARK: - Remote restore
+
+  /// The remote twin of `restore`: installs the exported session on the host the
+  /// imported loop will actually run on, and banks the fresh id at the exact file the
+  /// daemon's ensure resume branch consumes (`PresenceHooks.remoteSessionIDExpression`)
+  /// — so the first ensure after import runs `--resume` against the delivered
+  /// transcript instead of starting fresh.
+  ///
+  /// Runs *before* the import command is sent, like the local restore: the node does
+  /// not exist in any graph yet, so no ensure can race a half-delivered transcript.
+  /// The transfer is one local pipeline — `tar` of the rewritten files piped into the
+  /// host's own untar over the ssh dial — because the transcript is arbitrary bytes at
+  /// transcript size: megabytes don't fit in an argv, and a PTY-backed runner would
+  /// mangle them in transit. The id file is written last, only after the untar
+  /// succeeded, so a delivery that died mid-transfer banks nothing and the loop falls
+  /// through to today's fresh start.
+  ///
+  /// Codex and OpenCode return nil for the same reasons they bank nothing locally.
+  @discardableResult
+  public static func restoreRemote(
+    _ artifact: Artifact, forNodeID nodeID: UUID, at location: RemoteProjectLocation
+  ) async -> String? {
+    guard !artifact.files.isEmpty else { return nil }
+    let freshID = UUID().uuidString.lowercased()
+    guard
+      let script = remoteInstallScript(
+        for: artifact, freshID: freshID, nodeID: nodeID, at: location)
+    else { return nil }
+    var staged: [String: Data] = [:]
+    switch artifact.backend {
+    case .claudeCode:
+      guard let transcript = artifact.files["transcript.jsonl"] else { return nil }
+      staged["\(freshID).jsonl"] =
+        rewriting(transcript, replacing: artifact.sessionID, with: freshID)
+    case .copilotCLI:
+      for (relativePath, data) in artifact.files {
+        staged[relativePath] = rewriting(data, replacing: artifact.sessionID, with: freshID)
+      }
+    case .codex, .openCode:
+      return nil
+    }
+    guard await deliver(files: staged, remoteScript: script, at: location) else { return nil }
+    return freshID
+  }
+
+  /// What the remote host runs while the tar stream arrives on its stdin: make the
+  /// destination, untar into it, then bank the fresh id. One script, ordered so the
+  /// bank write cannot precede the bytes it points at.
+  ///
+  /// Claude's destination is the slug of the session's *resolved* working directory,
+  /// and only the remote host can resolve its own paths (`/tmp` is `/private/tmp` on a
+  /// Mac and itself on Linux) — so the slug is computed there, with the same
+  /// every-non-alphanumeric-becomes-`-` rule `claudeProjectSlug` applies locally.
+  static func remoteInstallScript(
+    for artifact: Artifact, freshID: String, nodeID: UUID, at location: RemoteProjectLocation
+  ) -> String? {
+    let bank =
+      "printf %s '\(freshID)' > \"$HOME/.graphcode/sessions/\(nodeID.uuidString).id\""
+    switch artifact.backend {
+    case .claudeCode:
+      let repo = RemoteProjectLocation.shellQuoted(location.remotePath)
+      return "set -e; slug=$(cd \(repo) && printf %s \"$(pwd -P)\" "
+        + "| LC_ALL=C tr -c '[:alnum:]' '-'); "
+        + "dir=\"$HOME/.claude/projects/$slug\"; "
+        + "mkdir -p \"$dir\" \"$HOME/.graphcode/sessions\"; "
+        + "tar -xf - -C \"$dir\"; \(bank)"
+    case .copilotCLI:
+      return "set -e; dir=\"$HOME/.copilot/session-state/\(freshID)\"; "
+        + "mkdir -p \"$dir\" \"$HOME/.graphcode/sessions\"; "
+        + "tar -xf - -C \"$dir\"; \(bank)"
+    case .codex, .openCode:
+      return nil
+    }
+  }
+
+  /// Stages the files in a temporary directory and streams them to the host as one
+  /// `tar | ssh` pipeline. The pipeline's exit status is the ssh side's, which is the
+  /// remote script's — `set -e` there turns any failed step into a failed delivery.
+  private static func deliver(
+    files: [String: Data], remoteScript: String, at location: RemoteProjectLocation
+  ) async -> Bool {
+    let staging = FileManager.default.temporaryDirectory
+      .appendingPathComponent("graphcode-transplant-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: staging) }
+    for (relativePath, data) in files {
+      guard write(data, to: staging.appendingPathComponent(relativePath)) else { return false }
+    }
+    RemoteProjectLocation.prepareControlSocketDirectory()
+    let pipeline =
+      "tar -C \(RemoteProjectLocation.shellQuoted(staging.path)) -cf - . | "
+      + location.sshCommandLine(remoteCommand: remoteScript)
+    return await runShell(pipeline)
+  }
+
+  private static func runShell(_ script: String) async -> Bool {
+    await withCheckedContinuation { continuation in
+      let process = Process()
+      process.executableURL = URL(fileURLWithPath: "/bin/sh")
+      process.arguments = ["-c", script]
+      process.standardOutput = FileHandle.nullDevice
+      process.standardError = FileHandle.nullDevice
+      process.terminationHandler = { continuation.resume(returning: $0.terminationStatus == 0) }
+      do {
+        try process.run()
+      } catch {
+        process.terminationHandler = nil
+        continuation.resume(returning: false)
+      }
+    }
   }
 
   private static func restoreCodex(_ artifact: Artifact, projectPath: String) -> String? {

--- a/graphcode-cli/Sources/main.swift
+++ b/graphcode-cli/Sources/main.swift
@@ -403,10 +403,23 @@ do {
     // the request goes out; the daemon still performs the graph merge — it owns the
     // live graph, and a client that wrote the graph file itself had its import
     // clobbered by the daemon's next save. Same verdict pattern as `node send`: an
-    // error event means refused, the changed graph means it landed.
-    guard
-      let request = bundle.preparedImportRequest(asChildOf: asChildOf, projectPath: projectPath)
-    else { fail("the bundle contains no loops") }
+    // error event means refused, the changed graph means it landed. Async behind a
+    // semaphore, the `reap` pattern: a remote target's sessions are delivered over
+    // ssh, and the delivery has to finish before the daemon can ensure the loops.
+    final class PreparedBox: @unchecked Sendable {
+      var value: (request: GraphImportRequest, resumingSessions: Int)?
+    }
+    let box = PreparedBox()
+    let prepared = DispatchSemaphore(value: 0)
+    Task {
+      box.value = await bundle.preparedImportRequest(
+        asChildOf: asChildOf, projectPath: projectPath)
+      prepared.signal()
+    }
+    prepared.wait()
+    guard let (request, resumingSessions) = box.value else {
+      fail("the bundle contains no loops")
+    }
     try client.send(.openProject(path: projectPath))
     _ = try client.waitForEvent { if case .graphChanged = $0 { return true } else { return false } }
     try client.send(
@@ -419,17 +432,13 @@ do {
     }
     if case .errorOccurred(let message) = verdict { fail(message) }
     if case .graphChanged(let graph) = verdict {
-      // A remote target gets no transplants — the sessions live on the remote host, so
-      // `SessionTransplant.restore` skips them — and promising a resume there would be
-      // a lie the loop's fresh first pass immediately exposes.
-      let resumable =
-        RemoteProjectLocation.parse(projectPath: projectPath) == nil
-        ? bundle.sessionsByNodeID.values.filter { $0.backend.supportsResume } : []
+      // The count of sessions actually installed — on this machine or, for a remote
+      // target, delivered to the host over ssh — not of sessions the bundle carried.
       print(
         "imported \(bundle.graphSnapshot.nodes.count) loop(s) "
           + "and \(bundle.graphSnapshot.edges.count) edge(s) with fresh identities"
-          + (resumable.isEmpty
-            ? "" : "; \(resumable.count) will resume their exported conversations"))
+          + (resumingSessions == 0
+            ? "" : "; \(resumingSessions) will resume their exported conversations"))
       print(GraphcodeCommand.render(graph))
     }
   }

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -800,19 +800,24 @@ extension ProjectFeature {
     projectPath: String, asChildOf parentID: UUID?, into compositeID: UUID?
   ) -> Effect<Action> {
     .run { _ in
-      let request = await MainActor.run { () -> GraphImportRequest? in
+      let bundle = await MainActor.run { () -> GraphExportBundle? in
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [.zip]
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
         panel.message = "Choose a GraphCode export bundle"
         guard panel.runModal() == .OK, let url = panel.url else { return nil }
-        guard let bundle = GraphExportBundle.readFromZip(at: url.path) else { return nil }
-        // Re-identifies and installs any carried sessions under the fresh ids, so
-        // an imported loop resumes its exported conversation on first open.
-        return bundle.preparedImportRequest(asChildOf: parentID, projectPath: projectPath)
+        return GraphExportBundle.readFromZip(at: url.path)
       }
-      guard let request else { return }
+      // Re-identifies and installs any carried sessions under the fresh ids — on this
+      // machine, or delivered over ssh for a remote project — so an imported loop
+      // resumes its exported conversation. Off the main actor: a remote delivery is
+      // ssh round-trips, and the panel is long dismissed by now.
+      guard
+        let request = await bundle?.preparedImportRequest(
+          asChildOf: parentID, projectPath: projectPath
+        )?.request
+      else { return }
       let command = GraphCommand.importNodes(request)
       try? await orchestratorClient.send(
         .graphCommand(

--- a/graphcode/Tests/RemoteSessionTransplantTests.swift
+++ b/graphcode/Tests/RemoteSessionTransplantTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// What `SessionTransplant.restoreRemote` sends to the host an imported loop will run
+/// on. The local restore writes into this Mac's home directory, which a remote session
+/// never reads — so a remote import used to arrive with its transcript left behind and
+/// start fresh from the goal prompt. The remote install has to land two things on the
+/// host, in order: the id-rewritten session files where the backend looks for them, and
+/// the fresh id at the exact file the ensure's resume branch consumes
+/// (`PresenceHooks.remoteSessionIDExpression`).
+@Suite
+struct RemoteSessionTransplantTests {
+  private let location = RemoteProjectLocation(
+    user: "dev", host: "codespace", remotePath: "/workspaces/widget")
+  private let nodeID = UUID()
+
+  private func artifact(
+    _ backend: CLISessionBackendKind, files: [String: Data] = ["transcript.jsonl": Data("x".utf8)]
+  ) -> SessionTransplant.Artifact {
+    SessionTransplant.Artifact(
+      backend: backend, sessionID: "aaaa-bbbb",
+      sourceWorkingDirectory: "/Users/someone/src", files: files)
+  }
+
+  @Test
+  func claudeInstallLandsInTheHostsOwnSlugDirectory() throws {
+    let script = try #require(
+      SessionTransplant.remoteInstallScript(
+        for: artifact(.claudeCode), freshID: "fresh-id", nodeID: nodeID, at: location))
+
+    // The slug is computed on the host from its own resolved path — `/tmp` is
+    // `/private/tmp` on a Mac and itself on Linux, and only the host knows which.
+    #expect(script.contains("cd '/workspaces/widget'"))
+    #expect(script.contains("pwd -P"))
+    #expect(script.contains("tr -c '[:alnum:]' '-'"))
+    #expect(script.contains("$HOME/.claude/projects/$slug"))
+    #expect(script.contains("tar -xf -"))
+  }
+
+  @Test
+  func installBanksTheFreshIDWhereTheEnsureResumeBranchReads() throws {
+    let script = try #require(
+      SessionTransplant.remoteInstallScript(
+        for: artifact(.claudeCode), freshID: "fresh-id", nodeID: nodeID, at: location))
+
+    // Written last — `set -e` plus ordering means a failed transfer banks nothing and
+    // the ensure falls through to today's fresh start.
+    let bank = try #require(script.range(of: ".graphcode/sessions/\(nodeID.uuidString).id"))
+    let untar = try #require(script.range(of: "tar -xf -"))
+    #expect(script.hasPrefix("set -e;"))
+    #expect(untar.lowerBound < bank.lowerBound)
+    #expect(script.contains("printf %s 'fresh-id'"))
+  }
+
+  @Test
+  func copilotInstallTargetsItsSessionStateDirectory() throws {
+    let script = try #require(
+      SessionTransplant.remoteInstallScript(
+        for: artifact(.copilotCLI, files: ["state.json": Data("{}".utf8)]),
+        freshID: "fresh-id", nodeID: nodeID, at: location))
+
+    #expect(script.contains("$HOME/.copilot/session-state/fresh-id"))
+    #expect(script.contains(".graphcode/sessions/\(nodeID.uuidString).id"))
+  }
+
+  @Test
+  func backendsThatCannotResumeGetNoRemoteInstall() {
+    #expect(
+      SessionTransplant.remoteInstallScript(
+        for: artifact(.codex), freshID: "f", nodeID: nodeID, at: location) == nil)
+    #expect(
+      SessionTransplant.remoteInstallScript(
+        for: artifact(.openCode), freshID: "f", nodeID: nodeID, at: location) == nil)
+  }
+
+  @Test
+  func bankPathMatchesWhatTheEnsureConsumes() throws {
+    // The writer here and the reader in `remoteCreateScript` must name the same file;
+    // drifting apart would not fail loudly — every remote import would just silently
+    // start fresh, the exact bug this path exists to end.
+    let script = try #require(
+      SessionTransplant.remoteInstallScript(
+        for: artifact(.claudeCode), freshID: "fresh-id", nodeID: nodeID, at: location))
+    let consumed = PresenceHooks.remoteSessionIDExpression(forNodeID: nodeID)
+      .replacingOccurrences(of: "\"", with: "")
+    let written = try #require(
+      script.split(separator: ";").last.map(String.init)?
+        .split(separator: ">").last.map { $0.trimmingCharacters(in: .whitespaces) }
+    ).replacingOccurrences(of: "\"", with: "")
+    #expect(written == consumed)
+  }
+}


### PR DESCRIPTION
## Problem

Import carried each loop's backend conversation in the bundle, but `SessionTransplant.restore` deliberately skipped remote targets — the files would land in this Mac's home directory, which a remote session never reads. So importing into an `ssh://` or Codespace project dropped the conversation and every loop started fresh from its goal prompt.

## Fix

- **`SessionTransplant.restoreRemote`** delivers the id-rewritten session to the host the loop will run on, as one `tar | ssh` pipeline (transcripts are megabytes of arbitrary bytes — they fit neither in an argv nor through a PTY-backed runner).
  - Claude: destination slug computed **on the host** from its own resolved working directory (`/tmp` is `/private/tmp` on a Mac, itself on Linux), transcript installed as `<freshID>.jsonl` with the id rewritten throughout.
  - Copilot: the session-state directory transplants under the fresh id.
  - The fresh id is banked **last**, at the exact file the ensure's resume branch consumes (`PresenceHooks.remoteSessionIDExpression`) — a delivery that dies mid-transfer banks nothing and falls through to today's fresh start.
- **`preparedImportRequest`** is async (ssh round-trips, finished before the import command is sent — the daemon ensures imported loops immediately, and the id must already be banked by then) and returns how many sessions actually installed, so the CLI's "N will resume their exported conversations" is a count of installations, not of hopes.
- App import moves the transplant work off the main actor; the open panel is long dismissed by then.

## Verification

- 1258 tests in 138 suites pass (+5: new `RemoteSessionTransplantTests`, including a writer/reader invariant test that the bank path matches what `remoteCreateScript` consumes).
- swiftlint 0 errors, swift-format strict clean.
- E2E against a loopback sshd with an isolated `$HOME`: transcript landed at `~/.claude/projects/-private-tmp-gct-rhome-repo/<freshID>.jsonl` on the "remote", codeword content intact, id file consumed, and the dial log shows `ensure resume` 3s after import — the imported loop resumed the exported conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBq4d5KckYx7RnkwkQPkau