### PR TITLE
Fix goal loops dying silently on Claude Code's folder-trust dialog (#215)

### DIFF
--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -368,7 +368,8 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     guard state == .running, let presence = presence?.presence else { return state }
     switch presence {
     case .busy: return .running
-    case .idle, .absent: return hasActiveDependents ? .waiting : .idle
+    case .idle: return hasActiveDependents ? .waiting : .idle
+    case .absent: return displayStateForAbsentSession
     // The combination `Presence` was written for: running in the graph, waiting on a
     // human in its session.
     case .awaitingInput: return .awaitingInput
@@ -376,6 +377,29 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
     // the only honest thing left to show, exactly as if no reading existed.
     case .unknown: return state
     }
+  }
+
+  /// How long after a node's creation an `absent` presence reading is still allowed to
+  /// look like ordinary quiet. A freshly created loop's session takes a moment to exist
+  /// (the ensure is fired, not awaited, and a remote one crosses ssh first), so the
+  /// first poll of a young node can read `absent` while the launch is still in flight;
+  /// past this grace an absent session on an unattended loop is not quiet — it is a
+  /// session that exited with nobody watching, issue #215's silent death.
+  public static let absentSessionGraceSeconds: TimeInterval = 60
+
+  /// A `.running` unattended loop whose session is *gone* is a dead loop, and IDLE is
+  /// the one word it must not show: nothing is waiting for work, there is no work and
+  /// no loop to do it — that is the `failed` the graph would record if anyone had seen
+  /// the exit. Attended (turn-based) loops stay IDLE: a human owns those sessions, and
+  /// the pane they open is the place the exit shows. A loop others are still waiting
+  /// on shows `waiting` either way — that word is about the dependents, and their edge
+  /// is the graph's business, not the presence poll's.
+  private var displayStateForAbsentSession: LoopState {
+    guard runsUnattended, !hasActiveDependents else {
+      return hasActiveDependents ? .waiting : .idle
+    }
+    let grace = Date().addingTimeInterval(-Self.absentSessionGraceSeconds)
+    return createdAt < grace ? .failed : .idle
   }
 
   /// Whether this node has finished for good. Used to stop a resolved goal from being

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -1882,6 +1882,22 @@ public actor GraphStore {
       return
     }
     guard await deliverToSession(target, message) else {
+      // The transport can also fail because the session died after the graph last
+      // looked — a goal loop whose agent exited on its very first turn had no session
+      // left to type into, and (before sessions that answer while dead stopped passing
+      // the send gate) even a "delivered" that nobody received (issue #215). An
+      // unattended loop is the daemon's to keep alive, so a failed delivery is the
+      // moment to do exactly that: the ensure is create-only and husk-aware, so it
+      // relaunches precisely the dead case, the settle is the fresh session's boot
+      // beat, and the retry lands the message that would otherwise have sat staged
+      // until a wake that a dead loop has no way to know about. Attended loops stay
+      // human-timed — a turn-based session is respawned by a human opening it, not by
+      // a message arriving.
+      if target.runsUnattended, !target.isResolved {
+        ensureSession(target)
+        try? await Task.sleep(for: Self.respawnedSessionSettle)
+        if await deliverToSession(target, message) { return }
+      }
       recordMemory(nodeID, "while you were away: \(message)")
       announceError(
         "delivery to \(target.title)'s session failed — message staged to its memory; "
@@ -1889,6 +1905,12 @@ public actor GraphStore {
       return
     }
   }
+
+  /// Long enough for a relaunched session to exist and start its agent's boot, short
+  /// enough that the send's own chunk beats dominate the retry's latency. The retry is
+  /// still best-effort: a session slow to accept input fails it and the message is
+  /// staged, exactly as before.
+  static let respawnedSessionSettle: Duration = .seconds(3)
 
   /// Whether a follow-up to this node should wait rather than type now. Mid-turn and
   /// mid-check both qualify — deferring to a busy agent is the flag's entire meaning —

--- a/GraphcodeKit/Sources/Sessions/ClaudeCodeTrust.swift
+++ b/GraphcodeKit/Sources/Sessions/ClaudeCodeTrust.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Seeds Claude Code's folder-trust answer so an unattended session is never parked at
+/// its first-run "Quick safety check: Is this a project you created or one you trust?"
+/// dialog — the Claude Code twin of `CopilotTrust`, for the same reason: a fresh
+/// unattended `claude` on a folder it has never seen stops on that dialog as its very
+/// first screen, exits with code 1 when nothing answers it, and takes the loop's opening
+/// pass with it (issue #215). No launch flag covers it, and the answer lives only as
+/// `projects[<path>].hasTrustDialogAccepted = true` in `~/.claude.json`.
+///
+/// Pre-trusting the one directory the loop was pointed at is the same consent the human
+/// gave by creating the loop there. The write is additive and idempotent, and any
+/// failure — unparseable JSON, unwritable file — falls back to today's behaviour: the
+/// dialog, answerable by opening the loop.
+public enum ClaudeCodeTrust {
+  public static var configURL: URL {
+    FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude.json")
+  }
+
+  /// Sets `projects[directory].hasTrustDialogAccepted = true` unless it is already set.
+  /// Never throws and never clobbers: a config it cannot parse is left exactly as found.
+  public static func ensureTrusted(directory: String, configURL: URL = configURL) {
+    guard !directory.isEmpty else { return }
+    let fileManager = FileManager.default
+    let existing = (try? Data(contentsOf: configURL)) ?? Data()
+    var config: [String: Any] = [:]
+    if !existing.isEmpty {
+      guard let parsed = try? JSONSerialization.jsonObject(with: existing),
+        let dictionary = parsed as? [String: Any]
+      else { return }
+      config = dictionary
+    }
+    var projects = config["projects"] as? [String: Any] ?? [:]
+    var entry = projects[directory] as? [String: Any] ?? [:]
+    guard (entry["hasTrustDialogAccepted"] as? Bool) != true else { return }
+    entry["hasTrustDialogAccepted"] = true
+    projects[directory] = entry
+    config["projects"] = projects
+    guard
+      let data = try? JSONSerialization.data(
+        withJSONObject: config, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+    else { return }
+    try? fileManager.createDirectory(
+      at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    // Claude Code rewrites this file for every session it runs, and it holds the user's
+    // prompt history — so a first write lands private (0600) and an existing file keeps
+    // whatever permissions it had, rather than `.atomic`'s default 0644 widening it.
+    let attributes = try? fileManager.attributesOfItem(atPath: configURL.path)
+    let permissions =
+      (attributes?[.posixPermissions] as? NSNumber).map { $0.uint16Value } ?? 0o600
+    try? data.write(to: configURL, options: .atomic)
+    try? fileManager.setAttributes(
+      [.posixPermissions: NSNumber(value: permissions)], ofItemAtPath: configURL.path)
+  }
+}

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -397,13 +397,77 @@ public enum ZmxSessionLauncher {
   /// Whether the node has a live session at all. Internal rather than private because
   /// `CopilotSessionLog` needs the same liveness gate before it trusts a log tail: a
   /// killed session's log still ends at whatever it was doing.
+  ///
+  /// "Live" means the *task inside* the session, not the session itself. A session
+  /// whose command has ended still answers `zmx get` forever — `zmx run`'s wrapper
+  /// shell stays at its prompt, so the session exists, answers existence checks, and
+  /// swallows anything typed at it (issue #215's `node send` that reported "delivered"
+  /// into a session whose `claude` had exited). Only a running task is a session a
+  /// keystroke can reach.
   static func sessionExists(_ node: LoopNode) async -> Bool {
-    guard
-      let session = try? PTYProcessSession(
-        executable: ZmxLocator.binaryURL.path,
-        arguments: existenceCheckArguments(forNode: node))
-    else { return false }
-    return await session.waitUntilFinished()
+    await sessionTaskState(node) == .alive
+  }
+
+  /// What is actually inside the node's zmx session: a running task (`alive`), a
+  /// completed one (`exited`, with the exit code when zmx caught it), or no session at
+  /// all (`absent`). One `zmx ls`, the same cost as the `zmx get` existence check it
+  /// replaces, and the one answer both the send gate and the create-only ensure need —
+  /// an ensure keyed on `zmx get` could never revive a husk, because the husk *is* the
+  /// session that check asks about.
+  static func sessionTaskState(_ node: LoopNode) async -> SessionTaskState {
+    guard ZmxLocator.isInstalled, let result = runZmx(["ls"]), result.status == 0 else {
+      return .absent
+    }
+    return parseSessionTaskState(
+      lsOutput: result.output,
+      sessionName: SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName)
+  }
+
+  enum SessionTaskState: Equatable {
+    case alive
+    case exited(exitCode: Int?)
+    case absent
+  }
+
+  /// Parses the `zmx ls` line for one session into a `SessionTaskState`. Internal so
+  /// tests can hold the real output shapes.
+  ///
+  /// `ended=` is tab-preceded in the ls line (`…\tcmd=…\tended=<ts>\texit_code=<n>`) and
+  /// printed only for a completed task — a live task and an interactive shell never
+  /// print it. Matching on the tab keeps a prompt or command that merely *contains* the
+  /// text (a pasted goal, say) from counting as a completed task; the same is why the
+  /// name is matched as a whole token, so `graphcode-A` is never found inside
+  /// `graphcode-AB`'s line.
+  static func parseSessionTaskState(lsOutput: String, sessionName: String) -> SessionTaskState {
+    let line = lsOutput.split(separator: "\n").first { line in
+      line.split(whereSeparator: \.isWhitespace).contains("name=\(sessionName)")
+    }
+    guard let line else { return .absent }
+    // An error row (`…\tname=…\terr=ConnectionRefused\tstatus=cleaning up`) is zmx
+    // reporting a session it cannot reach — the daemon behind it is gone, which is as
+    // absent as a missing row, and counts as neither alive nor exited.
+    guard line.range(of: "\terr=") == nil else { return .absent }
+    guard line.range(of: "\tended=") != nil else { return .alive }
+    var exitCode: Int?
+    if let range = line.range(of: "\texit_code=") {
+      let digits = line[range.upperBound...].prefix { $0.isNumber }
+      exitCode = Int(digits)
+    }
+    return .exited(exitCode: exitCode)
+  }
+
+  /// The shell-level form of the same judgement `sessionTaskState` makes — the check
+  /// half of every create-only ensure (`atomicCheckOrRun`, the remote ensure, the
+  /// remote send's gate). `zmx get <name>` exits 0 for a husk, so a check keyed on it
+  /// believed every dead session alive and nothing could ever be woken (#215); the ls
+  /// pipeline exits 0 only when the session is listed *and* its task has not ended.
+  /// The name token is matched tab-terminated, the field order `zmx ls` prints, so a
+  /// prefix of another session's name cannot pass.
+  static func aliveCheckCommand(zmxPath: String, forNode node: LoopNode) -> String {
+    let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
+    return RemoteProjectLocation.shellQuoted(zmxPath)
+      + " ls 2>/dev/null | grep -v -e $'\\tended=' -e $'\\terr=' | grep -q "
+      + RemoteProjectLocation.shellQuoted("name=\(name)\t")
   }
 
   /// Kills the session behind an id that isn't a graph node — a quick chat. Public
@@ -504,11 +568,12 @@ public enum ZmxSessionLauncher {
       output: String(data: data, encoding: .utf8) ?? "")
   }
 
-  /// `zmx get <name>` exits 0 when the session exists and 1 when it doesn't — the check
-  /// that stops `ensureUnattendedSessions()` from re-sending a prompt into a loop that's
-  /// already running. `zmx run` is *not* idempotent: against a live session it types the
-  /// command in again, which would either land as text in the running Claude's input or
-  /// queue a second `claude` behind the first.
+  /// `zmx get <name>` exits 0 when the session exists and 1 when it doesn't — raw
+  /// existence, which a husk (a session whose task has ended, its wrapper shell still
+  /// at the prompt) passes. That is the right answer only for "is there a session
+  /// record to interrogate"; every gate that decides whether a keystroke can reach an
+  /// agent — sends, presence, the create-only ensures — now asks `sessionTaskState` or
+  /// `aliveCheckCommand` instead, which treat an ended task as what it is (issue #215).
   static func existenceCheckArguments(forNode node: LoopNode) -> [String] {
     ["get", SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName]
   }
@@ -904,7 +969,11 @@ public enum ZmxSessionLauncher {
       let zmxArguments = arguments(
         forNode: node, projectPath: location.projectPath, settings: settings)
     else { return nil }
-    let check = quotedCommand(["zmx"] + existenceCheckArguments(forNode: node))
+    // The remote twin of the local alive check: raw existence (`zmx get`) answers for a
+    // husk too — the wrapper shell stays at its prompt after the command inside exits —
+    // so an ensure keyed on it could never revive a dead remote loop (#215). Only a
+    // listed session whose task has not ended counts as alive here.
+    let check = aliveCheckCommand(zmxPath: "zmx", forNode: node)
     let run = remoteQuotedCommand(["zmx"] + zmxArguments)
     // Copilot only, and remote only: an unattended Copilot queues its `--interactive`
     // goal behind a per-session folder-trust dialog that nobody is present to answer,
@@ -915,9 +984,16 @@ public enum ZmxSessionLauncher {
     // (the `trustedFolders` list in `~/.copilot/config.json`, schema read off a real
     // "remember this folder" answer), and any failure — no python3, malformed config —
     // falls back to today's behaviour: the dialog, answerable by opening the loop.
-    let trustSeed =
-      node.backend == .copilotCLI
-      ? copilotTrustSeedScript(forRemotePath: location.remotePath) + "; " : ""
+    // Claude Code's twin is its first-run trust dialog, which a fresh unattended
+    // `claude` answers by exiting 1 (issue #215); the seed and its `~/.claude.json`
+    // shape are `claudeTrustSeedScript`'s.
+    let trustSeed: String = {
+      switch node.backend {
+      case .copilotCLI: return copilotTrustSeedScript(forRemotePath: location.remotePath) + "; "
+      case .claudeCode: return claudeTrustSeedScript(forRemotePath: location.remotePath) + "; "
+      case .codex, .openCode: return ""
+      }
+    }()
     let hooksWrite =
       PresenceHooks.remoteWriteFragment(forBackend: node.backend)
       .map { $0 + "; " } ?? ""
@@ -1124,6 +1200,25 @@ public enum ZmxSessionLauncher {
     return quotedCommand(["python3", "-c", program, remotePath]) + " 2>/dev/null || true"
   }
 
+  /// Claude Code's twin of the Copilot seed above (`remoteEnsureInvocation`): a fresh
+  /// unattended `claude` stops on its first-run trust dialog and exits 1 when nobody
+  /// answers (issue #215), and the only record of the answer is
+  /// `projects[<path>].hasTrustDialogAccepted = true` in `~/.claude.json` — the same
+  /// consent the human gave by pointing the loop there. Plain JSON, no comment header,
+  /// and `~/.claude.json` already exists on any host Claude Code has been used on, so
+  /// the seed reads, adds the one key, writes back — additive and idempotent, a path
+  /// argument rather than interpolation, and `|| true` for the same reason: a failed
+  /// seed falls back to the dialog, answerable by opening the loop.
+  static func claudeTrustSeedScript(forRemotePath remotePath: String) -> String {
+    let program =
+      "import json,os,sys; p=os.path.expanduser('~/.claude.json'); "
+      + "c=json.load(open(p)) if os.path.exists(p) and open(p).read(1) else {}; "
+      + "e=c.setdefault('projects',{}).setdefault(sys.argv[1],{}); "
+      + "(e.get('hasTrustDialogAccepted') is True) or e.update(hasTrustDialogAccepted=True); "
+      + "open(p,'w').write(json.dumps(c))"
+    return quotedCommand(["python3", "-c", program, remotePath]) + " 2>/dev/null || true"
+  }
+
   /// One argv as one shell-safe string — each argument quoted, so a prompt containing
   /// quotes, `$(…)`, or `;` stays one word through the remote shell exactly as it does
   /// through zmx's own quoting locally. Public because the app's remote *attach* is
@@ -1135,8 +1230,11 @@ public enum ZmxSessionLauncher {
   /// The remote twin of the local text-then-Enter delivery, in one ssh round-trip:
   /// type, give the composer its beat, then the Enter as its own keystroke — the same
   /// paste-heuristic dance the local path does, run on the host that owns the session.
-  /// `zmx send` into a session that doesn't exist exits non-zero, so a dead remote
-  /// loop reports failure and the caller stages the message, exactly like local.
+  /// `zmx send` into a session that doesn't exist exits non-zero — but into a session
+  /// whose *task* has ended it exits 0, typing the message at the husk's shell prompt
+  /// and reporting a delivery nobody received (#215). So the whole delivery is gated on
+  /// the same alive check the remote ensure uses, and a dead remote loop reports
+  /// failure and the caller stages the message, exactly like local.
   static func remoteSendInvocation(
     _ text: String, toNode node: LoopNode, at location: RemoteProjectLocation
   ) -> [String] {
@@ -1151,7 +1249,9 @@ public enum ZmxSessionLauncher {
     let clearCodexPresence =
       node.backend == .codex
       ? " && " + quotedCommand(["zmx", "set", sessionName, "presence="]) : ""
-    let script = "\(sends) && sleep 0.4 && \(submit)\(clearCodexPresence)"
+    let script =
+      aliveCheckCommand(zmxPath: "zmx", forNode: node)
+      + " >/dev/null 2>&1 && { \(sends) && sleep 0.4 && \(submit)\(clearCodexPresence); }"
     return location.sshInvocation(remoteCommand: location.remoteLoginShellCommand(script))
   }
 
@@ -1314,14 +1414,18 @@ public enum ZmxSessionLauncher {
     guard ZmxLocator.isInstalled else { return }
 
     let zmxPath = ZmxLocator.binaryURL.path
-    let checkArgs = existenceCheckArguments(forNode: node)
+    let aliveCheck = aliveCheckCommand(zmxPath: zmxPath, forNode: node)
     let wd = workingDirectory(forNode: node, projectPath: projectPath)
 
-    // Same atomic check-or-create as the remote path (`remoteEnsureInvocation`):
-    // `zmx get` and `zmx run` in one shell, joined by `||`, so the app's own
+    // Same atomic check-or-create as the remote path (`remoteEnsureInvocation`): an
+    // alive-check and `zmx run` in one shell, joined by `||`, so the app's own
     // `zmx attach` cannot slip in between and create the session first. Without
     // this, a `zmx run` that loses the race types the entire launch command into
     // the now-live agent's input — the `/bin/zsh -i` leak in the Copilot input bar.
+    // The check is husk-aware (`aliveCheckCommand`): a session whose task ended is
+    // no session a keystroke can reach, so the run branch relaunches it — this is
+    // what lets an ensure, a send, or the sweep wake a loop that died unattended
+    // (issue #215), which a `zmx get` check could never do.
     let sessionID: String? =
       SessionIDStore.load(forNodeID: node.id)
       ?? {
@@ -1340,30 +1444,35 @@ public enum ZmxSessionLauncher {
         forNode: node, sessionID: sessionID, projectPath: projectPath)
     {
       await atomicCheckOrRun(
-        checkArguments: checkArgs, runArguments: resumeArgs,
+        checkCommand: aliveCheck, runArguments: resumeArgs,
         zmxPath: zmxPath, workingDirectory: wd,
         logFragment: DialLog.fragment(session: name, dial: "ensure", event: "resume"))
       // `zmx run -d` reports that the *session* exists, not that what it launched
       // survived: `claude --resume` against a transcript its retention expired dies
-      // within a second, taking the session with it, and the ensure returns 0 having
-      // achieved nothing. Nothing else notices — the card keeps saying `running` while
+      // within a second — and the wrapper shell it was typed with stays behind, a
+      // husk that answers `zmx get` — so the ensure returns 0 having achieved
+      // nothing. Nothing else notices — the card keeps saying `running` while
       // the loop is gone, and the next ensure retries the same dead ID, because
       // (unlike the remote path) the local one never consumed it. So look again, and
       // only if the session really failed to survive is the ID treated as dead: it is
       // dropped and the fresh launch runs. A resume that took is left alone, and its
       // `SessionStart` hook has already rebanked the same ID.
-      guard
-        await sessionDiedImmediately(
-          checkArguments: checkArgs, zmxPath: zmxPath, workingDirectory: wd)
-      else { return }
+      guard await sessionDiedImmediately(node: node) else { return }
       DialLog.record(session: name, dial: "ensure", event: "resume-dead")
       SessionIDStore.remove(forNodeID: node.id)
     }
     // The local half of the trust seed the remote ensure has always done: without it a
     // fresh unattended Copilot parks its opening prompt behind the folder-trust dialog
     // and swallows anything typed at it — the first pass included (`CopilotTrust`).
-    if node.backend == .copilotCLI, let directory = wd {
-      CopilotTrust.ensureTrusted(directory: directory)
+    // Claude Code has its own first-run dialog of the same shape ("Is this a project you
+    // created or one you trust?"), which a fresh unattended `claude` exits 1 on — same
+    // seed, its own config file (`ClaudeCodeTrust`, issue #215).
+    if let directory = wd {
+      switch node.backend {
+      case .copilotCLI: CopilotTrust.ensureTrusted(directory: directory)
+      case .claudeCode: ClaudeCodeTrust.ensureTrusted(directory: directory)
+      case .codex, .openCode: break
+      }
     }
     // Noted *before* the launch: the first pass below waits for a Copilot session
     // directory that was not already there, which is how it tells a session it just
@@ -1372,7 +1481,7 @@ public enum ZmxSessionLauncher {
       firstPassMessage(for: node) != nil
       ? CopilotSessionLog.directory(forSessionNamed: name)?.lastPathComponent : nil
     await atomicCheckOrRun(
-      checkArguments: checkArgs, runArguments: runArgs,
+      checkCommand: aliveCheck, runArguments: runArgs,
       zmxPath: zmxPath, workingDirectory: wd,
       logFragment: DialLog.fragment(session: name, dial: "ensure", event: "fresh"))
     await kickOffFirstPass(
@@ -1551,28 +1660,30 @@ public enum ZmxSessionLauncher {
   /// (`GhosttyTerminalView.localResumeOrFreshCommand`).
   public static let resumeSettleSeconds: UInt64 = 5
 
-  private static func sessionDiedImmediately(
-    checkArguments: [String], zmxPath: String, workingDirectory: String?
-  ) async -> Bool {
+  /// A resume that failed is not always a session that vanished: `claude --resume`
+  /// against a dead transcript exits, and the wrapper shell `zmx run` typed it with
+  /// stays at its prompt — a husk that answers `zmx get` and once read as a resume that
+  /// took. Judged by `sessionTaskState`, so both the vanished session and the husk
+  /// count as the death they are.
+  private static func sessionDiedImmediately(node: LoopNode) async -> Bool {
     try? await Task.sleep(for: .seconds(resumeSettleSeconds))
-    guard
-      let session = try? PTYProcessSession(
-        executable: zmxPath, arguments: checkArguments, workingDirectory: workingDirectory)
-    else { return false }
-    return await session.waitUntilFinished() == false
+    return await sessionTaskState(node) != .alive
   }
 
   /// `logFragment` rides inside the run branch, so an ensure whose check found the
   /// session alive records nothing — the dial log holds decisions, not ticks.
+  ///
+  /// The check is the alive command (`aliveCheckCommand`), not raw existence: a session
+  /// whose task has ended must fall through to the run, or a dead loop could never be
+  /// woken — the husk answered every `zmx get` (#215).
   private static func atomicCheckOrRun(
-    checkArguments: [String], runArguments: [String],
+    checkCommand: String, runArguments: [String],
     zmxPath: String, workingDirectory: String?, logFragment: String? = nil
   ) async {
-    let check = quotedCommand([zmxPath] + checkArguments)
     let run = quotedCommand([zmxPath] + runArguments)
     let script =
-      logFragment.map { "\(check) >/dev/null 2>&1 || { \($0); \(run); }" }
-      ?? "\(check) >/dev/null 2>&1 || \(run)"
+      logFragment.map { "\(checkCommand) >/dev/null 2>&1 || { \($0); \(run); }" }
+      ?? "\(checkCommand) >/dev/null 2>&1 || \(run)"
     guard
       let session = try? PTYProcessSession(
         executable: "/bin/zsh", arguments: ["-c", script],

--- a/graphcode/Tests/ClaudeCodeTrustTests.swift
+++ b/graphcode/Tests/ClaudeCodeTrustTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import GraphcodeKit
+
+/// Seeding Claude Code's folder trust so an unattended session never parks at its
+/// first-run "Is this a project you created or one you trust?" dialog — the dialog a
+/// fresh unattended `claude` answers by exiting 1, taking the loop's opening pass with
+/// it (issue #215). The answer lives only as `projects[<path>].hasTrustDialogAccepted`
+/// in `~/.claude.json`, a file Claude Code rewrites constantly, so the seed must be
+/// additive and never clobbering.
+@Suite
+struct ClaudeCodeTrustTests {
+  private func temporaryConfig(_ contents: String?) -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathComponent(".claude.json")
+    if let contents {
+      try? FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try? Data(contents.utf8).write(to: url)
+    }
+    return url
+  }
+
+  @Test
+  func aRealConfigGainsTheTrustEntryAndKeepsEverythingElse() throws {
+    // The real file holds projects with many keys each, plus top-level state. The seed
+    // adds one key to one project and touches nothing else.
+    let url = temporaryConfig(
+      """
+      {"numStartups":9,"projects":{"/tmp/other":{"allowedTools":["Bash"],"hasTrustDialogAccepted":true}},"tipsHistory":{"a":[1]}}
+      """)
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    ClaudeCodeTrust.ensureTrusted(directory: "/tmp/project", configURL: url)
+
+    let written = try String(contentsOf: url, encoding: .utf8)
+    let config = try #require(
+      JSONSerialization.jsonObject(with: Data(written.utf8)) as? [String: Any])
+    let projects = try #require(config["projects"] as? [String: Any])
+    let other = try #require(projects["/tmp/other"] as? [String: Any])
+    let seeded = try #require(projects["/tmp/project"] as? [String: Any])
+    #expect(other["hasTrustDialogAccepted"] as? Bool == true)
+    #expect(seeded["hasTrustDialogAccepted"] as? Bool == true)
+    #expect(config["numStartups"] as? Int == 9)
+  }
+
+  @Test
+  func aMissingConfigIsCreated() throws {
+    let url = temporaryConfig(nil)
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    ClaudeCodeTrust.ensureTrusted(directory: "/tmp/project", configURL: url)
+    let written = try String(contentsOf: url, encoding: .utf8)
+    let config = try #require(
+      JSONSerialization.jsonObject(with: Data(written.utf8)) as? [String: Any])
+    let projects = try #require(config["projects"] as? [String: Any])
+    #expect(projects.count == 1)
+  }
+
+  /// Additive and idempotent: a directory already trusted changes nothing, so the seed
+  /// can run on every launch without churning a file Claude Code is itself rewriting.
+  @Test
+  func anAlreadyTrustedDirectoryLeavesTheFileUntouched() throws {
+    let url = temporaryConfig(
+      #"{"projects":{"/tmp/project":{"hasTrustDialogAccepted":true,"allowedTools":[]}}}"#)
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    let before = try Data(contentsOf: url)
+    ClaudeCodeTrust.ensureTrusted(directory: "/tmp/project", configURL: url)
+    #expect(try Data(contentsOf: url) == before)
+  }
+
+  /// A config it cannot parse is left exactly as found — the dialog is a recoverable
+  /// failure, a clobbered `~/.claude.json` (prompt history, per-project state) is not.
+  @Test
+  func garbageIsLeftExactlyAsFound() throws {
+    let url = temporaryConfig("{not json at all")
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    ClaudeCodeTrust.ensureTrusted(directory: "/tmp/project", configURL: url)
+    #expect(try String(contentsOf: url, encoding: .utf8) == "{not json at all")
+  }
+
+  @Test
+  func anEmptyDirectoryIsNeverWritten() throws {
+    let url = temporaryConfig(#"{"projects":{}}"#)
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    let before = try Data(contentsOf: url)
+    ClaudeCodeTrust.ensureTrusted(directory: "", configURL: url)
+    #expect(try Data(contentsOf: url) == before)
+  }
+}

--- a/graphcode/Tests/DialLogTests.swift
+++ b/graphcode/Tests/DialLogTests.swift
@@ -90,8 +90,8 @@ struct DialLogTests {
     let remoteCommand = try #require(invocation.last)
     #expect(remoteCommand.contains("ensure resume"))
     #expect(remoteCommand.contains("ensure fresh"))
-    // Both live behind the existence check: a healthy sweep tick logs nothing.
-    let check = try #require(remoteCommand.range(of: "'get'"))
+    // Both live behind the alive check: a healthy sweep tick logs nothing.
+    let check = try #require(remoteCommand.range(of: "ls 2>/dev/null"))
     let resume = try #require(remoteCommand.range(of: "ensure resume"))
     #expect(check.upperBound <= resume.lowerBound)
   }

--- a/graphcode/Tests/PresenceReportingTests.swift
+++ b/graphcode/Tests/PresenceReportingTests.swift
@@ -314,7 +314,47 @@ struct PresenceReportingTests {
 
   @Test
   func aVanishedSessionIsNotWorkEither() {
+    // Within the boot grace a young loop's first poll can legitimately find no session
+    // — the ensure is fired, not awaited — so it reads as quiet, not dead.
     #expect(node(.running, .absent).displayState == .idle)
+  }
+
+  @Test
+  func aGoneSessionOnAnUnattendedLoopPastTheGraceIsFailed() {
+    // Issue #215: a goal loop whose agent exited on its first turn showed IDLE — the
+    // one word it must not show, since nothing is waiting for work. Past the boot
+    // grace, `absent` is a session that died unattended, and FAILED is the word the
+    // graph would have used had anyone seen the exit.
+    let dead = LoopNode(
+      title: "Fix the top crash", loopType: .goalBased,
+      goal: GoalSpec(summary: "Crash rate under 1%"),
+      presence: PresenceReading(presence: .absent, confidence: .reported), state: .running,
+      createdAt: Date().addingTimeInterval(-LoopNode.absentSessionGraceSeconds - 5))
+    #expect(dead.displayState == .failed)
+  }
+
+  @Test
+  func anAttendedLoopWithAGoneSessionStaysIdle() {
+    // A turn-based loop is a human's session — the pane they open is where its exit
+    // shows; the presence poll does not overrule that.
+    let attended = LoopNode(
+      title: "Sketch", loopType: .turnBased, triggerPrompt: "hi",
+      presence: PresenceReading(presence: .absent, confidence: .reported), state: .running,
+      createdAt: Date().addingTimeInterval(-LoopNode.absentSessionGraceSeconds - 5))
+    #expect(attended.displayState == .idle)
+  }
+
+  @Test
+  func aLoopOthersWaitOnShowsWaitingEvenWhenGone() {
+    // The waiting word is about the dependents, whose edges are the graph's business.
+    let dead = LoopNode(
+      title: "Fix the top crash", loopType: .goalBased,
+      goal: GoalSpec(summary: "Crash rate under 1%"),
+      presence: PresenceReading(presence: .absent, confidence: .reported), state: .running,
+      createdAt: Date().addingTimeInterval(-LoopNode.absentSessionGraceSeconds - 5))
+    var waiting = dead
+    waiting.hasActiveDependents = true
+    #expect(waiting.displayState == .waiting)
   }
 
   @Test

--- a/graphcode/Tests/RemoteSessionLaunchTests.swift
+++ b/graphcode/Tests/RemoteSessionLaunchTests.swift
@@ -21,14 +21,18 @@ struct RemoteSessionLaunchTests {
     #expect(invocation.first == "/usr/bin/ssh")
     let remoteCommand = try #require(invocation.last)
     // Login shell for the remote PATH, cd into the repository, then the create-only
-    // pair: `zmx get || zmx run`, detached, under the same session name the app
+    // pair: the alive check `|| zmx run`, detached, under the same session name the app
     // attaches to. The whole script is single-quote wrapped by the login-shell layer,
     // so assertions here are on content, not exact escaping —
     // `hostileTextSurvivesShellQuoting` pins the escaping itself.
     #expect(remoteCommand.hasPrefix("exec zsh -l -i -c '"))
     #expect(remoteCommand.contains("cd "))
     #expect(remoteCommand.contains("/home/dev/widget"))
-    #expect(remoteCommand.contains("'get'"))
+    #expect(remoteCommand.contains("ls 2>/dev/null"))
+    // The check is husk-aware (#215): a session whose task has ended must fail it, or
+    // a dead loop could never be woken — the husk is the session that check asks about.
+    #expect(remoteCommand.contains("ended="))
+    #expect(remoteCommand.contains("err="))
     #expect(remoteCommand.contains("||"))
     #expect(remoteCommand.contains("run"))
     #expect(
@@ -39,9 +43,9 @@ struct RemoteSessionLaunchTests {
     // round-trips here was the composer bug — the app's attach created the session in
     // the seconds between them, and the daemon's late `zmx run` typed the entire
     // launch command into the live agent's input bar.
-    let get = try #require(remoteCommand.range(of: "'get'"))
+    let check = try #require(remoteCommand.range(of: "ls 2>/dev/null"))
     let run = try #require(remoteCommand.range(of: "'run'"))
-    #expect(get.lowerBound < run.lowerBound)
+    #expect(check.lowerBound < run.lowerBound)
   }
 
   @Test
@@ -63,26 +67,31 @@ struct RemoteSessionLaunchTests {
     // the launch.
     #expect(remoteCommand.contains("|| true"))
     // And the seed runs before the launch it clears the way for — but *behind* the
-    // existence check, which is what keeps the liveness sweep's healthy tick a bare
-    // `zmx get` rather than a `python3` per minute against an already-trusted folder.
-    let get = try #require(remoteCommand.range(of: "'get'"))
+    // alive check, which is what keeps the liveness sweep's healthy tick a bare
+    // `zmx ls` rather than a `python3` per minute against an already-trusted folder.
+    let check = try #require(remoteCommand.range(of: "ls 2>/dev/null"))
     let seed = try #require(remoteCommand.range(of: "trustedFolders"))
     let run = try #require(remoteCommand.range(of: "'run'"))
-    #expect(get.lowerBound < seed.lowerBound)
+    #expect(check.lowerBound < seed.lowerBound)
     #expect(seed.lowerBound < run.lowerBound)
   }
 
   @Test
-  func aRemoteClaudeLaunchIsUntouchedByTrustSeeding() throws {
-    // The seed is Copilot-scoped: Claude's remote script must not carry it. (python3
-    // itself now appears for every backend — the delivery fragment rides on it.)
+  func aRemoteClaudeLaunchSeedsItsOwnTrustAndNeverCopilots() throws {
+    // Claude Code has its own first-run trust dialog, which a fresh unattended `claude`
+    // answers by exiting 1 (#215) — so the ensure carries Claude's seed too, its own
+    // `~/.claude.json` shape, never Copilot's.
     let node = LoopNode(
-      title: "Fix", loopType: .goalBased, goal: GoalSpec(summary: "tests pass"))
+      title: "Fix", loopType: .goalBased, goal: GoalSpec(summary: "tests pass"),
+      backend: .claudeCode)
     let invocation = try #require(
       ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location))
     let remoteCommand = try #require(invocation.last)
 
+    #expect(remoteCommand.contains("hasTrustDialogAccepted"))
+    #expect(remoteCommand.contains(".claude.json"))
     #expect(!remoteCommand.contains("trustedFolders"))
+    #expect(remoteCommand.contains("|| true"))
   }
 
   @Test
@@ -183,10 +192,10 @@ struct RemoteSessionLaunchTests {
     // Never load-bearing: a failed delivery degrades to an unbriefed session, not a
     // blocked launch.
     #expect(remoteCommand.contains("|| true"))
-    let get = try #require(remoteCommand.range(of: "'get'"))
+    let check = try #require(remoteCommand.range(of: "ls 2>/dev/null"))
     let deliver = try #require(remoteCommand.range(of: "b64decode"))
     let run = try #require(remoteCommand.range(of: "'run'"))
-    #expect(get.lowerBound < deliver.lowerBound)
+    #expect(check.lowerBound < deliver.lowerBound)
     #expect(deliver.lowerBound < run.lowerBound)
   }
 

--- a/graphcode/Tests/RemoteSessionResumeTests.swift
+++ b/graphcode/Tests/RemoteSessionResumeTests.swift
@@ -241,19 +241,21 @@ struct RemoteSessionResumeTests {
   }
 
   @Test
-  func theExistenceCheckStillGuardsBothBranches() throws {
+  func theAliveCheckStillGuardsBothBranches() throws {
     // The create-only property the one-shell ensure exists for: a live session must not
-    // be relaunched *or* resumed. Both are behind the same `zmx get`.
+    // be relaunched *or* resumed. Both are behind the same alive check — which, unlike
+    // raw existence, a husk does not pass (#215): a session whose task has ended has to
+    // fall through to the run, or a dead loop could never be woken.
     let node = goalNode()
     let invocation = try #require(
       ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location))
     let remoteCommand = try #require(invocation.last)
 
-    let get = try #require(remoteCommand.range(of: "'get'"))
+    let check = try #require(remoteCommand.range(of: "ls 2>/dev/null"))
     let resume = try #require(remoteCommand.range(of: "--resume"))
     let run = try #require(remoteCommand.range(of: "'run'"))
-    #expect(get.lowerBound < resume.lowerBound)
-    #expect(get.lowerBound < run.lowerBound)
+    #expect(check.lowerBound < resume.lowerBound)
+    #expect(check.lowerBound < run.lowerBound)
     #expect(remoteCommand.contains("||"))
   }
 
@@ -303,9 +305,9 @@ struct RemoteSessionResumeTests {
     #expect(remoteCommand.contains(".history"))
     #expect(remoteCommand.contains("[ -s"))
     #expect(remoteCommand.contains("bank copilot-id"))
-    // The bank rides the alive branch: behind the existence check, before the create —
+    // The bank rides the alive branch: behind the alive check, before the create —
     // and it must always exit 0, or an alive tick would fall into the create branch.
-    let check = try #require(remoteCommand.range(of: "'get'"))
+    let check = try #require(remoteCommand.range(of: "ls 2>/dev/null"))
     let bank = try #require(remoteCommand.range(of: "session-state"))
     let run = try #require(remoteCommand.range(of: "'run'"))
     #expect(check.upperBound <= bank.lowerBound)

--- a/graphcode/Tests/RespawnOnSendTests.swift
+++ b/graphcode/Tests/RespawnOnSendTests.swift
@@ -1,0 +1,108 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+/// `node send` to a loop whose session died unattended. Before issue #215's fix the
+/// send either lied — a husked session answered every existence check, so "delivered"
+/// typed into a dead PTY — or staged the message to a memory that a dead loop has no
+/// way to wake and read. Now the failed delivery is the moment the store revives the
+/// loop: the ensure is create-only and husk-aware, so it relaunches exactly the dead
+/// case, and the retry lands the message.
+@Suite
+struct RespawnOnSendTests {
+  private func graph(state: LoopState) -> LoopGraph {
+    LoopGraph(
+      project: ProjectRef(path: "/tmp/respawn", name: "respawn"),
+      nodes: [
+        LoopNode(
+          title: "Worker", loopType: .goalBased,
+          goal: GoalSpec(summary: "work"), state: state)
+      ])
+  }
+
+  @Test
+  func aFailedDeliveryToAnUnattendedLoopRespawnsAndRetries() async {
+    let deliveries = LockIsolated(0)
+    let ensured = LockIsolated(0)
+    let remembered = LockIsolated<[String]>([])
+    let graph = graph(state: .running)
+    let store = GraphStore(
+      graph: graph,
+      onEnsureSession: { _, _ in ensured.withValue { $0 += 1 } },
+      onDeliverMessage: { _, _, _ in
+        // First attempt: the session is a husk — the gate refuses it. Second: relaunched.
+        deliveries.withValue { $0 += 1 }
+        return deliveries.value > 1
+      },
+      onAppendMemory: { _, entry in remembered.withValue { $0.append(entry) } })
+    let nodeID = graph.nodes[0].id
+
+    await store.handle(.messageNode(nodeID, text: "wake up", from: nil, followUp: nil))
+
+    #expect(deliveries.value == 2)
+    #expect(ensured.value == 1)
+    #expect(remembered.value.isEmpty)
+  }
+
+  @Test
+  func aDeliveryThatStillFailsAfterRespawnIsStaged() async {
+    let deliveries = LockIsolated(0)
+    let remembered = LockIsolated<[String]>([])
+    let graph = graph(state: .running)
+    let store = GraphStore(
+      graph: graph,
+      onEnsureSession: { _, _ in },
+      onDeliverMessage: { _, _, _ in
+        deliveries.withValue { $0 += 1 }
+        return false
+      },
+      onAppendMemory: { _, entry in remembered.withValue { $0.append(entry) } })
+    let nodeID = graph.nodes[0].id
+
+    await store.handle(.messageNode(nodeID, text: "wake up", from: nil, followUp: nil))
+
+    #expect(deliveries.value == 2)
+    #expect(remembered.value.contains { $0.contains("while you were away") })
+  }
+
+  @Test
+  func anAttendedLoopIsNeverRespawnedByAMessage() async {
+    // A turn-based session is a human's: the human opening it is what starts it, and a
+    // message arriving must not spawn work the graph says waits for a person.
+    let deliveries = LockIsolated(0)
+    let ensured = LockIsolated(0)
+    var graph = graph(state: .running)
+    graph.nodes[0].loopType = .turnBased
+    let store = GraphStore(
+      graph: graph,
+      onEnsureSession: { _, _ in ensured.withValue { $0 += 1 } },
+      onDeliverMessage: { _, _, _ in
+        deliveries.withValue { $0 += 1 }
+        return false
+      },
+      onAppendMemory: { _, _ in })
+    let nodeID = graph.nodes[0].id
+
+    await store.handle(.messageNode(nodeID, text: "wake up", from: nil, followUp: nil))
+
+    #expect(deliveries.value == 1)
+    #expect(ensured.value == 0)
+  }
+
+  @Test
+  func aResolvedLoopIsNotRespawned() async {
+    let ensured = LockIsolated(0)
+    let graph = graph(state: .succeeded)
+    let store = GraphStore(
+      graph: graph,
+      onEnsureSession: { _, _ in ensured.withValue { $0 += 1 } },
+      onDeliverMessage: { _, _, _ in false },
+      onAppendMemory: { _, _ in })
+    let nodeID = graph.nodes[0].id
+
+    await store.handle(.messageNode(nodeID, text: "wake up", from: nil, followUp: nil))
+
+    #expect(ensured.value == 0)
+  }
+}

--- a/graphcode/Tests/ZmxSessionLauncherTests.swift
+++ b/graphcode/Tests/ZmxSessionLauncherTests.swift
@@ -119,6 +119,123 @@ struct ZmxSessionLauncherTests {
     #expect(check.last == ZmxSessionLauncher.arguments(forNode: node)?[1])
   }
 
+  // MARK: - Husk-aware session state (issue #215)
+
+  // A session whose task has ended is not a session a keystroke can reach: `zmx run`'s
+  // wrapper shell stays at its prompt, so the session answers `zmx get` forever and a
+  // send into it "succeeds" — the "delivered" that no one received. Every gate now
+  // judges the task inside, read off the `zmx ls` line zmx prints for the session.
+
+  private func lsLine(name: String, fields: String = "") -> String {
+    "name=\(name)\tpid=4242\tclients=0\tcreated=1756400000\(fields)"
+  }
+
+  @Test
+  func aLiveTaskIsAlive() {
+    let output = lsLine(name: "graphcode-a") + "\tpresence=idle activity=editing Foo.swift\n"
+    #expect(
+      ZmxSessionLauncher.parseSessionTaskState(lsOutput: output, sessionName: "graphcode-a")
+        == .alive)
+  }
+
+  @Test
+  func anEndedTaskIsExitedWithZmxCaughtExitCode() {
+    // The shape `zmx ls` prints for a completed task: `ended=<ts>\texit_code=<n>`.
+    let output = lsLine(name: "graphcode-a", fields: "\tended=1756400100\texit_code=1")
+    #expect(
+      ZmxSessionLauncher.parseSessionTaskState(lsOutput: output, sessionName: "graphcode-a")
+        == .exited(exitCode: 1))
+  }
+
+  @Test
+  func anEndedTaskWithNoExitCodeIsStillExited() {
+    let output = lsLine(name: "graphcode-a", fields: "\tended=1756400100")
+    #expect(
+      ZmxSessionLauncher.parseSessionTaskState(lsOutput: output, sessionName: "graphcode-a")
+        == .exited(exitCode: nil))
+  }
+
+  @Test
+  func aMissingRowIsAbsent() {
+    #expect(
+      ZmxSessionLauncher.parseSessionTaskState(lsOutput: "", sessionName: "graphcode-a")
+        == .absent)
+    #expect(
+      ZmxSessionLauncher.parseSessionTaskState(
+        lsOutput: lsLine(name: "graphcode-b") + "\n", sessionName: "graphcode-a")
+        == .absent)
+  }
+
+  @Test
+  func anUnreachableSessionIsAbsentNotAlive() {
+    // zmx prints an error row for a session whose daemon it cannot reach — as good as
+    // gone, and never a reason to believe a keystroke would land.
+    let output = "name=graphcode-a\terr=ConnectionRefused\tstatus=cleaning up\n"
+    #expect(
+      ZmxSessionLauncher.parseSessionTaskState(lsOutput: output, sessionName: "graphcode-a")
+        == .absent)
+  }
+
+  @Test
+  func aSessionNameIsNeverFoundInsideAnotherSessionsName() {
+    // Substring matching would read `graphcode-a` alive while only `graphcode-AB`
+    // exists — one loop wearing another's liveness.
+    let output = lsLine(name: "graphcode-AB") + "\n"
+    #expect(
+      ZmxSessionLauncher.parseSessionTaskState(lsOutput: output, sessionName: "graphcode-a")
+        == .absent)
+  }
+
+  @Test
+  func textThatMerelyContainsEndedDoesNotReadAsAHusk() {
+    // The `ended=` field is tab-preceded; a prompt or command that merely contains the
+    // text — no tab — must not turn a live session into a husk, or the ensure would
+    // re-type the launch command into a running agent.
+    let output =
+      lsLine(name: "graphcode-a", fields: "\tcmd=zmx run 'the report ended=ok'")
+      + "\tattached labels\n"
+    #expect(
+      ZmxSessionLauncher.parseSessionTaskState(lsOutput: output, sessionName: "graphcode-a")
+        == .alive)
+  }
+
+  @Test
+  func theShellAliveCheckFiltersHusksAndMatchesTheExactName() {
+    let node = Self.node(prompt: "/loop 1h Check")
+    let command = ZmxSessionLauncher.aliveCheckCommand(zmxPath: "/usr/local/bin/zmx", forNode: node)
+    let name = "graphcode-\(node.id.uuidString)"
+
+    // Husk rows (ended=) and error rows (err=) are filtered before the name is matched,
+    // and the name is matched tab-terminated so a prefix of another session's name
+    // cannot pass.
+    #expect(command.contains("ls 2>/dev/null"))
+    #expect(command.contains("grep -v -e $'\\tended=' -e $'\\terr='"))
+    #expect(command.contains("grep -q"))
+    #expect(command.contains("name=\(name)\t"))
+    #expect(command.contains("'/usr/local/bin/zmx'"))
+  }
+
+  @Test
+  func theRemoteSeedPreTrustsClaudeCodesFolder() {
+    // Issue #215's fix on the remote path: a fresh unattended `claude` exits 1 on its
+    // trust dialog, so the create branch seeds `hasTrustDialogAccepted` before it runs.
+    let node = LoopNode(
+      title: "Remote", loopType: .goalBased, goal: GoalSpec(summary: "work"),
+      backend: .claudeCode)
+    var remote = node
+    remote.backend = .copilotCLI
+    let location = RemoteProjectLocation(
+      host: "box", port: nil, remotePath: "/srv/repo", isCodespace: false)
+
+    let claude = ZmxSessionLauncher.remoteEnsureInvocation(forNode: node, at: location) ?? []
+    let script = claude.last ?? ""
+    #expect(script.contains("hasTrustDialogAccepted"))
+    #expect(script.contains("~/.claude.json"))
+
+    let copilot = ZmxSessionLauncher.remoteEnsureInvocation(forNode: remote, at: location) ?? []
+    #expect(!(copilot.last ?? "").contains("hasTrustDialogAccepted"))
+  }
+
   @Test
   func opensInTheProjectWhenTheNodeHasNoWorktree() {
     // `graphcoded`'s own directory is `/` under launchd, so falling through to nil ran


### PR DESCRIPTION
Fixes #215

## The bug, layer by layer

Creating a goal loop on a folder Claude Code had never opened killed the loop three ways at once, and each layer hid the one below it:

| Layer | What happened | What it looked like |
|---|---|---|
| **Death** | A fresh unattended `claude` stops on its first-run dialog — *"Quick safety check: Is this a project you created or one you trust?"* — and exits 1 because nobody is present to answer it. No launch flag covers it; the only record of the answer is `projects[<path>].hasTrustDialogAccepted` in `~/.claude.json` | `zmx history` ends with the dialog and `ZMX_TASK_COMPLETED:1` |
| **Silence** | `zmx run` types the command into a wrapper *shell*, which stays at its prompt after the command exits — the session survives as a husk. `zmx get <name>` (the existence check everywhere) exits 0 for a husk, presence read IDLE, and `node send` typed the message into the dead shell's prompt and reported **"delivered"** | `status` shows `idle`/`running`; sends claim success |
| **No wake** | The create-only ensure is `zmx get <name> \|\| zmx run …`. The husk *is* the session that check asks about, so it always passed — neither the send path, the load-time ensure, nor the remote liveness sweep could ever relaunch. Only `node delete` + `node create` worked | "cannot be woken" |

The Copilot backend had already solved layer one for itself (`CopilotTrust` + `copilotTrustSeedScript`) — this is the Claude Code twin plus the two layers Copilot never needed.

## The fixes

### 1. Trust seeding — the root cause (`ClaudeCodeTrust`, new)

Before launching `claude`, graphcode now pre-trusts the one directory the loop was pointed at — the same consent the human gave by creating the loop there — by setting `projects[<path>].hasTrustDialogAccepted = true` in `~/.claude.json`:

- **Local**: `ZmxSessionLauncher.start` seeds it for `.claudeCode` alongside Copilot's seed for `.copilotCLI`.
- **Remote**: `claudeTrustSeedScript(forRemotePath:)` — a python3 one-liner in the ensure's create branch, same posture as the Copilot seed: path rides as an argv (never interpolated), `2>/dev/null \|\| true` so a failed seed falls back to the dialog rather than blocking the launch.
- **Never clobbers**: `~/.claude.json` is plain JSON that Claude Code rewrites constantly. A config that can't parse is left exactly as found; the write is atomic and preserves the file's permissions (first write lands 0600); the run is idempotent (already-true → untouched).
- **Verified empirically** against a `HOME`-sandboxed run: missing config → created; existing config → additive (other projects and keys survive); re-run → no-op; corrupt file → error swallowed, file untouched.

With the seed in place the dialog never appears, which is what the issue reporter confirmed fixed their loop.

### 2. Husk-aware liveness — the recovery mechanism

The honest unit of liveness is the **task inside** the session, not the session record. zmx records the difference for us: a completed task prints `\tended=<ts>\texit_code=<n>` on its `zmx ls` row, and a session whose daemon is unreachable prints an `\terr=` row — a live task never prints either.

- `SessionTaskState` (`alive` / `exited(exitCode:)` / `absent`), parsed from the real `zmx ls` line shapes by `parseSessionTaskState` — name matched as a whole whitespace token (so `graphcode-A` is never found inside `graphcode-AB`'s line, or inside another session's activity label), `ended=`/`err=` matched tab-anchored so a prompt that merely *contains* the text can't read as a husk.
- `sessionExists` now means "task running" (same cost: one `zmx ls`, previously one `zmx get`) — which fixes the send gate, the presence probe, and the log-tail liveness checks in one move.
- `aliveCheckCommand` is the shell form of the same judgement: `zmx ls 2>/dev/null | grep -v -e $'\tended=' -e $'\terr=' | grep -q 'name=<session>\t'`. Both create-only ensures — local `atomicCheckOrRun` and the remote ensure — and the remote send's gate now use it. This is what makes a dead loop **wakeable**: the ensure's run branch finally falls through for a husk, and `zmx run` against the husk re-runs the agent in the same session (zmx resets `task_ended_at` on `handleRun` — verified in the daemon source).
- `sessionDiedImmediately` (the resume-settle check) now judges by task state too, so a `claude --resume` that dies into a husk is correctly treated as a dead resume and the fresh launch runs.

**Empirically verified** against the real zmx binary: live session → alive check exits 0; same session after its task exits (even with code 0) → `ended=` appears, check exits 1; missing session → exits 1; `zmx get` exits 0 for the husk throughout — the bug premise, confirmed.

### 3. Respawn on send (`GraphStore.deliverAdHocMessage`)

When delivery fails to an **unattended, unresolved** loop, the store now runs the ensure (create-only + husk-aware ⇒ relaunches exactly the dead case), waits 3s for the boot, and retries delivery once before staging to memory. This is the issue's second expectation — `node send` waking a dead loop — and it closes the staged-message black hole: a dead loop has no "next wake" to read staged messages at. Attended (turn-based) loops are deliberately excluded: a human opening the loop is what starts those, not a message arriving.

### 4. Surfacing the silent death (`LoopNode.displayState`)

A `.running` unattended loop whose presence reads `absent` past a 60-second boot grace now displays **FAILED** instead of IDLE — the graph would have recorded exactly that if anyone had seen the exit. The grace window covers the real race where the ensure is fired (not awaited) and a young node's first poll lands before its session exists; remote probes that fail in transport read `unknown`, not `absent`, so a slow ssh dial can't fake it. Attended loops stay IDLE (the pane is where their exit shows) and loops with active dependents keep `waiting` (that word is about the dependents' edges, not the session).

## Testing

- New: `ClaudeCodeTrustTests` (5 tests), `RespawnOnSendTests` (4), husk-parsing + seed coverage in `ZmxSessionLauncherTests` (8), absent-display coverage in `PresenceReportingTests` (3 new + grace keeps the existing one passing).
- Updated: the ensure-script suites that pinned the old `zmx get` check (`RemoteSessionLaunchTests`, `RemoteSessionResumeTests`, `DialLogTests`) to the alive check, including a new assertion that the Claude remote ensure carries its own seed and never Copilot's.
- Full suite: **1288 tests, 140 suites, all passing**; swiftlint/swift-format clean on all touched files (no new violations).

## Deliberately out of scope

`node send` respawning and the FAILED word are for goal/time loops — the thing `graphcoded` is responsible for keeping alive. Surfacing the exact exit code (`session exited (1)` as the issue words it) is parsed (`SessionTaskState.exited(exitCode:)` carries it) but not yet rendered anywhere; wiring it into the card text needs a Presence-vocabulary change with graph-JSON persistence implications, so I left it out of this fix rather than smuggle it in.