### PR TITLE
fix: drop degenerate surface resizes; log zmx daemonLoop errors

### DIFF
--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalNSView.swift
@@ -189,8 +189,18 @@ final class GhosttyTerminalNSView: NSView {
   ///
   /// One implementation for both callers on purpose: the size and the scale are two halves
   /// of the same fact, and the bug this fixes was them being updated in different places.
+  ///
+  /// Degenerate sizes are dropped rather than forwarded: SwiftUI lays a remounting view
+  /// out at a near-zero frame before the real one arrives, and pushing that through
+  /// libghostty resizes the session's PTY to a 1×1 grid. Reflowing to one column erases
+  /// the alternate screen — there is no scrollback to reflow from — so a full-screen TUI
+  /// (opencode) that diffs against its own last frame comes back to a black pane the
+  /// moment the real size lands, because to the TUI nothing changed. The session logs
+  /// show these `resize rows=1 cols=1` blips at exactly the switch-back moments.
+  /// 32pt can't fit a legible terminal, so nothing real is ever suppressed.
   private func syncSurfaceSize() {
     guard let surface else { return }
+    guard bounds.width >= 32, bounds.height >= 32 else { return }
     let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0
     ghostty_surface_set_size(
       surface, UInt32(bounds.width * scale), UInt32(bounds.height * scale))


### PR DESCRIPTION
## Summary
Two fixes from the 2026-08-28 session-death / opencode-black-screen investigation:

- **Resize guard** — `GhosttyTerminalNSView.syncSurfaceSize` no longer forwards near-zero layout sizes to libghostty. SwiftUI lays a remounting pane out at a degenerate frame before the real one, which resized the session PTY to a 1×1 grid and erased the alternate screen; a diff-painting TUI (opencode) then came back black because to it nothing had changed. Session logs show `resize rows=1 cols=1` blips at exactly the switch-back moments.
- **zmx daemonLoop error logging** — submodule bumped to scgopi/zmx@929263d. The daemon's shutdown defer prints "kill received" on every death, so an errored `daemonLoop` was indistinguishable from a killed session; three loop sessions died undiagnosably on 2026-08-28. Errors now log their name before propagating.

## Test plan
- [x] Build succeeds from worktree
- [x] 1258 tests / 138 suites pass
- [x] swiftlint 0 errors, swift format clean
- [x] Patched zmx builds (ReleaseFast) and passes create/list/kill smoke test
- [ ] Manual: switch between loops with an opencode loop open and confirm no black pane on return

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1WN1qAjvJDHV1iZvmYBrS