### PR TITLE
Name the agent tab for the backend it is actually running (#255)

### DIFF
--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
@@ -219,7 +219,10 @@ struct LoopWorkspaceView: View {
       HStack(spacing: 4) {
         ForEach(Array(store.layout.tabs.enumerated()), id: \.element.id) { index, tab in
           TabPillView(
-            title: agentTabTitle(for: tab),
+            title: Self.agentTabTitle(
+              loopType: store.node.loopType,
+              backend: store.node.backend,
+              launchesAgent: tab.primary.launchesClaudeCode),
             // Only the agent tab has a loop state to report — a plain shell is a shell.
             // This is the fix for "a background tab asked a question and nothing said so".
             state: tab.surfaces.contains(where: \.launchesClaudeCode) ? store.node.state : nil,
@@ -264,15 +267,18 @@ struct LoopWorkspaceView: View {
   }
 
   /// An unattended loop's agent tab is labelled for what it's actually doing rather than
-  /// "Claude Code" — a time-based session is running its own `/loop`, a goal-based one is
-  /// working toward a stop condition, and that distinction is the one thing a glance at
-  /// the tab strip should tell you apart from a turn-based loop's session.
-  private func agentTabTitle(for tab: TabLayout) -> String {
-    guard tab.primary.launchesClaudeCode else { return "Shell" }
-    switch store.node.loopType {
+  /// for the CLI doing it — a time-based session is running its own `/loop`, a goal-based
+  /// one is working toward a stop condition, and that distinction is the one thing a
+  /// glance at the tab strip should tell you apart from an attended loop's session. Every
+  /// other type names its backend, which is only Claude Code when the loop chose it (#255).
+  static func agentTabTitle(loopType: LoopType, backend: CLISessionBackendKind, launchesAgent: Bool)
+    -> String
+  {
+    guard launchesAgent else { return "Shell" }
+    switch loopType {
     case .timeBased: return "Loop"
     case .goalBased: return "Goal"
-    case .sketch, .turnBased, .composite: return "Claude Code"
+    case .sketch, .turnBased, .composite: return backend.displayName
     }
   }
 

--- a/graphcode/Tests/AgentTabTitleTests.swift
+++ b/graphcode/Tests/AgentTabTitleTests.swift
@@ -1,0 +1,43 @@
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// What the agent tab in a loop's tab strip is called.
+///
+/// A rule rather than a view: the strip is what tells you at a glance whether a session
+/// is running its own cadence, working to a stop condition, or just sitting at a prompt —
+/// and, for that last case, which CLI is sitting there. It named Claude Code whatever the
+/// loop had actually chosen (#255), which is exactly the kind of thing no pixel test
+/// would have caught.
+@Suite
+struct AgentTabTitleTests {
+  private func title(
+    _ loopType: LoopType, _ backend: CLISessionBackendKind = .claudeCode, agent: Bool = true
+  ) -> String {
+    LoopWorkspaceView.agentTabTitle(loopType: loopType, backend: backend, launchesAgent: agent)
+  }
+
+  @Test
+  func anAttendedLoopNamesItsBackend() {
+    #expect(title(.sketch, .copilotCLI) == "Copilot CLI")
+    #expect(title(.turnBased, .codex) == "Codex")
+    #expect(title(.composite, .openCode) == "OpenCode")
+    #expect(title(.sketch, .claudeCode) == "Claude Code")
+  }
+
+  @Test
+  func anUnattendedLoopNamesWhatItIsDoingInstead() {
+    for backend in CLISessionBackendKind.allCases {
+      #expect(title(.timeBased, backend) == "Loop")
+      #expect(title(.goalBased, backend) == "Goal")
+    }
+  }
+
+  @Test
+  func aPlainShellPaneIsNeverNamedForABackend() {
+    for loopType in LoopType.allCases {
+      #expect(title(loopType, .copilotCLI, agent: false) == "Shell")
+    }
+  }
+}


### PR DESCRIPTION
Fixes #255.

## The bug

A Main loop's terminal tab was labelled **Claude Code** whatever backend the loop had actually been created with — Copilot CLI, Codex, or OpenCode.

## Cause

`LoopWorkspaceView.agentTabTitle` returned the string as a literal:

```swift
case .sketch, .turnBased, .composite: return "Claude Code"
```

`.timeBased` ("Loop") and `.goalBased` ("Goal") were unaffected only because they name what the session is *doing* rather than what is doing it — so the wrong name showed up on exactly the three attended types, Main among them.

The pane header two rows below it was already correct (`store.node.backend.displayName.lowercased()`), which is why the strip and the pane disagreed in the reporter's screenshot.

## The fix

Return `backend.displayName`. The rule moved from a private method on the view to a static one taking `(loopType, backend, launchesAgent)`, so which name a tab gets is assertable without a window — the previous shape could only have been caught by looking at it.

## Verification

| Check | Result |
|---|---|
| `xcodebuild test` | ✅ 1523 tests in 158 suites, up 3 |
| `swiftlint lint` | ✅ 0 errors |
| `swift format lint --strict` | ✅ clean |

New `AgentTabTitleTests` covers all four backends on the attended types, both unattended types across every backend, and a plain shell pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hEyiK8W9XW4Tq6je98kTX