### PR TITLE
Stop the test suite popping the 'no application to open the URL' dialog

### DIFF
--- a/graphcode/Sources/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -145,6 +145,12 @@ final class GhosttyRuntime: @unchecked Sendable {
     return Unmanaged<GhosttyTerminalNSView>.fromOpaque(userdata).takeUnretainedValue()
   }
 
+  /// Who actually opens an intercepted link. Tests swap in a recorder so a URL no
+  /// application claims (the test-only `x-graphcode-test://` scheme) never reaches
+  /// LaunchServices — with the real opener, every `xcodebuild test` run popped the
+  /// "There is no application set to open the URL" dialog.
+  static var openURL: (URL) -> Void = { NSWorkspace.shared.open($0) }
+
   /// The one action graphcode handles: a ⌘-clicked link. Everything else returns
   /// false and libghostty's defaults apply — the same posture as before, just no
   /// longer for URLs, because who opens a link is where remote sign-ins are won.
@@ -184,7 +190,7 @@ final class GhosttyRuntime: @unchecked Sendable {
         Task { await RemoteAuthPortForwarder.shared.ensureForwarding(port: port, to: location) }
       }
     }
-    DispatchQueue.main.async { NSWorkspace.shared.open(url) }
+    DispatchQueue.main.async { Self.openURL(url) }
     return true
   }
 

--- a/graphcode/Tests/AuthPortForwardingTests.swift
+++ b/graphcode/Tests/AuthPortForwardingTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import GhosttyKit
 import GraphcodeKit
 import Testing
+import os
 
 @testable import graphcode
 
@@ -91,7 +92,7 @@ struct AuthPortForwardingTests {
   }
 
   @Test
-  func onlySchemeCarryingUnknownURLsAreIntercepted() {
+  func onlySchemeCarryingUnknownURLsAreIntercepted() async {
     // ⌘⇧-click on a local folder's surface must not regress: a clicked *file path*
     // (Ghostty hands over a bare absolute path for resolved links) and the
     // editor-opening scrollback kinds return false, so libghostty's own opener runs
@@ -99,9 +100,19 @@ struct AuthPortForwardingTests {
     #expect(!linkOpenHandled("/Users/dev/notes.txt"))
     #expect(!linkOpenHandled("https://example.com/dump", kind: GHOSTTY_ACTION_OPEN_URL_KIND_TEXT))
     #expect(!linkOpenHandled("https://example.com/dump", kind: GHOSTTY_ACTION_OPEN_URL_KIND_HTML))
-    // A real link is ours — the interception the forwarder rides on. A test-only
-    // scheme, so the open attempt resolves to no application.
+    // A real link is ours — the interception the forwarder rides on. The opener is a
+    // test recorder, so the URL lands in a list instead of LaunchServices: nothing
+    // claims this scheme, and the real opener popped the "no application set to open
+    // the URL" dialog on every test run.
+    let opened = OSAllocatedUnfairLock(initialState: [URL]())
+    let systemOpener = GhosttyRuntime.openURL
+    GhosttyRuntime.openURL = { url in opened.withLock { $0.append(url) } }
+    defer { GhosttyRuntime.openURL = systemOpener }
     #expect(linkOpenHandled("x-graphcode-test://sign-in"))
+    // The open is dispatched to the main queue; a sentinel enqueued after it runs
+    // once the recorded open has happened.
+    await MainActor.run {}
+    #expect(opened.withLock { $0 } == [URL(string: "x-graphcode-test://sign-in")!])
   }
 
   @Test


### PR DESCRIPTION
## Problem

Every `xcodebuild test` run popped a macOS dialog on the developer's machine:

> There is no application set to open the URL `x-graphcode-test://sign-in`.

## Root cause

`AuthPortForwardingTests.onlySchemeCarryingUnknownURLsAreIntercepted` drives `GhosttyRuntime.handleAction` with a real open-url action whose URL uses the unclaimed test-only scheme `x-graphcode-test`. `handleAction` handed every intercepted link straight to `NSWorkspace.shared.open`, so each test run sent that URL to LaunchServices, which popped the dialog. The test's own comment acknowledged the side effect ('the open attempt resolves to no application') — it was baked in, and recurred on every verification pass, including every graphcode worktree loop that runs the suite.

## Fix

- `GhosttyRuntime.openURL` is now an injectable closure, defaulting to the same `NSWorkspace.shared.open` — zero behavior change in the app.
- The test installs a recorder and asserts the intercepted URL reaches the opener (previously untestable), then restores the system opener.

## Verification

- `xcodebuild test` from a worktree: 1293 tests, TEST SUCCEEDED — and dialog-free.
- `swiftlint lint`: 0 serious (128 standing warnings, unchanged). `swift format lint` clean on both files.