### PR TITLE
Fix Codex and OpenCode time loops

### DIFF
--- a/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
+++ b/GraphcodeKit/Sources/CLI/GraphcodeCommand.swift
@@ -416,7 +416,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
 
     var heartbeat: Double?
     if let raw = flags["heartbeat"] {
-      guard let value = Double(raw), value > 0 else {
+      guard let value = Double(raw), value.isFinite, value > 0 else {
         throw ParseError.invalidValue(argument: "--heartbeat", value: raw)
       }
       heartbeat = value
@@ -498,7 +498,7 @@ public enum GraphcodeCommand: Equatable, Sendable {
     }
     var heartbeat: Double?
     if let raw = flags["heartbeat"] {
-      guard let value = Double(raw) else {
+      guard let value = Double(raw), value.isFinite else {
         throw ParseError.invalidValue(argument: "--heartbeat", value: raw)
       }
       heartbeat = value

--- a/GraphcodeKit/Sources/Domain/BackendCapabilities.swift
+++ b/GraphcodeKit/Sources/Domain/BackendCapabilities.swift
@@ -25,13 +25,10 @@ public struct BackendCapabilities: Codable, Equatable, Sendable {
   /// Can the *session itself* re-trigger its own work on a cadence — Claude Code's
   /// `/loop` and `/schedule`?
   ///
-  /// This is what a time-based loop is actually built on: graphcode holds no interval of
-  /// its own and deliberately never inspects the prompt (`LoopNode.triggerPrompt`), so
-  /// the recurrence has to live inside the agent. A backend without it can still be
-  /// handed a `/loop …` prompt — it will simply do the work once and stop, which looks
-  /// like a broken schedule rather than an unsupported one. Hence its own capability
-  /// rather than being inferred from something adjacent.
+  /// A time-based loop may instead use graphcode's daemon cadence, represented by
+  /// `supportsDaemonRecurrence`. A backend with neither capability cannot host one.
   public var supportsInSessionRecurrence: Bool
+  public var supportsDaemonRecurrence: Bool
 
   public init(
     supportsGoalMode: Bool = false,
@@ -40,7 +37,8 @@ public struct BackendCapabilities: Codable, Equatable, Sendable {
     supportsSubAgents: Bool = false,
     supportsMCP: Bool = false,
     supportsMidSessionInput: Bool = false,
-    supportsInSessionRecurrence: Bool = false
+    supportsInSessionRecurrence: Bool = false,
+    supportsDaemonRecurrence: Bool = false
   ) {
     self.supportsGoalMode = supportsGoalMode
     self.supportsHooks = supportsHooks
@@ -49,6 +47,7 @@ public struct BackendCapabilities: Codable, Equatable, Sendable {
     self.supportsMCP = supportsMCP
     self.supportsMidSessionInput = supportsMidSessionInput
     self.supportsInSessionRecurrence = supportsInSessionRecurrence
+    self.supportsDaemonRecurrence = supportsDaemonRecurrence
   }
 }
 
@@ -126,9 +125,8 @@ extension CLISessionBackendKind {
       // some form (`--dangerously-bypass-hook-trust` implies a trust store for them), but
       // nothing in its help describes a lifecycle hook that could report presence the way
       // Claude Code's do, so presence stays heuristic. Sub-agent fan-out and a
-      // `/loop`-equivalent aren't visible in the CLI surface at all; if either exists it
-      // will be inside the TUI, and a capability claimed on a hunch is exactly what
-      // `isSpiked` exists to prevent.
+      // `/loop` equivalent aren't visible in the CLI surface, so recurrence is provided
+      // by graphcode's daemon rather than claimed as an in-session feature.
       return BackendCapabilities(
         supportsGoalMode: true,
         supportsHooks: false,
@@ -136,7 +134,8 @@ extension CLISessionBackendKind {
         supportsSubAgents: false,
         supportsMCP: true,
         supportsMidSessionInput: true,
-        supportsInSessionRecurrence: false)
+        supportsInSessionRecurrence: false,
+        supportsDaemonRecurrence: true)
 
     case .openCode:
       // Spiked against OpenCode 1.18.21 — every entry read off `opencode --help` and its
@@ -156,7 +155,7 @@ extension CLISessionBackendKind {
       // source, not assumed (`PresenceHooks.openCodePlugin`).
       //
       // Sub-agents exist inside the TUI (`@agent` mentions) but not as anything a
-      // composite could lean on from outside, and there is no `/loop` equivalent.
+      // composite could lean on from outside. Recurrence is provided by graphcode's daemon.
       return BackendCapabilities(
         supportsGoalMode: true,
         supportsHooks: true,
@@ -164,7 +163,8 @@ extension CLISessionBackendKind {
         supportsSubAgents: false,
         supportsMCP: true,
         supportsMidSessionInput: true,
-        supportsInSessionRecurrence: false)
+        supportsInSessionRecurrence: false,
+        supportsDaemonRecurrence: true)
     }
   }
 
@@ -201,7 +201,7 @@ extension CLISessionBackendKind {
       // The cadence lives inside the session, so this needs a backend whose agent can
       // re-trigger its own work. Without that a `/loop …` prompt runs once and stops,
       // which reads as a broken schedule rather than an unsupported one.
-      return capabilities.supportsInSessionRecurrence
+      return capabilities.supportsInSessionRecurrence || capabilities.supportsDaemonRecurrence
     case .composite:
       return capabilities.supportsSubAgents
     }

--- a/GraphcodeKit/Sources/Domain/BackendCommand.swift
+++ b/GraphcodeKit/Sources/Domain/BackendCommand.swift
@@ -80,11 +80,14 @@ extension CLISessionBackendKind {
   public func launchArguments(
     prompt: String?, tier: ModelTier, briefingPath: String? = nil,
     settings: GraphcodeSettings = GraphcodeSettings(), workspacePaths: [String] = [],
-    hooksFile: URL? = nil, sessionName: String? = nil, zmxPath: String? = nil
+    hooksFile: URL? = nil, sessionName: String? = nil, zmxPath: String? = nil,
+    sessionsDirectory: String? = nil
   ) -> [String] {
     let model =
       modelArguments(for: tier) + permissionArguments(settings)
-      + presenceArguments(hooksFile: hooksFile, sessionName: sessionName, zmxPath: zmxPath)
+      + presenceArguments(
+        hooksFile: hooksFile, sessionName: sessionName, zmxPath: zmxPath,
+        sessionsDirectory: sessionsDirectory)
     guard let prompt, !prompt.isEmpty else { return model }
     let briefingDirectory = (briefingPath as NSString?)?.deletingLastPathComponent
     switch self {
@@ -198,17 +201,16 @@ extension CLISessionBackendKind {
   /// (`GhosttyTerminalView.resumeCommand`) — so a backend gaining or losing resume
   /// support changes both paths together rather than one silently drifting.
   public var supportsResume: Bool {
-    self == .claudeCode || self == .copilotCLI || self == .openCode
+    self == .claudeCode || self == .copilotCLI || self == .codex || self == .openCode
   }
 
-  /// The argv that picks `sessionID` back up — `--resume` for Claude Code and Copilot,
-  /// `--session` for OpenCode, whose `--continue` would take the *last* session on the
-  /// machine rather than this loop's. Empty for a backend that can't resume.
+  /// The argv that picks `sessionID` back up. OpenCode's `--session` and Codex's
+  /// `resume <id>` both name the exact conversation rather than selecting the last one.
   public func resumeArguments(sessionID: String) -> [String] {
     switch self {
     case .claudeCode, .copilotCLI: return ["--resume", sessionID]
+    case .codex: return ["resume", sessionID]
     case .openCode: return ["--session", sessionID]
-    case .codex: return []
     }
   }
 
@@ -247,7 +249,8 @@ extension CLISessionBackendKind {
   /// Empty when the handle isn't available, which leaves presence at the heuristic: what
   /// every session did before any of this existed.
   public func presenceArguments(
-    hooksFile: URL?, sessionName: String? = nil, zmxPath: String? = nil
+    hooksFile: URL?, sessionName: String? = nil, zmxPath: String? = nil,
+    sessionsDirectory: String? = nil
   ) -> [String] {
     switch self {
     case .claudeCode:
@@ -259,7 +262,13 @@ extension CLISessionBackendKind {
       // it — just somewhere to write, which is why this is the one backend that takes the
       // `zmx` path rather than a path to something graphcode wrote. Its other edge is
       // covered without asking Codex anything: see `ZmxSessionLauncher.codexPresence`.
-      return zmxPath.map { ["-c", PresenceHooks.codexNotifyOverride(zmxPath: $0)] } ?? []
+      return zmxPath.map {
+        [
+          "-c",
+          PresenceHooks.codexNotifyOverride(
+            zmxPath: $0, sessionsDirectory: sessionsDirectory),
+        ]
+      } ?? []
     case .openCode:
       // Reports through a plugin, which rides in the environment rather than the argv —
       // see `presenceEnvironment`.

--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -217,15 +217,27 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
       // first-pass workaround raced the composer. The reliable channel is the opening
       // prompt itself, so for Copilot it carries both halves as prose: run the task
       // now, then arm your own `/every`. The session still owns the cadence; graphcode
-      // holds no timer. Other backends keep the directive verbatim — Claude Code's
-      // `/loop` runs its first iteration itself.
+      // holds no timer. Claude Code keeps the directive verbatim — its `/loop` runs the
+      // first iteration itself.
       if backend == .copilotCLI, heartbeatIntervalSeconds == nil, let prompt = triggerPrompt,
         let recurrence = SessionPrompt.recurrence(of: prompt)
       {
         return "Run this task now: \(recurrence.task) Then schedule it to repeat with: "
           + "/every \(recurrence.interval) \(recurrence.task)"
       }
-      guard let interval = heartbeatIntervalSeconds, interval > 0, let task = triggerPrompt
+      if backend.capabilities.supportsDaemonRecurrence,
+        let interval = effectiveHeartbeatInterval,
+        interval.isFinite,
+        interval > 0
+      {
+        let task = heartbeatTask ?? ""
+        return "Run one pass of this task now: \(task) Then stay in the session — every "
+          + "\(Int(interval))s you will receive a [graphcode] heartbeat message, and each "
+          + "one is your cue to run the next pass. Do not schedule your own /loop, wakeup, "
+          + "or cron for it — the orchestrator holds the timer."
+      }
+      guard let interval = heartbeatIntervalSeconds, interval.isFinite, interval > 0,
+        let task = triggerPrompt
       else { return triggerPrompt }
       // The heartbeat counterpart of the /loop directive: the session is told who
       // holds the timer, so it neither schedules its own cadence (double-driving)
@@ -241,6 +253,20 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
         beforeWritesOnly: pausesBeforeWritesOnly)
     case .composite: return nil
     }
+  }
+
+  public var effectiveHeartbeatInterval: Double? {
+    if let interval = heartbeatIntervalSeconds, interval.isFinite, interval > 0 {
+      return interval
+    }
+    guard backend.capabilities.supportsDaemonRecurrence, loopType == .timeBased,
+      let prompt = triggerPrompt, let recurrence = SessionPrompt.recurrence(of: prompt)
+    else { return nil }
+    return SessionPrompt.intervalSeconds(recurrence.interval)
+  }
+
+  public var heartbeatTask: String? {
+    triggerPrompt.map { SessionPrompt.firstPass(of: $0) ?? $0 }
   }
 
   /// What a turn-based session opens with: work in turns, stop for review, and here is

--- a/GraphcodeKit/Sources/Domain/NodeDraft.swift
+++ b/GraphcodeKit/Sources/Domain/NodeDraft.swift
@@ -134,7 +134,19 @@ public struct NodeDraft: Codable, Equatable, Sendable {
     case .goalBased:
       return !(goal?.summary ?? "").trimmingCharacters(in: .whitespaces).isEmpty
     case .timeBased:
-      return !(triggerPrompt ?? "").trimmingCharacters(in: .whitespaces).isEmpty
+      let prompt = (triggerPrompt ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !prompt.isEmpty else { return false }
+      if let heartbeatIntervalSeconds,
+        !heartbeatIntervalSeconds.isFinite || heartbeatIntervalSeconds <= 0
+      {
+        return false
+      }
+      let capabilities = effectiveBackend.capabilities
+      guard capabilities.supportsDaemonRecurrence && !capabilities.supportsInSessionRecurrence
+      else { return true }
+      if heartbeatIntervalSeconds != nil { return true }
+      guard let recurrence = SessionPrompt.recurrence(of: prompt) else { return false }
+      return SessionPrompt.intervalSeconds(recurrence.interval) != nil
     case .composite:
       // Its *contents* are still not required — a composite is built by editing its
       // sub-graph after creation, and demanding a populated one at creation time would

--- a/GraphcodeKit/Sources/Domain/SessionBriefing.swift
+++ b/GraphcodeKit/Sources/Domain/SessionBriefing.swift
@@ -60,8 +60,8 @@ public enum SessionBriefing {
         "every hour", "keep checking", "each morning". Also starts immediately.
         **The daemon drives it**: a heartbeat is typed into the session each interval, and
         the prompt is the bare task — no `/loop`, no cron, no self-scheduling. Only when
-        the loop must own its own cadence (self-pacing, a complex schedule), omit
-        `--heartbeat` and write the directive into the prompt (`/loop 1h …`) instead.
+        the loop must own its own cadence (self-pacing, a complex schedule), use a backend
+        with in-session recurrence and omit `--heartbeat`.
         Do not reach for this for one-off work: "check the build" is a goal, "check the
         build every hour" is time-based.
       """
@@ -70,8 +70,10 @@ public enum SessionBriefing {
         finishes because it repeats: watching, polling, monitoring, anything phrased as
         "every hour", "keep checking", "each morning". Also starts immediately.
         **The cadence goes inside the prompt**, as a directive the session runs on itself
-        (`/loop 1h Check for new reports`, `/schedule …`) — graphcode holds no timer of its
-        own, so a time-based loop whose prompt carries no cadence just runs once and stops.
+        (`/loop 1h Check for new reports`, `/schedule …`). Codex and OpenCode cannot own
+        that schedule: for them, use `--heartbeat <seconds>` with a bare task, or a leading
+        `/loop` or `/every` with a simple `s`, `m`, `h`, or `d` interval that graphcode can
+        convert into daemon recurrence.
         Do not reach for this for one-off work: "check the build" is a goal, "check the
         build every hour" is time-based.
       """

--- a/GraphcodeKit/Sources/Domain/SessionPrompt.swift
+++ b/GraphcodeKit/Sources/Domain/SessionPrompt.swift
@@ -9,10 +9,9 @@ import Foundation
 /// in front is what a preamble usually means, and for prose it is right.
 ///
 /// It is wrong for exactly one prompt shape, and that shape is a whole loop type. A
-/// time-based node's prompt *is* a slash command — `/loop 1h …`, the directive that makes
-/// the session re-trigger itself, since graphcode holds no timer of its own
-/// (`ZmxSessionLauncher`). Buried mid-message it is literal text: no schedule is created,
-/// the loop runs exactly one pass and sits `idle` forever. Copilot hosts time-based loops
+/// time-based node whose session owns recurrence has a slash-command prompt — `/loop 1h
+/// …`. Buried mid-message it is literal text: no schedule is created, the loop runs
+/// exactly one pass and sits `idle` forever. Copilot hosts this form of time-based loop
 /// and receives its briefing as a preamble, so it got both halves of that and never armed
 /// recurrence at all (issue #179).
 ///
@@ -65,6 +64,20 @@ public enum SessionPrompt {
       return (String(interval), task)
     }
     return nil
+  }
+
+  public static func intervalSeconds(_ interval: String) -> Double? {
+    let trimmed = interval.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !trimmed.isEmpty else { return nil }
+    let number =
+      trimmed.last.map { "smhd".contains($0) ? String(trimmed.dropLast()) : trimmed } ?? trimmed
+    guard let value = Double(number), value.isFinite, value > 0 else { return nil }
+    switch trimmed.last {
+    case "s": return value
+    case "h": return value * 3600
+    case "d": return value * 86400
+    default: return value * 60
+    }
   }
 
   /// Whether the prompt involves a recurring directive at all — leading or mentioned —

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -290,6 +290,7 @@ public actor GraphStore {
       // The experiment's gate: a heartbeat loop created while the toggle is off would
       // sit silent looking broken, and refusal-with-a-pointer is the export precedent.
       if let interval = draft.heartbeatIntervalSeconds, interval > 0,
+        !draft.effectiveBackend.capabilities.supportsDaemonRecurrence,
         onHeartbeatEnabled?() != true
       {
         announceError(
@@ -946,10 +947,17 @@ public actor GraphStore {
         sessionFacing.append("prompt is now: \(trimmed)")
       }
       if let interval = update.heartbeatIntervalSeconds {
+        guard interval.isFinite else {
+          announceError("update refused: a heartbeat interval must be finite")
+          return
+        }
         // Setting an interval needs the experiment on; *clearing* one never does —
         // turning the toggle off must not strand a loop with a cadence nobody can
         // remove.
-        if interval > 0, onHeartbeatEnabled?() != true {
+        if interval > 0,
+          !node.backend.capabilities.supportsDaemonRecurrence,
+          onHeartbeatEnabled?() != true
+        {
           announceError(
             "update refused: heartbeats need the Daemon heartbeat experiment enabled "
               + "in Settings")
@@ -969,6 +977,16 @@ public actor GraphStore {
 
     case .sketch, .composite:
       break
+    }
+
+    let capabilities = node.backend.capabilities
+    if node.loopType == .timeBased, capabilities.supportsDaemonRecurrence,
+      !capabilities.supportsInSessionRecurrence, node.effectiveHeartbeatInterval == nil
+    {
+      announceError(
+        "update refused: \(node.backend.displayName) needs a positive heartbeat or a "
+          + "leading /loop or /every directive with a parseable interval")
+      return
     }
 
     if let tier = update.modelTier {
@@ -1075,7 +1093,20 @@ public actor GraphStore {
       }
       node.loopType = .timeBased
       node.triggerPrompt = trimmed
-      nudge = "You are now a time-based loop. Adopt this cadence by running it now: \(trimmed)"
+      let capabilities = node.backend.capabilities
+      if capabilities.supportsDaemonRecurrence && !capabilities.supportsInSessionRecurrence {
+        guard node.effectiveHeartbeatInterval != nil else {
+          announceError(
+            "promotion refused: \(node.backend.displayName) needs a leading /loop or "
+              + "/every directive with a parseable interval")
+          return
+        }
+        nudge =
+          "You are now a time-based loop. The daemon owns your cadence; run one pass now: "
+          + "\(node.heartbeatTask ?? trimmed)"
+      } else {
+        nudge = "You are now a time-based loop. Adopt this cadence by running it now: \(trimmed)"
+      }
     }
 
     graph.nodes[id: nodeID] = node
@@ -1099,6 +1130,7 @@ public actor GraphStore {
       cancelGoalPoller(nodeID)
       armGoalPoller(for: node)
     }
+    if node.loopType == .timeBased { armHeartbeat(for: node) }
   }
 
   /// A learned note into a node's memory log — `graphcode node memo`, the agent-written
@@ -2126,7 +2158,7 @@ public actor GraphStore {
   /// the session on every beat, so the timer itself holds no authority anything else
   /// would need revoking.
   private func armHeartbeat(for node: LoopNode) {
-    guard node.loopType == .timeBased, let interval = node.heartbeatIntervalSeconds,
+    guard node.loopType == .timeBased, let interval = node.effectiveHeartbeatInterval,
       interval > 0, onDeliverMessage != nil
     else { return }
     heartbeatTimers[node.id]?.cancel()
@@ -2153,13 +2185,14 @@ public actor GraphStore {
   /// was the double-driving this experiment must not reintroduce. Skips are silent; a
   /// heartbeat that logged every beat would turn the memory log into a metronome.
   public func deliverHeartbeat(_ nodeID: UUID) async {
-    guard onHeartbeatEnabled?() == true else { return }
     guard let node = graph.nodes[id: nodeID], node.loopType == .timeBased, !node.isResolved,
-      let interval = node.heartbeatIntervalSeconds, interval > 0
+      let interval = node.effectiveHeartbeatInterval, interval > 0
     else {
       cancelHeartbeat(nodeID)
       return
     }
+    guard node.backend.capabilities.supportsDaemonRecurrence || onHeartbeatEnabled?() == true
+    else { return }
     guard MessageBus.deliverability(to: node) == nil else { return }
     let presence: Presence?
     if let onReadPresence {
@@ -2168,7 +2201,7 @@ public actor GraphStore {
       presence = node.presence?.presence
     }
     guard presence != .busy else { return }
-    let task = node.triggerPrompt ?? ""
+    let task = node.heartbeatTask ?? ""
     _ = await deliverToSession(
       node, "[graphcode] Heartbeat — run one pass of your task now: \(task)")
   }

--- a/GraphcodeKit/Sources/Sessions/OpenCodePresencePlugin.swift
+++ b/GraphcodeKit/Sources/Sessions/OpenCodePresencePlugin.swift
@@ -27,8 +27,18 @@ import Foundation
 /// arrives with a `parentID` — which is why every reading is filtered to the session the
 /// loop itself opened, exactly as `SubagentStop` is left out of Claude Code's hooks.
 enum OpenCodePresencePlugin {
+  static func remoteSource(zmxPath: String) -> String {
+    source(
+      zmxPath: zmxPath,
+      sessionsDirectoryExpression: #"join(process.env.HOME ?? "", ".graphcode", "sessions")"#)
+  }
+
   /// The plugin source, with the paths only this machine can know baked in.
   static func source(zmxPath: String, sessionsDirectory: String) -> String {
+    source(zmxPath: zmxPath, sessionsDirectoryExpression: jsString(sessionsDirectory))
+  }
+
+  private static func source(zmxPath: String, sessionsDirectoryExpression: String) -> String {
     """
     // Written by graphcode. Reports what this session is doing, for its card in the graph.
     import { spawnSync } from "node:child_process"
@@ -36,7 +46,7 @@ enum OpenCodePresencePlugin {
     import { join } from "node:path"
 
     const ZMX = \(jsString(zmxPath))
-    const SESSIONS = \(jsString(sessionsDirectory))
+    const SESSIONS = \(sessionsDirectoryExpression)
     const PREFIX = \(jsString(SurfaceRef.zmxSessionPrefix))
 
     export const GraphcodePresence = async ({ directory }) => {

--- a/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
+++ b/GraphcodeKit/Sources/Sessions/PresenceHooks.swift
@@ -286,6 +286,10 @@ public enum PresenceHooks {
 
   public static let remoteUsageScriptExpression = "\"$HOME/.graphcode/hooks/usage.sh\""
 
+  public static let remoteOpenCodeConfigPath = "$HOME/.graphcode/hooks/openCode.json"
+  public static let remoteOpenCodePluginExpression =
+    "\"$HOME/.graphcode/hooks/opencode-presence.js\""
+
   /// The remote twin of `SessionIDStore.file(forNodeID:)` — the file the remote
   /// `SessionStart` hook wrote, as a shell expression the ensure dial can `cat`.
   ///
@@ -304,10 +308,11 @@ public enum PresenceHooks {
   public static func json(
     forBackend backend: CLISessionBackendKind, zmxPath: String,
     sessionsDirectory: String? = nil, activityScriptPath: String? = nil,
-    usageScriptPath: String? = nil
+    usageScriptPath: String? = nil, openCodePluginPath: String? = nil
   ) -> String? {
     if backend == .openCode {
-      return OpenCodePresencePlugin.config(pluginPath: openCodePluginFile.path)
+      return OpenCodePresencePlugin.config(
+        pluginPath: openCodePluginPath ?? openCodePluginFile.path)
     }
     guard let events = events(forBackend: backend) else { return nil }
     let sessions = sessionsDirectory ?? localSessionsExpression
@@ -393,7 +398,21 @@ public enum PresenceHooks {
   /// launch still passes `--settings`; if the file has never once been written the
   /// launch fails visibly in the loop's own terminal, which beats silently running an
   /// unobservable session.
-  public static func remoteWriteFragment() -> String? {
+  public static func remoteWriteFragment(
+    forBackend backend: CLISessionBackendKind = .claudeCode
+  ) -> String? {
+    if backend == .openCode {
+      let source = OpenCodePresencePlugin.remoteSource(zmxPath: "zmx")
+      let configPrefix = "{\"plugin\":[\""
+      let configSuffix = "/.graphcode/hooks/opencode-presence.js\"]}"
+      return "{ mkdir -p \"$HOME/.graphcode/hooks\""
+        + " && printf '%s' \(singleQuoted(source))"
+        + " > \(remoteOpenCodePluginExpression)"
+        + " && printf '%s%s%s' \(singleQuoted(configPrefix)) \"$HOME\""
+        + " \(singleQuoted(configSuffix)) > \"\(remoteOpenCodeConfigPath)\"; }"
+        + " 2>/dev/null || true"
+    }
+    guard backend == .claudeCode else { return nil }
     guard
       let json = json(
         forBackend: .claudeCode, zmxPath: "zmx",
@@ -429,10 +448,20 @@ public enum PresenceHooks {
   /// invented field outright ("unknown configuration field") and accepts this one.
   ///
   /// The value is TOML, parsed by Codex out of one argv element. Codex appends its event
-  /// JSON as a further argument, which `sh -c` puts in `$0` and this ignores.
-  public static func codexNotifyOverride(zmxPath: String) -> String {
+  /// JSON as a further argument, which `sh -c` puts in `$0`; its thread ID is persisted
+  /// under the node ID so only that node can resume it after the zmx session disappears.
+  public static func codexNotifyOverride(
+    zmxPath: String, sessionsDirectory: String? = nil
+  ) -> String {
+    let sessions = sessionsDirectory ?? localSessionsExpression
     let script =
-      "\(singleQuoted(zmxPath)) set \"$ZMX_SESSION\" presence=idle >/dev/null 2>&1; exit 0"
+      "i=$(printf '%s' \"$0\"|sed -n "
+      + "'s/.*\"thread-id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p'); "
+      + "n=\"${ZMX_SESSION#\(SurfaceRef.zmxSessionPrefix)}\"; d=\(sessions); "
+      + "if [ -n \"$i\" ]&&[ \"$n\" != \"$ZMX_SESSION\" ];then mkdir -p \"$d\"; "
+      + "printf '%s %s %s\\n' \"$(date +%s)\" \"$i\" \"$PWD\" "
+      + ">>\"$d/$n.history\" 2>/dev/null; printf %s \"$i\">\"$d/$n.id\"; fi; "
+      + "\(singleQuoted(zmxPath)) set \"$ZMX_SESSION\" presence=idle >/dev/null 2>&1; exit 0"
     return "notify=[\"/bin/sh\",\"-c\",\(tomlString(script))]"
   }
 

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -609,11 +609,13 @@ public enum ZmxSessionLauncher {
     // by the ensure script (`remoteEnsureInvocation`) and referenced as a `$HOME` path
     // only the remote shell can mint, via `scriptSuffix` below.
     let hooksFile = remote == nil ? PresenceHooks.write(forBackend: node.backend) : nil
-    // Codex needs no file, only somewhere to report to. Nil for a remote session for the
-    // same reason: it would name a binary at this machine's path on a host that has its
-    // own.
     let reportingPath =
-      remote == nil && ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil
+      remote != nil ? "zmx" : (ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil)
+    let sessionsDirectory =
+      remote != nil ? PresenceHooks.remoteSessionsExpression : nil
+    let remoteEnvironmentPath =
+      remote != nil && node.backend == .openCode
+      ? PresenceHooks.remoteOpenCodeConfigPath : nil
     let remoteHooksSuffix =
       remote != nil && node.backend == .claudeCode
       ? " --settings \"\(PresenceHooks.remotePathExpression)\"" : ""
@@ -623,7 +625,8 @@ public enum ZmxSessionLauncher {
       workspacePaths: paths,
       hooksFile: hooksFile,
       sessionName: SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName,
-      zmxPath: reportingPath)
+      zmxPath: reportingPath,
+      sessionsDirectory: sessionsDirectory)
     let command =
       [
         "run", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName, "-d",
@@ -631,7 +634,8 @@ public enum ZmxSessionLauncher {
       + Self.loginShellInvocation(
         of: executable, arguments: arguments,
         environment: Self.environment(
-          forBackend: node.backend, briefingPath: briefingPath, hooksFile: hooksFile),
+          forBackend: node.backend, briefingPath: briefingPath, hooksFile: hooksFile,
+          remoteHooksPath: remoteEnvironmentPath),
         scriptSuffix: remoteHooksSuffix)
 
     // `zmx` types this command into the session's shell, and a tty in canonical mode
@@ -651,13 +655,18 @@ public enum ZmxSessionLauncher {
         workspacePaths: Self.workspacePaths(forNode: node, projectPath: projectPath),
         hooksFile: hooksFile,
         sessionName: SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName,
-        zmxPath: reportingPath)
+        zmxPath: reportingPath,
+        sessionsDirectory: sessionsDirectory)
       let unbriefedCommand =
         [
           "run", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName, "-d",
         ]
         + Self.loginShellInvocation(
-          of: executable, arguments: unbriefed, scriptSuffix: remoteHooksSuffix)
+          of: executable, arguments: unbriefed,
+          environment: Self.environment(
+            forBackend: node.backend, briefingPath: nil, hooksFile: hooksFile,
+            remoteHooksPath: remoteEnvironmentPath),
+          scriptSuffix: remoteHooksSuffix)
       if Self.fitsInATypedCommandLine(unbriefedCommand) { return unbriefedCommand }
 
       // The file carries the *unflattened* prompt — a file has no newline hazard, so a
@@ -685,13 +694,18 @@ public enum ZmxSessionLauncher {
           + [promptDirectory],
         hooksFile: hooksFile,
         sessionName: SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName,
-        zmxPath: reportingPath)
+        zmxPath: reportingPath,
+        sessionsDirectory: sessionsDirectory)
       let pointeredCommand =
         [
           "run", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName, "-d",
         ]
         + Self.loginShellInvocation(
-          of: executable, arguments: pointered, scriptSuffix: remoteHooksSuffix)
+          of: executable, arguments: pointered,
+          environment: Self.environment(
+            forBackend: node.backend, briefingPath: briefingPath, hooksFile: hooksFile,
+            remoteHooksPath: remoteEnvironmentPath),
+          scriptSuffix: remoteHooksSuffix)
       if Self.fitsInATypedCommandLine(pointeredCommand) { return pointeredCommand }
       // Deep support-directory paths can push briefing plus pointer past the line even
       // now; the pointer is the one part that cannot be given up, so the briefing goes.
@@ -702,12 +716,17 @@ public enum ZmxSessionLauncher {
           + [promptDirectory],
         hooksFile: hooksFile,
         sessionName: SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName,
-        zmxPath: reportingPath)
+        zmxPath: reportingPath,
+        sessionsDirectory: sessionsDirectory)
       return [
         "run", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName, "-d",
       ]
         + Self.loginShellInvocation(
-          of: executable, arguments: pointeredUnbriefed, scriptSuffix: remoteHooksSuffix)
+          of: executable, arguments: pointeredUnbriefed,
+          environment: Self.environment(
+            forBackend: node.backend, briefingPath: nil, hooksFile: hooksFile,
+            remoteHooksPath: remoteEnvironmentPath),
+          scriptSuffix: remoteHooksSuffix)
     }
     return command
   }
@@ -735,7 +754,12 @@ public enum ZmxSessionLauncher {
     let tier = node.effectiveModelTier(autoSelecting: settings.autoSelectsModel)
     let hooksFile = remote == nil ? PresenceHooks.write(forBackend: node.backend) : nil
     let reportingPath =
-      remote == nil && ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil
+      remote != nil ? "zmx" : (ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil)
+    let sessionsDirectory =
+      remote != nil ? PresenceHooks.remoteSessionsExpression : nil
+    let remoteEnvironmentPath =
+      remote != nil && node.backend == .openCode
+      ? PresenceHooks.remoteOpenCodeConfigPath : nil
     let remoteHooksSuffix =
       remote != nil && node.backend == .claudeCode
       ? " --settings \"\(PresenceHooks.remotePathExpression)\"" : ""
@@ -752,7 +776,8 @@ public enum ZmxSessionLauncher {
         workspacePaths: Self.workspacePaths(forNode: node, projectPath: projectPath),
         hooksFile: hooksFile,
         sessionName: sessionName,
-        zmxPath: reportingPath)
+        zmxPath: reportingPath,
+        sessionsDirectory: sessionsDirectory)
       + node.backend.resumeArguments(sessionID: sessionID)
     return [
       "run", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName, "-d",
@@ -760,7 +785,8 @@ public enum ZmxSessionLauncher {
       + Self.loginShellInvocation(
         of: executable, arguments: resumeArgs,
         environment: Self.environment(
-          forBackend: node.backend, briefingPath: nil, hooksFile: hooksFile),
+          forBackend: node.backend, briefingPath: nil, hooksFile: hooksFile,
+          remoteHooksPath: remoteEnvironmentPath),
         scriptSuffix: remoteHooksSuffix)
   }
 
@@ -801,9 +827,13 @@ public enum ZmxSessionLauncher {
   /// environment route turned out not to work; OpenCode's presence plugin is the one
   /// thing that genuinely has to travel this way (`presenceEnvironment`).
   static func environment(
-    forBackend backend: CLISessionBackendKind, briefingPath: String?, hooksFile: URL? = nil
+    forBackend backend: CLISessionBackendKind, briefingPath: String?, hooksFile: URL? = nil,
+    remoteHooksPath: String? = nil
   ) -> [String: String] {
-    backend.presenceEnvironment(hooksFile: hooksFile)
+    if backend == .openCode, let remoteHooksPath {
+      return ["OPENCODE_CONFIG": remoteHooksPath]
+    }
+    return backend.presenceEnvironment(hooksFile: hooksFile)
   }
 
   /// Whether the assembled command survives being typed into a terminal. Budgeted well
@@ -889,8 +919,8 @@ public enum ZmxSessionLauncher {
       node.backend == .copilotCLI
       ? copilotTrustSeedScript(forRemotePath: location.remotePath) + "; " : ""
     let hooksWrite =
-      node.backend == .claudeCode
-      ? (PresenceHooks.remoteWriteFragment().map { $0 + "; " } ?? "") : ""
+      PresenceHooks.remoteWriteFragment(forBackend: node.backend)
+      .map { $0 + "; " } ?? ""
     let delivery =
       remoteDeliveryScript(forNode: node, at: location, settings: settings)
       .map { $0 + "; " } ?? ""
@@ -906,9 +936,14 @@ public enum ZmxSessionLauncher {
     // session-state directory while the session is alive — the `&& { … } || { … }` is
     // safe only because the bank fragment always exits 0 (`remoteIDBankFragment`); a
     // fragment that could fail would send an alive tick into the create branch.
-    let bank =
-      node.backend == .copilotCLI
-      ? " && { " + CopilotSessionLog.remoteIDBankFragment(forNodeID: node.id) + "; }" : ""
+    let bank: String = {
+      switch node.backend {
+      case .copilotCLI:
+        return " && { " + CopilotSessionLog.remoteIDBankFragment(forNodeID: node.id) + "; }"
+      case .claudeCode, .codex, .openCode:
+        return ""
+      }
+    }()
     let script =
       "cd \(RemoteProjectLocation.shellQuoted(location.remotePath)) && { "
       + deliveryFragment(delivery, ifSessionMissing: check)
@@ -1113,7 +1148,10 @@ public enum ZmxSessionLauncher {
       .map { quotedCommand(["zmx", "send", sessionName, $0]) }
       .joined(separator: " && sleep 0.15 && ")
     let submit = quotedCommand(["zmx"] + submitArguments(forNode: node))
-    let script = "\(sends) && sleep 0.4 && \(submit)"
+    let clearCodexPresence =
+      node.backend == .codex
+      ? " && " + quotedCommand(["zmx", "set", sessionName, "presence="]) : ""
+    let script = "\(sends) && sleep 0.4 && \(submit)\(clearCodexPresence)"
     return location.sshInvocation(remoteCommand: location.remoteLoginShellCommand(script))
   }
 
@@ -1287,9 +1325,13 @@ public enum ZmxSessionLauncher {
     let sessionID: String? =
       SessionIDStore.load(forNodeID: node.id)
       ?? {
-        guard node.backend == .copilotCLI else { return nil }
-        let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
-        return CopilotSessionLog.directory(forSessionNamed: name)?.lastPathComponent
+        switch node.backend {
+        case .copilotCLI:
+          let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
+          return CopilotSessionLog.directory(forSessionNamed: name)?.lastPathComponent
+        case .claudeCode, .codex, .openCode:
+          return nil
+        }
       }()
     guard let runArgs = arguments(forNode: node, projectPath: projectPath) else { return }
     let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
@@ -1351,7 +1393,7 @@ public enum ZmxSessionLauncher {
   /// first beat itself — or for any backend whose recurrence is not a scheduler.
   static func firstPassMessage(for node: LoopNode) -> String? {
     guard node.backend == .copilotCLI, node.loopType == .timeBased,
-      node.heartbeatIntervalSeconds == nil, let prompt = node.sessionPrompt
+      node.effectiveHeartbeatInterval == nil, let prompt = node.sessionPrompt
     else { return nil }
     return SessionPrompt.firstPass(of: prompt)
   }

--- a/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
+++ b/graphcode/Sources/Features/Project/NodeDraftTypeFields.swift
@@ -169,8 +169,10 @@ struct TimedDraftFields: View {
     VStack(alignment: .leading, spacing: 14) {
       DraftField(
         label: "How often?",
-        help: "GraphCode writes the /loop directive for you — you don't have to know "
-          + "the syntax."
+        help: store.draftRequiresDaemonHeartbeat
+          ? "GraphCode's daemon holds the timer for this backend."
+          : "GraphCode writes the /loop directive for you — you don't have to know "
+            + "the syntax."
       ) {
         VStack(alignment: .leading, spacing: 8) {
           Picker("", selection: $store.draftInterval) {
@@ -193,7 +195,17 @@ struct TimedDraftFields: View {
           text: $store.draftTimedTask)
       }
 
-      if SettingsModel.shared.settings.daemonHeartbeatEnabled {
+      if store.draftRequiresDaemonHeartbeat {
+        DraftField(
+          label: "Driven by",
+          help: "This backend cannot schedule its own session, so GraphCode delivers "
+            + "each pass on the selected interval."
+        ) {
+          Text("Daemon heartbeat")
+            .font(.system(size: 11.5, weight: .medium))
+            .foregroundStyle(.white.opacity(0.78))
+        }
+      } else if SettingsModel.shared.settings.daemonHeartbeatEnabled {
         DraftField(
           label: "Driven by", qualifier: "experimental",
           help: "Heartbeat (the default while the experiment is on): the daemon wakes "
@@ -224,7 +236,7 @@ struct TimedDraftFields: View {
         .background(Theme.draftField, in: RoundedRectangle(cornerRadius: 8))
       }
 
-      if !store.draftUsesHeartbeat {
+      if !store.effectiveDraftUsesHeartbeat {
         DraftField(
           label: "Stop after", qualifier: "optional",
           help: "Left empty, it keeps running until you stop it."

--- a/graphcode/Sources/Features/Project/ProjectFeatureState.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeatureState.swift
@@ -48,7 +48,7 @@ extension ProjectFeature.State {
       loopType: draftLoopType,
       checkDescription: draftLoopType == .turnBased ? draftCheck : nil,
       triggerPrompt: composedTriggerPrompt,
-      heartbeatIntervalSeconds: draftLoopType == .timeBased && draftUsesHeartbeat
+      heartbeatIntervalSeconds: draftLoopType == .timeBased && effectiveDraftUsesHeartbeat
         ? draftHeartbeatSeconds : nil,
       firstInstruction: {
         switch draftLoopType {
@@ -101,7 +101,7 @@ extension ProjectFeature.State {
       // Heartbeat mode: the daemon holds the timer, so the prompt is the bare task —
       // `LoopNode.sessionPrompt` wraps it in the who-holds-the-timer framing at
       // launch. No /loop, and no "Stop after": a heartbeat loop runs until stopped.
-      if draftUsesHeartbeat { return task }
+      if effectiveDraftUsesHeartbeat { return task }
       var directive = "/loop \(draftInterval.directiveValue(custom: draftCustomInterval)) \(task)"
       let stop = draftStopAfter.trimmingCharacters(in: .whitespaces)
       if !stop.isEmpty { directive += " Stop after \(stop)." }
@@ -116,13 +116,23 @@ extension ProjectFeature.State {
   /// The mono line the dialog shows under the interval control, so what will be written
   /// is visible before it is written.
   var triggerPreview: String {
-    if draftLoopType == .timeBased, draftUsesHeartbeat,
-      !draftTimedTask.trimmingCharacters(in: .whitespaces).isEmpty
-    {
+    let showsHeartbeat =
+      draftLoopType == .timeBased && effectiveDraftUsesHeartbeat
+      && !draftTimedTask.trimmingCharacters(in: .whitespaces).isEmpty
+    if showsHeartbeat {
       let interval = draftInterval.directiveValue(custom: draftCustomInterval)
       return "[graphcode] heartbeat every \(interval) — the daemon holds the timer"
     }
     return composedTriggerPrompt ?? ""
+  }
+
+  var draftRequiresDaemonHeartbeat: Bool {
+    let capabilities = draftBackend.capabilities
+    return capabilities.supportsDaemonRecurrence && !capabilities.supportsInSessionRecurrence
+  }
+
+  var effectiveDraftUsesHeartbeat: Bool {
+    draftUsesHeartbeat || draftRequiresDaemonHeartbeat
   }
 
   /// The form's interval as the seconds `LoopNode.heartbeatIntervalSeconds` stores.
@@ -148,7 +158,7 @@ extension ProjectFeature.State {
     let digits =
       trimmed.hasSuffix("s") || trimmed.hasSuffix("m") || trimmed.hasSuffix("h")
         || trimmed.hasSuffix("d") ? String(trimmed.dropLast()) : trimmed
-    guard let value = Double(digits), value > 0 else { return nil }
+    guard let value = Double(digits), value.isFinite, value > 0 else { return nil }
     switch trimmed.last {
     case "s": return value
     case "h": return value * 3600

--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -157,7 +157,8 @@ struct SettingsView: View {
           "The daemon drives time-based loops on its own timer. On, new timed loops "
             + "default to the heartbeat (pick \"Itself, with /loop\" in the form, or "
             + "omit --heartbeat in the CLI, for the classic model). Off, existing "
-            + "heartbeat loops fall silent immediately; nothing is ever converted."
+            + "experimental heartbeat loops fall silent immediately; nothing is ever "
+            + "converted. Codex and OpenCode always use daemon recurrence."
         )
         .font(.caption2)
         .foregroundStyle(.secondary)

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView+Remote.swift
@@ -102,11 +102,11 @@ extension GhosttyTerminalView {
     guard
       let agentLaunch = agentCommand(
         settings: settings, briefingPath: briefingPath,
-        remoteSettingsPath: backend == .claudeCode ? PresenceHooks.remotePathExpression : nil)
+        remoteSettingsPath: remotePresenceSettingsPath, isRemote: true)
     else { return nil }
     let markerWrite = RemoteBootMarker.writeFragment(forSessionName: sessionName)
     let hooksWrite =
-      (backend == .claudeCode ? PresenceHooks.remoteWriteFragment() : nil)
+      PresenceHooks.remoteWriteFragment(forBackend: backend)
       .map { $0 + " && " } ?? ""
     var promptExport = ""
     if let prompt = sessionEnvironment(briefingPath: briefingPath)[Self.promptVariable] {
@@ -208,8 +208,7 @@ extension GhosttyTerminalView {
     var script = preparation + "{ "
     let nodeID = SurfaceRef.nodeID(fromZmxSessionName: sessionName)
     let resumeLaunch = resumeCommand(
-      settings: settings,
-      remoteSettingsPath: backend == .claudeCode ? PresenceHooks.remotePathExpression : nil)
+      settings: settings, remoteSettingsPath: remotePresenceSettingsPath, isRemote: true)
     if let nodeID, let resumeLaunch {
       let idFile = PresenceHooks.remoteSessionIDExpression(forNodeID: nodeID)
       let attempt =
@@ -243,22 +242,32 @@ extension GhosttyTerminalView {
   /// machine wrote. A resumed local session needs them for the same reason a fresh one
   /// does: without them the loop reports IDLE for as long as it runs.
   func resumeCommand(
-    settings: GraphcodeSettings, hooksFile: URL? = nil, remoteSettingsPath: String?
+    settings: GraphcodeSettings, hooksFile: URL? = nil, remoteSettingsPath: String?,
+    isRemote: Bool = false
   ) -> [String]? {
     guard backend.supportsResume, var parts = launchPrefix(settings: settings) else {
       return nil
     }
     let presence = backend.presenceArguments(
       hooksFile: hooksFile, sessionName: nil,
-      zmxPath: ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil
+      zmxPath: isRemote ? "zmx" : (ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil),
+      sessionsDirectory: isRemote ? PresenceHooks.remoteSessionsExpression : nil
     )
     .map(PresenceHooks.singleQuoted)
     .joined(separator: " ")
     if !presence.isEmpty { parts.append(presence) }
-    if let remoteSettingsPath { parts.append("--settings \"\(remoteSettingsPath)\"") }
+    addRemotePresenceSettings(remoteSettingsPath, to: &parts)
     parts += backend.resumeArguments(
       sessionID: "\"$\(ZmxSessionLauncher.remoteResumeIDVariable)\"")
     return Self.interactiveLoginShell(parts)
+  }
+
+  private var remotePresenceSettingsPath: String? {
+    switch backend {
+    case .claudeCode: return PresenceHooks.remotePathExpression
+    case .openCode: return PresenceHooks.remoteOpenCodeConfigPath
+    case .copilotCLI, .codex: return nil
+    }
   }
 
   /// The remote twin of `briefingFile`: the `~/`-relative path the briefing is

--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyTerminalView.swift
@@ -155,7 +155,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
   /// precisely so the expansion happens there.
   func agentCommand(
     settings: GraphcodeSettings = GraphcodeSettingsStore.load(), briefingPath: String? = nil,
-    hooksFile: URL? = nil, remoteSettingsPath: String? = nil
+    hooksFile: URL? = nil, remoteSettingsPath: String? = nil, isRemote: Bool = false
   ) -> [String]? {
     guard var parts = launchPrefix(settings: settings) else { return nil }
     let prompt = initialPrompt == nil ? "" : "\"$\(Self.promptVariable)\""
@@ -175,14 +175,15 @@ struct GhosttyTerminalView: NSViewRepresentable {
     let presence =
       backend.presenceArguments(
         hooksFile: hooksFile, sessionName: sessionName,
-        zmxPath: ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil
+        zmxPath: isRemote ? "zmx" : (ZmxLocator.isInstalled ? ZmxLocator.binaryURL.path : nil),
+        sessionsDirectory: isRemote ? PresenceHooks.remoteSessionsExpression : nil
       )
       .map(PresenceHooks.singleQuoted)
       .joined(separator: " ")
     if !presence.isEmpty { parts.append(presence) }
     // Double-quoted, not `singleQuoted`: the `$HOME` inside must expand when the remote
     // shell evaluates this script.
-    if let remoteSettingsPath { parts.append("--settings \"\(remoteSettingsPath)\"") }
+    addRemotePresenceSettings(remoteSettingsPath, to: &parts)
     // The briefing, delivered the same per-backend way `BackendCommand.launchArguments`
     // delivers it for a daemon-started session — before this, only daemon-started loops
     // knew they could fan out, and a turn-based loop (which only ever starts here) asked
@@ -228,6 +229,15 @@ struct GhosttyTerminalView: NSViewRepresentable {
   /// fresh launches cannot diverge on how the shell resolves the agent.
   static func interactiveLoginShell(_ parts: [String]) -> [String] {
     ["/bin/zsh", "-i", "-l", "-c", parts.joined(separator: " ")]
+  }
+
+  func addRemotePresenceSettings(_ path: String?, to parts: inout [String]) {
+    guard let path else { return }
+    if backend == .claudeCode {
+      parts.append("--settings \"\(path)\"")
+    } else if backend == .openCode {
+      parts.insert(contentsOf: ["env", "OPENCODE_CONFIG=\"\(path)\""], at: 1)
+    }
   }
 
   /// Where the graph briefing for this session landed, or `nil` when it shouldn't get

--- a/graphcode/Tests/CodexPresenceTests.swift
+++ b/graphcode/Tests/CodexPresenceTests.swift
@@ -30,6 +30,9 @@ struct CodexPresenceTests {
     // Same session-owned label store the other two backends report into, so one reader
     // serves all three.
     #expect(override.contains(#"$ZMX_SESSION"#))
+    #expect(override.contains("thread-id"))
+    #expect(override.contains(".history"))
+    #expect(override.contains(".id"))
   }
 
   @Test
@@ -63,11 +66,27 @@ struct CodexPresenceTests {
 
   @Test
   func nowhereToReportMeansNoFlagRatherThanABrokenOne() {
-    // A remote session, or a machine with no zmx: the override would name a binary that
-    // isn't there, and Codex would run it once per turn forever.
+    // A machine with no zmx cannot accept a presence or resume-ID report.
     #expect(
       CLISessionBackendKind.codex.presenceArguments(
         hooksFile: nil, sessionName: "graphcode-A", zmxPath: nil) == [])
+  }
+
+  @Test
+  func aRemoteOverrideUsesTheRemoteBinaryAndSessionBank() throws {
+    let node = LoopNode(
+      title: "Ship it", loopType: .goalBased, goal: GoalSpec(summary: "Tests pass"),
+      backend: .codex, state: .running)
+    let location = RemoteProjectLocation(
+      user: "dev", host: "build-box", remotePath: "/home/dev/widget")
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location))
+    let command = try #require(invocation.last)
+
+    #expect(command.contains("notify="))
+    #expect(command.contains("thread-id"))
+    #expect(command.contains("$HOME/.graphcode/sessions"))
+    #expect(!command.contains(ZmxLocator.binaryURL.path))
   }
 
   @Test

--- a/graphcode/Tests/DaemonHeartbeatTests.swift
+++ b/graphcode/Tests/DaemonHeartbeatTests.swift
@@ -141,6 +141,53 @@ struct DaemonHeartbeatTests {
   }
 
   @Test
+  func codexAndOpenCodeUseDaemonCadenceWhenTheToggleIsOff() async {
+    for backend in [CLISessionBackendKind.codex, .openCode] {
+      let node = LoopNode(
+        title: "Watcher", loopType: .timeBased,
+        triggerPrompt: "/loop 30m check reports", backend: backend, state: .running)
+      let delivered = LockIsolated(0)
+      let graph = LoopGraph(
+        project: ProjectRef(path: "/tmp/heartbeat", name: "heartbeat"), nodes: [node])
+      let store = GraphStore(
+        graph: graph,
+        onDeliverMessage: { _, _, _ in
+          delivered.withValue { $0 += 1 }
+          return true
+        },
+        onHeartbeatEnabled: { false })
+
+      #expect(node.effectiveHeartbeatInterval == 1800)
+      #expect(node.sessionPrompt?.contains("Run one pass") == true)
+      await store.deliverHeartbeat(node.id)
+      #expect(delivered.value == 1)
+    }
+  }
+
+  @Test
+  func explicitCodexAndOpenCodeHeartbeatsIgnoreTheToggle() async {
+    for backend in [CLISessionBackendKind.codex, .openCode] {
+      let draft = NodeDraft(
+        title: "Watcher", loopType: .timeBased,
+        triggerPrompt: "check reports", heartbeatIntervalSeconds: 300, backend: backend)
+      let delivered = LockIsolated(0)
+      let store = GraphStore(
+        onDeliverMessage: { _, _, _ in
+          delivered.withValue { $0 += 1 }
+          return true
+        },
+        onHeartbeatEnabled: { false })
+
+      await store.handle(.createNode(draft))
+      #expect(await store.graph.nodes.count == 1)
+      if let node = await store.graph.nodes.first {
+        await store.deliverHeartbeat(node.id)
+      }
+      #expect(delivered.value == 1)
+    }
+  }
+
+  @Test
   func settingAnIntervalNeedsTheExperimentButClearingNeverDoes() async {
     // Turning the toggle off must not strand a loop with a cadence nobody can remove.
     let graph = heartbeatGraph()
@@ -179,6 +226,12 @@ struct DaemonHeartbeatTests {
       try GraphcodeCommand.parse([
         "node", "create", "/tmp/p", "--title", "W", "--type", "time",
         "--prompt", "check", "--heartbeat", "-5",
+      ])
+    }
+    #expect(throws: GraphcodeCommand.ParseError.self) {
+      try GraphcodeCommand.parse([
+        "node", "create", "/tmp/p", "--title", "W", "--type", "time",
+        "--prompt", "check", "--heartbeat", "inf",
       ])
     }
   }

--- a/graphcode/Tests/GraphcodeCommandTests.swift
+++ b/graphcode/Tests/GraphcodeCommandTests.swift
@@ -103,17 +103,15 @@ struct GraphcodeCommandTests {
   }
 
   @Test
-  func anImpossibleBackendPairingIsRejected() throws {
-    // Codex used to be the example here because it could host *nothing*. It is spiked now
-    // (issue #1) and takes turn- and goal-based loops fine — but a time-based loop needs
-    // the session to re-trigger itself, and Codex has no `/loop` equivalent, so that
-    // pairing would run once and look like a broken schedule.
-    #expect(throws: GraphcodeCommand.ParseError.invalidDraft) {
+  func aDaemonBackedCodexTimeLoopIsAccepted() throws {
+    // Codex has no in-session recurrence, but a leading simple directive is converted to
+    // the graphcode daemon cadence rather than rejected as an unsupported pairing.
+    #expect(throws: Never.self, performing: {
       try GraphcodeCommand.parse([
         "node", "create", "/tmp/x", "--title", "Poll", "--type", "time",
         "--prompt", "/loop 1h Check", "--backend", "codex",
       ])
-    }
+    })
     // And the pairing that is fine now, which is the point of the change.
     #expect(
       throws: Never.self,

--- a/graphcode/Tests/LocalSessionResumeTests.swift
+++ b/graphcode/Tests/LocalSessionResumeTests.swift
@@ -72,13 +72,18 @@ struct LocalSessionResumeTests {
   }
 
   @Test
-  func aBackendThatCannotResumeIsUnaffected() {
+  func codexResumesFromItsSessionID() throws {
     let nodeID = UUID()
     let view = surface(nodeID: nodeID, backend: .codex)
-    let command = withBankedID("abc-123", forNode: nodeID) {
-      view.localResumeOrFreshCommand(agentLaunch: ["codex", "the prompt"])
+    let command = try withBankedID("abc-123", forNode: nodeID) {
+      try #require(view.localResumeOrFreshCommand(agentLaunch: ["codex", "the prompt"])?.last)
     }
-    #expect(command == nil)
+    #expect(command.contains("resume"))
+    #expect(command.contains(#""$GRAPHCODE_RESUME_ID""#))
+    #expect(command.contains("the prompt"))
+    let resume = try #require(command.range(of: "resume"))
+    let fallback = try #require(command.range(of: "the prompt"))
+    #expect(resume.upperBound < fallback.lowerBound)
   }
 
   // MARK: - A resume that does not take

--- a/graphcode/Tests/NodeDraftTests.swift
+++ b/graphcode/Tests/NodeDraftTests.swift
@@ -198,12 +198,10 @@ struct NodeDraftTests {
         #expect(backend.isSpiked)
       }
     }
-    // Codex has no `/loop` equivalent, so the pairing is refused all the way through to
-    // the draft — the same path an unspiked backend used to take for every type.
-    #expect(!CLISessionBackendKind.codex.canHost(.timeBased))
+    #expect(CLISessionBackendKind.codex.canHost(.timeBased))
     #expect(
-      !NodeDraft(
-        title: "Poll", loopType: .timeBased, triggerPrompt: "/loop 1h", backend: .codex
+      NodeDraft(
+        title: "Poll", loopType: .timeBased, triggerPrompt: "/loop 1h Check", backend: .codex
       ).isValid)
   }
 
@@ -226,10 +224,9 @@ struct NodeDraftTests {
       CLISessionBackendKind.hosting(.turnBased) == [.claudeCode, .copilotCLI, .codex, .openCode])
     #expect(
       CLISessionBackendKind.hosting(.goalBased) == [.claudeCode, .copilotCLI, .codex, .openCode])
-    // Time-based needs the session to re-trigger itself, since graphcode holds no timer.
-    // Copilot gained that; Codex and OpenCode have no `/loop` equivalent in their CLI
-    // surfaces.
-    #expect(CLISessionBackendKind.hosting(.timeBased) == [.claudeCode, .copilotCLI])
+    #expect(
+      CLISessionBackendKind.hosting(.timeBased)
+        == [.claudeCode, .copilotCLI, .codex, .openCode])
     // A composite still needs sub-agent fan-out, which only Claude Code has been shown
     // to do.
     #expect(CLISessionBackendKind.hosting(.composite) == [.claudeCode])
@@ -304,6 +301,34 @@ struct NodeDraftTests {
   }
 
   @Test
+  func daemonOnlyBackendsRequireARealDaemonCadence() {
+    for backend in [CLISessionBackendKind.codex, .openCode] {
+      for prompt in ["check reports", "/loop tomorrow check reports", "/schedule daily check"] {
+        #expect(
+          !NodeDraft(
+            title: "Poll", loopType: .timeBased, triggerPrompt: prompt, backend: backend
+          ).isValid,
+          "\(backend.rawValue) accepted \(prompt)")
+      }
+      #expect(
+        NodeDraft(
+          title: "Poll", loopType: .timeBased, triggerPrompt: "/loop 30m check reports",
+          backend: backend
+        ).isValid)
+      #expect(
+        NodeDraft(
+          title: "Poll", loopType: .timeBased, triggerPrompt: "check reports",
+          heartbeatIntervalSeconds: 1800, backend: backend
+        ).isValid)
+      #expect(
+        !NodeDraft(
+          title: "Poll", loopType: .timeBased, triggerPrompt: "check reports",
+          heartbeatIntervalSeconds: .infinity, backend: backend
+        ).isValid)
+    }
+  }
+
+  @Test
   func aCompositeCarriesTheScheduleItIsIntendedFor() {
     // Nothing runs at creation, so this is a statement of intent — but one the composite
     // should still be holding when someone comes back to arm it.
@@ -323,16 +348,14 @@ struct NodeDraftTests {
     // The rule `BackendPicker.onChange` applied, now that the dialog draws the note
     // itself: an impossible pairing left selected is a form that refuses to submit
     // without saying which field is at fault.
-    #expect(!CLISessionBackendKind.codex.canHost(.timeBased))
-    #expect(CLISessionBackendKind.hosting(.timeBased).first == .claudeCode)
+    #expect(CLISessionBackendKind.codex.canHost(.timeBased))
+    #expect(CLISessionBackendKind.hosting(.timeBased).contains(.codex))
     // And the note the dialog shows for it is the picker's own sentence, not a second
     // version of the same refusal.
     #expect(
       BackendPicker.unsupportedReason(backend: .codex, loopType: .timeBased)
         == BackendPicker.unsupportedReason(backend: .codex, loopType: .timeBased))
-    #expect(
-      BackendPicker.unsupportedReason(backend: .codex, loopType: .timeBased)
-        .contains("run once and stop"))
+    #expect(CLISessionBackendKind.openCode.canHost(.timeBased))
   }
 
   @Test

--- a/graphcode/Tests/OpenCodeBackendTests.swift
+++ b/graphcode/Tests/OpenCodeBackendTests.swift
@@ -109,7 +109,9 @@ struct OpenCodeBackendTests {
     #expect(CLISessionBackendKind.openCode.supportsResume)
     #expect(
       CLISessionBackendKind.claudeCode.resumeArguments(sessionID: "abc") == ["--resume", "abc"])
-    #expect(CLISessionBackendKind.codex.resumeArguments(sessionID: "abc").isEmpty)
+    #expect(CLISessionBackendKind.codex.supportsResume)
+    #expect(
+      CLISessionBackendKind.codex.resumeArguments(sessionID: "abc") == ["resume", "abc"])
   }
 
   @Test
@@ -147,12 +149,28 @@ struct OpenCodeBackendTests {
   }
 
   @Test
-  func itHostsEveryLoopTypeButRecurringAndComposite() {
+  func aRemoteLaunchWritesAndLoadsItsPresencePlugin() throws {
+    let remoteNode = LoopNode(
+      title: "Ship it", loopType: .goalBased, goal: GoalSpec(summary: "Tests pass"),
+      backend: .openCode, state: .running)
+    let location = RemoteProjectLocation(
+      user: "dev", host: "build-box", remotePath: "/home/dev/widget")
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(forNode: remoteNode, at: location))
+    let command = try #require(invocation.last)
+
+    #expect(command.contains("opencode-presence.js"))
+    #expect(command.contains("OPENCODE_CONFIG"))
+    #expect(command.contains("$HOME/.graphcode/hooks/openCode.json"))
+    #expect(command.contains("process.env.HOME"))
+  }
+
+  @Test
+  func itHostsEveryLoopTypeButComposite() {
     #expect(CLISessionBackendKind.openCode.canHost(.goalBased))
     #expect(CLISessionBackendKind.openCode.canHost(.turnBased))
     #expect(CLISessionBackendKind.openCode.canHost(.sketch))
-    // No `/loop` equivalent, and no sub-agent fan-out reachable from outside the TUI.
-    #expect(!CLISessionBackendKind.openCode.canHost(.timeBased))
+    #expect(CLISessionBackendKind.openCode.canHost(.timeBased))
     #expect(!CLISessionBackendKind.openCode.canHost(.composite))
     #expect(CLISessionBackendKind.offerableAsDefault.contains(.openCode))
   }

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -259,6 +259,25 @@ struct ProjectFeatureTests {
 
   @Test
   @MainActor
+  func codexAndOpenCodeDraftsAlwaysUseDaemonCadence() {
+    for backend in [CLISessionBackendKind.codex, .openCode] {
+      var state = ProjectFeature.State(graph: LoopGraph(project: Self.testProject))
+      state.draftLoopType = .timeBased
+      state.draftBackend = backend
+      state.draftTimedTask = "check reports"
+      state.draftInterval = .quarterHour
+      state.draftUsesHeartbeat = false
+      state.draftStopAfter = "20 runs"
+
+      #expect(state.draftRequiresDaemonHeartbeat)
+      #expect(state.effectiveDraftUsesHeartbeat)
+      #expect(state.draft.triggerPrompt == "check reports")
+      #expect(state.draft.heartbeatIntervalSeconds == 900)
+    }
+  }
+
+  @Test
+  @MainActor
   func customIntervalsParseIntoSecondsWithAnHonestFallback() {
     #expect(ProjectFeature.State.seconds(fromInterval: "90s") == 90)
     #expect(ProjectFeature.State.seconds(fromInterval: "30m") == 1800)
@@ -267,6 +286,7 @@ struct ProjectFeatureTests {
     // Bare digits are minutes, matching what people type into the /loop field.
     #expect(ProjectFeature.State.seconds(fromInterval: "45") == 2700)
     #expect(ProjectFeature.State.seconds(fromInterval: "tomorrow") == nil)
+    #expect(ProjectFeature.State.seconds(fromInterval: "inf") == nil)
 
     var state = ProjectFeature.State(graph: LoopGraph(project: Self.testProject))
     state.draftLoopType = .timeBased

--- a/graphcode/Tests/RemoteLoopSurvivalTests.swift
+++ b/graphcode/Tests/RemoteLoopSurvivalTests.swift
@@ -383,17 +383,19 @@ struct RemoteLoopSurvivalTests {
   }
 
   @Test
-  func copilotRestoreResumesWithoutANameAndCodexCannotResume() {
-    // Copilot's `--name` and `--resume` are mutually exclusive; Codex has no resume at
-    // all, so its restore goes straight to the fresh launch.
+  func copilotAndCodexRestoreWithTheirOwnResumeSyntax() {
+    // Copilot's `--name` and `--resume` are mutually exclusive. Codex resumes through
+    // its subcommand and the notifier banks the next thread ID under this remote node.
     let copilot = agentSurface(backend: .copilotCLI)
       .resumeCommand(settings: GraphcodeSettings(), remoteSettingsPath: nil)?
       .joined(separator: " ")
     #expect(copilot?.contains(#"--resume "$GRAPHCODE_RESUME_ID""#) == true)
     #expect(copilot?.contains("--name") == false)
     let codex = agentSurface(backend: .codex)
-      .resumeCommand(settings: GraphcodeSettings(), remoteSettingsPath: nil)
-    #expect(codex == nil)
+      .resumeCommand(settings: GraphcodeSettings(), remoteSettingsPath: nil, isRemote: true)?
+      .joined(separator: " ")
+    #expect(codex?.contains(#"resume "$GRAPHCODE_RESUME_ID""#) == true)
+    #expect(codex?.contains("$HOME/.graphcode/sessions") == true)
   }
 
   // MARK: - Remote presence hooks

--- a/graphcode/Tests/RemoteSessionLaunchTests.swift
+++ b/graphcode/Tests/RemoteSessionLaunchTests.swift
@@ -105,6 +105,20 @@ struct RemoteSessionLaunchTests {
   }
 
   @Test
+  func aRemoteCodexMessageClearsItsIdleLabelAfterSubmission() throws {
+    let node = LoopNode(
+      title: "Watcher", loopType: .timeBased, triggerPrompt: "/loop 5m Check",
+      backend: .codex)
+    let invocation = ZmxSessionLauncher.remoteSendInvocation(
+      "[graphcode] Heartbeat", toNode: node, at: location)
+    let remoteCommand = try #require(invocation.last)
+
+    let clear = try #require(remoteCommand.range(of: "presence="))
+    #expect(remoteCommand[..<clear.lowerBound].contains("sleep 0.4"))
+    #expect(remoteCommand[..<clear.lowerBound].contains("set"))
+  }
+
+  @Test
   func aLargeRemoteMessageIsChunkedIntoTheSameRoundTrip() throws {
     // The remote host's PTY queue is no bigger than ours, so an oversized single write
     // vanishes there the same way — the chunks ride the one ssh dial, drain beats

--- a/graphcode/Tests/RemoteSessionResumeTests.swift
+++ b/graphcode/Tests/RemoteSessionResumeTests.swift
@@ -323,13 +323,23 @@ struct RemoteSessionResumeTests {
   }
 
   @Test
-  func aCodexNodeHasNoResumeToOffer() {
-    // Codex has no `--resume` graphcode has spiked, so the remote ensure keeps the
-    // single fresh-launch branch rather than inventing a flag.
-    #expect(
+  func aCodexNodeUsesItsResumeSubcommand() throws {
+    let arguments = try #require(
       ZmxSessionLauncher.resumeArguments(
-        forNode: goalNode(.codex), sessionID: "abc-123", projectPath: location.projectPath)
-        == nil)
+        forNode: goalNode(.codex), sessionID: "abc-123", projectPath: location.projectPath))
+    #expect(arguments.contains { $0.contains("resume") })
+    #expect(arguments.contains("abc-123"))
+  }
+
+  @Test
+  func aRemoteCodexEnsureBanksTheRolloutID() throws {
+    let invocation = try #require(
+      ZmxSessionLauncher.remoteEnsureInvocation(
+        forNode: goalNode(.codex), at: location))
+    let command = try #require(invocation.last)
+    #expect(command.contains("notify="))
+    #expect(command.contains("thread-id"))
+    #expect(command.contains(".graphcode/sessions"))
   }
 
   // MARK: - One ensure per node

--- a/graphcode/Tests/SessionBriefingTests.swift
+++ b/graphcode/Tests/SessionBriefingTests.swift
@@ -385,7 +385,7 @@ struct BriefingCadenceGuidanceTests {
     let off = try #require(
       SessionBriefing.text(projectPath: "/tmp/p", settings: GraphcodeSettings()))
     #expect(off.contains("The cadence goes inside the prompt"))
-    #expect(!off.contains("--heartbeat"))
+    #expect(off.contains("--heartbeat <seconds>"))
 
     let on = try #require(
       SessionBriefing.text(

--- a/graphcode/Tests/SessionPromptTests.swift
+++ b/graphcode/Tests/SessionPromptTests.swift
@@ -5,9 +5,8 @@ import Testing
 
 /// Where the preambles graphcode wraps around a session's opening prompt are allowed to
 /// sit. Every backend reads a leading `/` as a command and anything else as prose, and a
-/// time-based node's prompt *is* a command — the `/loop …` directive that makes the
-/// session re-trigger itself, since graphcode holds no timer of its own. A preamble in
-/// front of it is not a preamble, it is a silently disabled loop type (issue #179).
+/// time-based node whose session owns recurrence uses the `/loop …` command. A preamble
+/// in front of it is not a preamble, it is a silently disabled loop type (issue #179).
 @Suite
 struct SessionPromptTests {
   /// Copilot is the backend that both hosts time-based loops and takes its briefing as a
@@ -171,6 +170,20 @@ struct SessionPromptTests {
     // The experimental flag follows any mention, prose included.
     #expect(SessionPrompt.mentionsRecurrence("Run now. Then: /every 15m say hi"))
     #expect(!SessionPrompt.mentionsRecurrence("fix the failing test"))
+  }
+
+  @Test
+  func daemonIntervalsAcceptOnlyPositiveFiniteSimpleDurations() {
+    #expect(SessionPrompt.intervalSeconds("90s") == 90)
+    #expect(SessionPrompt.intervalSeconds("30m") == 1800)
+    #expect(SessionPrompt.intervalSeconds("2h") == 7200)
+    #expect(SessionPrompt.intervalSeconds("3d") == 259_200)
+    #expect(SessionPrompt.intervalSeconds("45") == 2700)
+    #expect(SessionPrompt.intervalSeconds("soon") == nil)
+    #expect(SessionPrompt.intervalSeconds("0") == nil)
+    #expect(SessionPrompt.intervalSeconds("inf") == nil)
+    #expect(SessionPrompt.intervalSeconds("1w") == nil)
+    #expect(SessionPrompt.intervalSeconds("1h30m") == nil)
   }
 
   /// The marker is what stops the opening pass repeating, and it records *which* session


### PR DESCRIPTION
## Summary
- make remote Codex notify and OpenCode presence hooks travel with daemon and Ghostty launches
- resume Codex/OpenCode only from node-scoped session IDs; remove ambiguous cwd fallback
- enforce daemon cadence for Codex/OpenCode, hide incompatible self-pacing controls, and validate intervals
- cover remote heartbeat overlap, resume syntax, malformed cadence, and non-finite values

## Verification
- `mise exec -- make check`
- `mise exec -- make test` (1,267 passed, 0 failed, 0 skipped)
- `git diff --check`