### PR TITLE
Show close UX for terminal tabs and split panes; ⌘W ends the session (#254)

### DIFF
--- a/GraphcodeKit/Sources/Domain/TerminalLayout.swift
+++ b/GraphcodeKit/Sources/Domain/TerminalLayout.swift
@@ -297,15 +297,27 @@ public struct TerminalLayout: Codable, Equatable, Sendable {
     return TerminalLayout(tabs: [tab], selectedTabID: tab.id)
   }
 
-  /// The layout a node's workspace should open with: the saved one, unless it lost the
-  /// node's own surface — the agent pane every layout starts with — in which case the
-  /// default is used instead. A tab (or split pane) can be closed like any other now,
-  /// and a layout persisted without the agent surface would otherwise reopen a running
-  /// loop as shells-only, with its live session attached to nothing on screen.
+  /// The layout a node's workspace should open with: the saved one, with the node's own
+  /// surface — the agent pane every layout starts with — put back at the front if the
+  /// saved layout lost it. A tab (or split pane) can be closed like any other now, and a
+  /// layout persisted without the agent surface would otherwise reopen a running loop as
+  /// shells-only, with its live session attached to nothing on screen.
+  ///
+  /// Repaired rather than replaced: the shell tabs a saved layout carries have live zmx
+  /// sessions of their own, and dropping them from the layout would not end those
+  /// sessions — only hide them, which is the leak `killSessions` exists to close. The
+  /// only layout thrown away is the one that was never saved.
   public static func opening(forNode nodeID: UUID, saved: TerminalLayout?) -> TerminalLayout {
-    guard let saved,
-      saved.tabs.contains(where: { tab in tab.surfaces.contains { $0.id == nodeID } })
-    else { return .defaultLayout(forNode: nodeID) }
-    return saved
+    guard var layout = saved, !layout.tabs.isEmpty else { return .defaultLayout(forNode: nodeID) }
+    guard !layout.tabs.contains(where: { tab in tab.surfaces.contains { $0.id == nodeID } })
+    else { return layout }
+    let agentTab = TabLayout(primary: SurfaceRef(id: nodeID, launchesClaudeCode: true))
+    layout.tabs.insert(agentTab, at: 0)
+    // A selection naming a tab that is still here is the human's and stays theirs; one
+    // left dangling by whatever removed the agent tab lands on the tab just restored.
+    if layout.tabs[id: layout.selectedTabID] == nil {
+      layout.selectedTabID = agentTab.id
+    }
+    return layout
   }
 }

--- a/GraphcodeKit/Sources/Domain/TerminalLayout.swift
+++ b/GraphcodeKit/Sources/Domain/TerminalLayout.swift
@@ -277,6 +277,12 @@ public struct TerminalLayout: Codable, Equatable, Sendable {
   public var tabs: IdentifiedArrayOf<TabLayout>
   public var selectedTabID: UUID
 
+  /// The selected tab's focused pane — the one the keyboard is in, and the one ⌘W
+  /// closes. `nil` only when there are no tabs, which the workspace never allows.
+  public var focusedSurface: SurfaceRef? {
+    tabs[id: selectedTabID]?.focusedSurface
+  }
+
   public init(tabs: IdentifiedArrayOf<TabLayout>, selectedTabID: UUID) {
     self.tabs = tabs
     self.selectedTabID = selectedTabID
@@ -289,5 +295,17 @@ public struct TerminalLayout: Codable, Equatable, Sendable {
   public static func defaultLayout(forNode nodeID: UUID) -> TerminalLayout {
     let tab = TabLayout(primary: SurfaceRef(id: nodeID, launchesClaudeCode: true))
     return TerminalLayout(tabs: [tab], selectedTabID: tab.id)
+  }
+
+  /// The layout a node's workspace should open with: the saved one, unless it lost the
+  /// node's own surface — the agent pane every layout starts with — in which case the
+  /// default is used instead. A tab (or split pane) can be closed like any other now,
+  /// and a layout persisted without the agent surface would otherwise reopen a running
+  /// loop as shells-only, with its live session attached to nothing on screen.
+  public static func opening(forNode nodeID: UUID, saved: TerminalLayout?) -> TerminalLayout {
+    guard let saved,
+      saved.tabs.contains(where: { tab in tab.surfaces.contains { $0.id == nodeID } })
+    else { return .defaultLayout(forNode: nodeID) }
+    return saved
   }
 }

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -470,11 +470,14 @@ public enum ZmxSessionLauncher {
       + RemoteProjectLocation.shellQuoted("name=\(name)\t")
   }
 
-  /// Kills the session behind an id that isn't a graph node — a quick chat. Public
-  /// because chats are app-owned: no daemon deletes their sessions for them, the way
-  /// `GraphStore` does when a loop is deleted.
-  public static func killSession(id: UUID) async {
-    await kill(LoopNode(id: id, title: ""))
+  /// Kills the session behind an id that isn't a graph node — a quick chat, or a plain
+  /// shell pane the human closed. Public because both are app-owned: no daemon deletes
+  /// their sessions for them, the way `GraphStore` does when a loop is deleted.
+  /// `projectPath` routes a remote project's session to the kill that runs on its host;
+  /// a shell surface has no session id banked for it, so the bookkeeping `kill` does
+  /// alongside is all no-ops for it.
+  public static func killSession(id: UUID, projectPath: String? = nil) async {
+    await kill(LoopNode(id: id, title: ""), projectPath: projectPath)
   }
 
   static func kill(_ node: LoopNode, projectPath: String? = nil) async {

--- a/graphcode/Sources/Features/App/AppFeature+QuickChats.swift
+++ b/graphcode/Sources/Features/App/AppFeature+QuickChats.swift
@@ -109,7 +109,8 @@ extension AppFeature {
       loopType: .composite,
       backend: chat.backend,
       createdAt: chat.createdAt)
-    let layout = terminalLayoutStore.load(forNode: chat.id) ?? .defaultLayout(forNode: chat.id)
+    let layout = TerminalLayout.opening(
+      forNode: chat.id, saved: terminalLayoutStore.load(forNode: chat.id))
     state.openLoop = LoopWorkspaceFeature.State(
       node: node,
       layout: layout,

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -549,18 +549,21 @@ struct AppFeature {
             .graphCommand(projectPath: projectPath, command: command))
         }
 
-      // The keypress on the agent pane's "Press any key to close" screen. The session
-      // was already resolved when it exited (above) — this is the human dismissing what
-      // remains, so the workspace closes *and* the node leaves the graph. Deleting via
-      // the daemon rather than locally, the same way the sidebar's delete does: the
-      // resulting broadcast is what removes the card everywhere, and `GraphStore` also
-      // kills the loop's zmx session. Closed here as well rather than waiting for that
-      // broadcast, so the dead pane goes away even with the daemon unreachable.
-      case .openLoop(.primaryExitAcknowledged):
+      // Two roads to the same end, both the human dismissing what's left of a loop for
+      // good: the keypress on the agent pane's "Press any key to close." screen
+      // (`.primaryExitAcknowledged`), and closing the workspace's last tab
+      // (`.lastTabClosed`) — which for a running loop is the human ending it, exactly
+      // what the sidebar's delete does. The workspace closes *and* the node leaves the
+      // graph, session and all: deleting via the daemon rather than locally, the same
+      // way the sidebar's delete does — the resulting broadcast is what removes the card
+      // everywhere, and `GraphStore` also kills the loop's zmx session. Closed here as
+      // well rather than waiting for that broadcast, so the dead pane goes away even
+      // with the daemon unreachable. A chat, though, is not a node in any graph — there
+      // is nothing to delete, and the chat itself should outlive its session. Just put
+      // the dead terminal away.
+      case .openLoop(.primaryExitAcknowledged), .openLoop(.lastTabClosed):
         guard let id = state.openLoop?.node.id, let projectPath = state.openLoop?.projectPath
         else { return .none }
-        // A chat is not a node in any graph — there is nothing to delete, and the chat
-        // itself should outlive its session. Just put the dead terminal away.
         guard !state.isQuickChat(id) else {
           closeOpenWorkspace(&state)
           state.detailSelection = .quickChats
@@ -698,7 +701,8 @@ extension AppFeature {
         node: node, graph: state.projects[id: path]?.graph)
       return .none
     }
-    let layout = terminalLayoutStore.load(forNode: nodeID) ?? .defaultLayout(forNode: nodeID)
+    let layout = TerminalLayout.opening(
+      forNode: nodeID, saved: terminalLayoutStore.load(forNode: nodeID))
     state.openLoop = LoopWorkspaceFeature.State(
       node: node,
       graph: state.projects[id: path]?.graph ?? LoopGraph(scope: .global),
@@ -773,11 +777,21 @@ extension AppFeature {
   private func isGlobal(_ path: String) -> Bool { path == LoopGraphScope.globalPath }
 
   /// Closes the open workspace *and ends its terminals* — for when the loop itself is
-  /// gone, as opposed to merely not being the one on screen any more. Not `private`
+  /// going away, as opposed to merely not being the one on screen any more. Not `private`
   /// because a deleted chat needs the same treatment and lives in the other file.
+  ///
+  /// Ending the terminals is two halves: the surfaces are retired (the attach ends), and
+  /// the plain shells behind them are killed (#254) — nothing owns a shell once its
+  /// workspace is gone, and one left running is invisible until reboot. The agent
+  /// surface is deliberately not on the kill list: the loop's session belongs to the
+  /// node, and whichever side deletes the node ends it (`GraphStore` on the daemon's
+  /// path, `QuickChats` for a chat).
   func closeOpenWorkspace(_ state: inout State) {
     guard let openLoop = state.openLoop else { return }
-    terminalSurfaceClient.retire(openLoop.layout.tabs.flatMap { $0.surfaces.map(\.id) })
+    let surfaces = openLoop.layout.tabs.flatMap { $0.surfaces }
+    terminalSurfaceClient.retire(surfaces.map(\.id))
+    terminalSurfaceClient.killSessions(
+      surfaces.filter { !$0.launchesClaudeCode }.map(\.id), openLoop.projectPath)
     state.openLoop = nil
   }
 

--- a/graphcode/Sources/Features/App/AppFeature.swift
+++ b/graphcode/Sources/Features/App/AppFeature.swift
@@ -549,19 +549,16 @@ struct AppFeature {
             .graphCommand(projectPath: projectPath, command: command))
         }
 
-      // Two roads to the same end, both the human dismissing what's left of a loop for
-      // good: the keypress on the agent pane's "Press any key to close." screen
-      // (`.primaryExitAcknowledged`), and closing the workspace's last tab
-      // (`.lastTabClosed`) — which for a running loop is the human ending it, exactly
-      // what the sidebar's delete does. The workspace closes *and* the node leaves the
-      // graph, session and all: deleting via the daemon rather than locally, the same
-      // way the sidebar's delete does — the resulting broadcast is what removes the card
-      // everywhere, and `GraphStore` also kills the loop's zmx session. Closed here as
-      // well rather than waiting for that broadcast, so the dead pane goes away even
-      // with the daemon unreachable. A chat, though, is not a node in any graph — there
-      // is nothing to delete, and the chat itself should outlive its session. Just put
-      // the dead terminal away.
-      case .openLoop(.primaryExitAcknowledged), .openLoop(.lastTabClosed):
+      // The keypress on the agent pane's "Press any key to close." screen. The session
+      // was already resolved when it exited (above) — this is the human dismissing what
+      // remains, so the workspace closes *and* the node leaves the graph. Deleting via
+      // the daemon rather than locally, the same way the sidebar's delete does: the
+      // resulting broadcast is what removes the card everywhere, and `GraphStore` also
+      // kills the loop's zmx session. Closed here as well rather than waiting for that
+      // broadcast, so the dead pane goes away even with the daemon unreachable. A chat,
+      // though, is not a node in any graph — there is nothing to delete, and the chat
+      // itself should outlive its session. Just put the dead terminal away.
+      case .openLoop(.primaryExitAcknowledged):
         guard let id = state.openLoop?.node.id, let projectPath = state.openLoop?.projectPath
         else { return .none }
         guard !state.isQuickChat(id) else {
@@ -575,6 +572,19 @@ struct AppFeature {
           try? await orchestratorClient.send(
             .graphCommand(projectPath: projectPath, command: .deleteNode(id)))
         }
+
+      // Closing the workspace's last tab — by its x, by ⌘W, or by a plain shell simply
+      // exiting. There is nothing left to show, which for a loop means ending the loop,
+      // and unlike `.primaryExitAcknowledged` above the session may still be running:
+      // this is a live loop being thrown away by a keystroke every terminal on the
+      // machine binds to closing a tab. So it goes through the same "Delete Loop…"
+      // confirmation every other delete in the app does (`deleteNodeRequested`, whose
+      // dialog `AppView` hosts) rather than deleting behind the human's back. Confirming
+      // deletes through the daemon, and the broadcast that follows is what closes this
+      // workspace — see `.daemonEvent`. Cancelling leaves the tab exactly where it was,
+      // which is why `.tabClosed` retires nothing until the answer is in.
+      case .openLoop(.lastTabClosed):
+        return endOpenWorkspace(&state)
 
       case .openLoop(.stopLoopTapped):
         guard let id = state.openLoop?.node.id, let path = state.openLoop?.projectPath
@@ -775,6 +785,34 @@ extension AppFeature {
   /// workspace belonging to the removed project would otherwise stay on screen with
   /// nothing in the sidebar pointing at it.
   private func isGlobal(_ path: String) -> Bool { path == LoopGraphScope.globalPath }
+
+  /// The workspace's last tab going: nothing is left to show, which for a loop means
+  /// ending the loop. Put to the same "Delete Loop…" confirmation every other delete in
+  /// the app goes through (`deleteNodeRequested`, whose dialog `AppView` hosts) rather
+  /// than deleted outright — unlike `.primaryExitAcknowledged`, the session behind this
+  /// one may still be running, and ⌘W is a keystroke for closing a tab everywhere else
+  /// on the machine, not consent to throw a loop away. Confirming deletes through the
+  /// daemon and the broadcast that follows closes this workspace; cancelling leaves the
+  /// tab where it was, which is why `.tabClosed` retires nothing until the answer is in.
+  func endOpenWorkspace(_ state: inout State) -> Effect<Action> {
+    guard let id = state.openLoop?.node.id, let projectPath = state.openLoop?.projectPath
+    else { return .none }
+    // A chat is not a node in any graph: nothing to confirm and nothing to delete, and
+    // the chat itself outlives its session. Just put the terminal away.
+    guard !state.isQuickChat(id) else {
+      closeOpenWorkspace(&state)
+      state.detailSelection = .quickChats
+      return .none
+    }
+    // No project row means no graph holding this node and no dialog to present it —
+    // closing the workspace is all that is honestly available.
+    guard state.projects[id: projectPath] != nil else {
+      state.openLoop = nil
+      state.selectedProjectPath = projectPath
+      return .none
+    }
+    return .send(.projects(.element(id: projectPath, action: .deleteNodeRequested(id))))
+  }
 
   /// Closes the open workspace *and ends its terminals* — for when the loop itself is
   /// going away, as opposed to merely not being the one on screen any more. Not `private`

--- a/graphcode/Sources/Features/App/GraphcodeCommands.swift
+++ b/graphcode/Sources/Features/App/GraphcodeCommands.swift
@@ -87,9 +87,20 @@ struct GraphcodeCommands: Commands {
       Button("New Tab") { store.send(.openLoop(.newTabButtonTapped)) }
         .keyboardShortcut("t", modifiers: .command)
         .disabled(!hasWorkspace)
+      // ⌘W closes what the keyboard is in: the focused pane of a split, the tab when it
+      // isn't one — and, through the reducer, the workspace's last tab ends the loop
+      // itself. That last step is why it is never disabled here: there is always
+      // something ⌘W can close while a workspace is open (#254).
+      Button(closeTitle) {
+        guard let layout = store.openLoop?.layout, let focused = layout.focusedSurface
+        else { return }
+        store.send(.openLoop(.paneClosed(tabID: layout.selectedTabID, surfaceID: focused.id)))
+      }
+      .keyboardShortcut("w", modifiers: .command)
+      .disabled(!hasWorkspace)
       Button("Close Tab") { store.send(.openLoop(.tabClosed(selectedTabID))) }
-        .keyboardShortcut("w", modifiers: .command)
-        .disabled(!canCloseTab)
+        .keyboardShortcut("w", modifiers: [.command, .shift])
+        .disabled(!hasWorkspace)
 
       Divider()
 
@@ -134,9 +145,10 @@ struct GraphcodeCommands: Commands {
     (store.openLoop?.isRailVisible ?? false) ? "Hide Loop Panel" : "Show Loop Panel"
   }
 
-  /// A workspace always keeps at least one tab, so closing the last one is refused by
-  /// the reducer — the menu says so rather than offering a no-op.
-  private var canCloseTab: Bool { (store.openLoop?.layout.tabs.count ?? 0) > 1 }
+  /// ⌘W's label follows what it will close — a split's pane, or the tab when it isn't
+  /// split — the way a terminal menu should say what the keystroke does before you
+  /// learn it the hard way.
+  private var closeTitle: String { isSplit ? "Close Pane" : "Close Tab" }
 
   private var isSplit: Bool {
     guard let layout = store.openLoop?.layout else { return false }

--- a/graphcode/Sources/Features/App/GraphcodeCommands.swift
+++ b/graphcode/Sources/Features/App/GraphcodeCommands.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ComposableArchitecture
 import GraphcodeKit
 import SwiftUI
@@ -31,6 +32,17 @@ struct GraphcodeCommands: Commands {
     // `File ▸ Worktrees…` — the sweeper for the focused folder, same sheet the lane
     // chip and the context menus open. In File because it is about the folder on disk,
     // not about any loop.
+    // SwiftUI gives every `WindowGroup` a `File ▸ Close` at ⌘W, and AppKit resolves a
+    // key equivalent by walking the menu bar left to right: File would answer ⌘W before
+    // the Terminal menu ever saw it, so Close Pane below would never fire. Replacing the
+    // group is what frees the key. Closing the window keeps a shortcut, ⇧⌘W — Ghostty's
+    // own, and the pairing anyone who has closed a split before already has in their
+    // hands.
+    CommandGroup(replacing: .saveItem) {
+      Button("Close Window") { NSApp.keyWindow?.performClose(nil) }
+        .keyboardShortcut("w", modifiers: [.command, .shift])
+    }
+
     CommandGroup(after: .newItem) {
       Divider()
       // Beside New Window rather than in a menu of its own: a workspace is the other
@@ -87,19 +99,25 @@ struct GraphcodeCommands: Commands {
       Button("New Tab") { store.send(.openLoop(.newTabButtonTapped)) }
         .keyboardShortcut("t", modifiers: .command)
         .disabled(!hasWorkspace)
-      // ⌘W closes what the keyboard is in: the focused pane of a split, the tab when it
-      // isn't one — and, through the reducer, the workspace's last tab ends the loop
-      // itself. That last step is why it is never disabled here: there is always
-      // something ⌘W can close while a workspace is open (#254).
-      Button(closeTitle) {
+      // ⌘W closes what the keyboard is in: the focused pane of a split, and the pane
+      // that *is* the tab when it isn't split — Ghostty's own `close_split` binding,
+      // which is the terminal these panes are. Through the reducer, closing the
+      // workspace's last one asks whether the loop should end (#254), which is why it is
+      // never disabled: there is always something ⌘W can close while a workspace is
+      // open. "Close Pane" rather than a title that follows the split — a label that
+      // renames itself to "Close Tab" collides with the item below it, and a menu with
+      // the same words twice teaches nobody which key does what.
+      Button("Close Pane") {
         guard let layout = store.openLoop?.layout, let focused = layout.focusedSurface
         else { return }
         store.send(.openLoop(.paneClosed(tabID: layout.selectedTabID, surfaceID: focused.id)))
       }
       .keyboardShortcut("w", modifiers: .command)
       .disabled(!hasWorkspace)
+      // Every pane of the tab at once. Unbound on purpose: ⌘W already closes a tab that
+      // isn't split, which is nearly every tab here, and the shortcut this used to carry
+      // is spent on Close Window below — the one ⌘W has to give back.
       Button("Close Tab") { store.send(.openLoop(.tabClosed(selectedTabID))) }
-        .keyboardShortcut("w", modifiers: [.command, .shift])
         .disabled(!hasWorkspace)
 
       Divider()
@@ -144,11 +162,6 @@ struct GraphcodeCommands: Commands {
   private var railTitle: String {
     (store.openLoop?.isRailVisible ?? false) ? "Hide Loop Panel" : "Show Loop Panel"
   }
-
-  /// ⌘W's label follows what it will close — a split's pane, or the tab when it isn't
-  /// split — the way a terminal menu should say what the keystroke does before you
-  /// learn it the hard way.
-  private var closeTitle: String { isSplit ? "Close Pane" : "Close Tab" }
 
   private var isSplit: Bool {
     guard let layout = store.openLoop?.layout else { return false }

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
@@ -74,6 +74,11 @@ struct LoopWorkspaceFeature {
     case newTabButtonTapped
     case tabSelected(UUID)
     case tabClosed(UUID)
+    /// The workspace's last tab was closed. What that means is `AppFeature`'s to say:
+    /// for a loop it is the end of the loop itself (deleted the way the sidebar's delete
+    /// does, session and all), and for a quick chat it is just the terminal being put
+    /// away — the chat outlives its session.
+    case lastTabClosed
     case selectNextTab
     case selectPreviousTab
     case splitButtonTapped(direction: SplitDirection)
@@ -117,9 +122,10 @@ struct LoopWorkspaceFeature {
   }
 
   @Dependency(\.terminalLayoutStore) var terminalLayoutStore
-  /// Closing a tab or a pane is the one thing that should still end a surface. Switching
-  /// loops deliberately doesn't — see `TerminalSurfaceStore` — so without telling it
-  /// here, a closed pane's terminal would linger until it aged out of the cache.
+  /// Closing a tab or a pane is the one thing that should still end a surface — and,
+  /// since #254, the shell session behind it. Switching loops deliberately doesn't — see
+  /// `TerminalSurfaceStore` — so without telling it here, a closed pane's terminal would
+  /// linger until it aged out of the cache.
   @Dependency(\.terminalSurfaceClient) var terminalSurfaceClient
 
   var body: some ReducerOf<Self> {
@@ -139,13 +145,19 @@ struct LoopWorkspaceFeature {
         return .none
 
       case .tabClosed(let id):
-        // A workspace always keeps at least one tab.
-        guard state.layout.tabs.count > 1, let index = state.layout.tabs.index(id: id),
-          let tab = state.layout.tabs[id: id]
-        else {
-          return .none
-        }
+        guard let index = state.layout.tabs.index(id: id), let tab = state.layout.tabs[id: id]
+        else { return .none }
         terminalSurfaceClient.retire(tab.surfaces.map(\.id))
+        // The shells in the tab die with it — a pane's zmx session is the pane's reason
+        // for existing, and one left running after its pane is gone is invisible until
+        // reboot (#254). The agent surface is exempt: its session belongs to the loop,
+        // which outlives any pane and is ended by deleting the node, not by closing a
+        // tab in front of it.
+        terminalSurfaceClient.killSessions(
+          tab.surfaces.filter { !$0.launchesClaudeCode }.map(\.id), state.projectPath)
+        // The last tab going means the workspace has nothing left to show, which is the
+        // end of the loop itself — `AppFeature`'s call, since the deletion is its job.
+        guard state.layout.tabs.count > 1 else { return .send(.lastTabClosed) }
         state.layout.tabs.remove(id: id)
         if state.layout.selectedTabID == id {
           let fallbackIndex = min(index, state.layout.tabs.count - 1)
@@ -213,6 +225,12 @@ struct LoopWorkspaceFeature {
         // Only the pane that went is retired. Every survivor is the same live terminal it
         // was, and is about to be re-mounted in the space the closed one gave up.
         terminalSurfaceClient.retire([surfaceID])
+        // A shell the human closed ends with its pane (#254) — whether it was closed by
+        // the x, ⌘W, or its own process exiting. An agent pane is never killed here: the
+        // loop's session is the loop's, and ends when the node does.
+        if !paneOrder[closedIndex].launchesClaudeCode {
+          terminalSurfaceClient.killSessions([surfaceID], state.projectPath)
+        }
         tab.root = root
         if tab.focusedSurfaceID == surfaceID {
           // Where the keyboard lands, matching Ghostty: the pane before the one that
@@ -276,7 +294,8 @@ struct LoopWorkspaceFeature {
         state.seenBeatID = state.node.summary?.current?.id
         return .none
 
-      case .stopLoopTapped, .showInGraphTapped, .railTargetTapped, .primaryExitAcknowledged:
+      case .stopLoopTapped, .showInGraphTapped, .railTargetTapped, .primaryExitAcknowledged,
+        .lastTabClosed:
         // Handled by `AppFeature`'s parent `Reduce` — see the actions' own doc comment.
         return .none
       }

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceFeature.swift
@@ -75,9 +75,10 @@ struct LoopWorkspaceFeature {
     case tabSelected(UUID)
     case tabClosed(UUID)
     /// The workspace's last tab was closed. What that means is `AppFeature`'s to say:
-    /// for a loop it is the end of the loop itself (deleted the way the sidebar's delete
-    /// does, session and all), and for a quick chat it is just the terminal being put
-    /// away — the chat outlives its session.
+    /// for a loop it is the end of the loop itself, put to the same "Delete Loop…"
+    /// confirmation the sidebar's delete goes through — the loop may still be running,
+    /// and ⌘W is not consent. For a quick chat it is just the terminal being put away;
+    /// the chat outlives its session.
     case lastTabClosed
     case selectNextTab
     case selectPreviousTab
@@ -147,6 +148,12 @@ struct LoopWorkspaceFeature {
       case .tabClosed(let id):
         guard let index = state.layout.tabs.index(id: id), let tab = state.layout.tabs[id: id]
         else { return .none }
+        // The last tab going means the workspace has nothing left to show, which is the
+        // end of the loop itself — `AppFeature`'s call, since the deletion is its job,
+        // and it asks the human first. Nothing is torn down on the way out: the answer
+        // may be no, and a tab whose terminals were already retired and whose shells
+        // were already killed is not a tab anyone can be given back.
+        guard state.layout.tabs.count > 1 else { return .send(.lastTabClosed) }
         terminalSurfaceClient.retire(tab.surfaces.map(\.id))
         // The shells in the tab die with it — a pane's zmx session is the pane's reason
         // for existing, and one left running after its pane is gone is invisible until
@@ -155,9 +162,6 @@ struct LoopWorkspaceFeature {
         // tab in front of it.
         terminalSurfaceClient.killSessions(
           tab.surfaces.filter { !$0.launchesClaudeCode }.map(\.id), state.projectPath)
-        // The last tab going means the workspace has nothing left to show, which is the
-        // end of the loop itself — `AppFeature`'s call, since the deletion is its job.
-        guard state.layout.tabs.count > 1 else { return .send(.lastTabClosed) }
         state.layout.tabs.remove(id: id)
         if state.layout.selectedTabID == id {
           let fallbackIndex = min(index, state.layout.tabs.count - 1)

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspacePanes.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspacePanes.swift
@@ -47,7 +47,6 @@ struct TabPillView: View {
   let state: LoopState?
   let isSelected: Bool
   let shortcutHint: String?
-  let canClose: Bool
   let onSelect: () -> Void
   let onClose: () -> Void
 
@@ -89,7 +88,10 @@ struct TabPillView: View {
 
   @ViewBuilder
   private var trailingGlyph: some View {
-    if canClose && isHovering {
+    // Every tab closes, the loop's own included — a lone tab used to hide the button
+    // because closing it "did nothing", but now the last tab's close ends the loop
+    // itself (see `.tabClosed`), which is exactly when an x is most needed (#254).
+    if isHovering {
       Button(action: onClose) {
         Image(systemName: "xmark")
           .font(.system(size: 8, weight: .bold))

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceView.swift
@@ -214,7 +214,6 @@ struct LoopWorkspaceView: View {
             state: tab.surfaces.contains(where: \.launchesClaudeCode) ? store.node.state : nil,
             isSelected: tab.id == store.layout.selectedTabID,
             shortcutHint: index < 9 ? "⌘\(index + 1)" : nil,
-            canClose: store.layout.tabs.count > 1,
             onSelect: { store.send(.tabSelected(tab.id)) },
             onClose: { store.send(.tabClosed(tab.id)) }
           )
@@ -294,7 +293,9 @@ struct LoopWorkspaceView: View {
       PaneHeaderView(
         title: ref.launchesClaudeCode ? "agent" : "shell",
         isFocused: isFocused && tab.id == store.layout.selectedTabID,
-        detail: ref.launchesClaudeCode ? store.node.backend.displayName.lowercased() : "zsh")
+        detail: ref.launchesClaudeCode ? store.node.backend.displayName.lowercased() : "zsh",
+        canClose: tab.isSplit,
+        onClose: { store.send(.paneClosed(tabID: tab.id, surfaceID: ref.id)) })
       terminal(tab: tab, ref: ref)
     }
     // `ref.id` (not just this slot's structural position) is a surface's real

--- a/graphcode/Sources/Features/LoopWorkspace/PaneHeaderView.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/PaneHeaderView.swift
@@ -13,6 +13,12 @@ struct PaneHeaderView: View {
   let isFocused: Bool
   /// The shell or agent behind the pane — `claude`, `zsh`. Trailing, quiet.
   var detail: String?
+  /// Whether this pane can be closed here — true for any pane of a split. A lone pane
+  /// is its whole tab, and the tab strip's close button already speaks for it.
+  var canClose: Bool
+  var onClose: (() -> Void)?
+
+  @State private var isHovering = false
 
   var body: some View {
     HStack(spacing: 6) {
@@ -28,14 +34,34 @@ struct PaneHeaderView: View {
           .foregroundStyle(.white.opacity(0.35))
       }
       Spacer(minLength: 6)
-      Text(isFocused ? (detail ?? "") : "⌘] to focus")
-        .font(.system(size: 9.5, design: .monospaced))
-        .foregroundStyle(.white.opacity(0.35))
+      trailing
     }
     .lineLimit(1)
     .padding(.horizontal, 8)
     .frame(height: 22)
     .background(isFocused ? Theme.paneFocusTint.opacity(0.1) : Color.white.opacity(0.03))
+    .contentShape(Rectangle())
+    .onHover { isHovering = $0 }
+  }
+
+  /// The pane's own detail text, traded for an x while the header is hovered — the same
+  /// swap the tab pill makes of its ⌘-number. Without it a split had panes that could
+  /// only ever be closed by focus gymnastics, which is the hole #254 was filed through.
+  @ViewBuilder
+  private var trailing: some View {
+    if canClose, isHovering, let onClose {
+      Button(action: onClose) {
+        Image(systemName: "xmark")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundStyle(.white.opacity(0.6))
+      }
+      .buttonStyle(.plain)
+      .help("Close pane")
+    } else {
+      Text(isFocused ? (detail ?? "") : "⌘] to focus")
+        .font(.system(size: 9.5, design: .monospaced))
+        .foregroundStyle(.white.opacity(0.35))
+    }
   }
 
   /// The blue lifted for text — the saturated tint is a dot colour, not an ink.

--- a/graphcode/Sources/Infrastructure/Ghostty/TerminalSurfaceStore.swift
+++ b/graphcode/Sources/Infrastructure/Ghostty/TerminalSurfaceStore.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Dependencies
 import Foundation
+import GraphcodeKit
 
 /// Owns every live terminal surface, keyed by the `SurfaceRef.id` it belongs to.
 ///
@@ -99,6 +100,14 @@ final class TerminalSurfaceStore {
 /// a plain closure rather than an effect.
 struct TerminalSurfaceClient: Sendable {
   var retire: @Sendable ([UUID]) -> Void
+  /// Ends the `zmx` sessions behind the given surface ids — the half of closing a pane
+  /// that `retire` deliberately doesn't. Retirement only ends the attach; without this a
+  /// shell the human closed kept running detached, invisible, until reboot (#254). Only
+  /// ever called for plain shells — a loop's agent surface belongs to its loop, whose
+  /// session outlives any one pane and dies with the node, not with the view.
+  /// `projectPath` is the workspace's, so a remote project's shells are killed on their
+  /// own host.
+  var killSessions: @Sendable (_ ids: [UUID], _ projectPath: String?) -> Void
 }
 
 extension TerminalSurfaceClient: DependencyKey {
@@ -114,12 +123,22 @@ extension TerminalSurfaceClient: DependencyKey {
           MainActor.assumeIsolated { TerminalSurfaceStore.shared.retire(ids) }
         }
       }
+    },
+    killSessions: { ids, projectPath in
+      guard !ids.isEmpty else { return }
+      // `killSession` waits on `zmx` round-trips (and retries them); none of that has a
+      // surface attached any more, so it runs off the main thread and nobody waits.
+      Task.detached(priority: .utility) {
+        for id in ids {
+          await ZmxSessionLauncher.killSession(id: id, projectPath: projectPath)
+        }
+      }
     })
 
   /// Tests exercise the retention rules against `SurfaceRetentionPolicy` directly; a
   /// reducer test asserting on tab bookkeeping has no surfaces to retire and should not
   /// spin up a `ghostty_app_t` to find that out.
-  static let testValue = TerminalSurfaceClient(retire: { _ in })
+  static let testValue = TerminalSurfaceClient(retire: { _ in }, killSessions: { _, _ in })
 }
 
 extension DependencyValues {

--- a/graphcode/Tests/AppFeatureCloseTests.swift
+++ b/graphcode/Tests/AppFeatureCloseTests.swift
@@ -1,0 +1,121 @@
+import ComposableArchitecture
+import Foundation
+import GraphcodeKit
+import Testing
+
+@testable import graphcode
+
+/// Closing the terminal, and what it is allowed to take with it (#254).
+///
+/// Separate from `AppFeatureTests` for the reason that suite documents about
+/// `AppFeature` itself: it sits against swiftlint's `type_body_length` ceiling, and a
+/// group of tests with a subject of its own is the natural place to spend the lines
+/// somewhere else.
+@Suite
+struct AppFeatureCloseTests {
+  private static let projectA = ProjectRef(path: "/tmp/project-a", name: "project-a")
+
+  /// Closing the workspace's last tab is the other way a loop reaches its end — but the
+  /// loop may still be running, and ⌘W (or a hover x, or a shell exiting) is not consent
+  /// to throw one away. It raises the same "Delete Loop…" confirmation every other
+  /// delete in the app goes through: nothing is sent to the daemon and the workspace
+  /// stays put until the human answers (#254).
+  @Test
+  @MainActor
+  func closingTheLastTabAsksBeforeDeletingTheLoop() async {
+    let node = LoopNode(title: "Hello", checkDescription: "Said?")
+    var state = AppFeature.State()
+    state.projects.append(
+      ProjectFeature.State(graph: LoopGraph(project: Self.projectA, nodes: [node])))
+    state.selectedProjectPath = Self.projectA.path
+    state.openLoop = LoopWorkspaceFeature.State(
+      node: node, layout: .defaultLayout(forNode: node.id), projectPath: Self.projectA.path,
+      projectName: Self.projectA.name)
+
+    let sentCommands = SentCommandsBox()
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.orchestratorClient.send = { command in await sentCommands.append(command) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openLoop(.lastTabClosed))
+    await store.receive(\.projects)
+    #expect(store.state.pendingLoopDeletion?.node.id == node.id)
+    #expect(store.state.openLoop != nil)
+    #expect(await sentCommands.all.isEmpty)
+
+    // And confirming it is the ordinary delete, on the ordinary path.
+    await store.send(.projects(.element(id: Self.projectA.path, action: .deleteNodeConfirmed)))
+    #expect(
+      await sentCommands.all == [
+        .graphCommand(projectPath: Self.projectA.path, command: .deleteNode(node.id))
+      ])
+  }
+
+  /// Cancelling that dialog leaves the loop exactly as it was — still in the graph,
+  /// still on screen, its terminals still attached.
+  @Test
+  @MainActor
+  func decliningTheLastTabConfirmationKeepsTheLoop() async {
+    let node = LoopNode(title: "Hello", checkDescription: "Said?")
+    var state = AppFeature.State()
+    state.projects.append(
+      ProjectFeature.State(graph: LoopGraph(project: Self.projectA, nodes: [node])))
+    state.selectedProjectPath = Self.projectA.path
+    state.openLoop = LoopWorkspaceFeature.State(
+      node: node, layout: .defaultLayout(forNode: node.id), projectPath: Self.projectA.path,
+      projectName: Self.projectA.name)
+
+    let sentCommands = SentCommandsBox()
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.orchestratorClient.send = { command in await sentCommands.append(command) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openLoop(.lastTabClosed))
+    await store.receive(\.projects)
+    await store.send(.projects(.element(id: Self.projectA.path, action: .deleteNodeCancelled)))
+
+    #expect(store.state.pendingLoopDeletion == nil)
+    #expect(store.state.openLoop?.node.id == node.id)
+    #expect(store.state.projects[id: Self.projectA.path]?.graph.nodes[id: node.id] != nil)
+    #expect(await sentCommands.all.isEmpty)
+  }
+
+  /// A quick chat has no node to confirm the deletion of and no graph to delete it from.
+  /// Closing its last tab just puts the terminal away; the chat outlives its session.
+  @Test
+  @MainActor
+  func closingAQuickChatsLastTabOnlyClosesTheWorkspace() async {
+    let chat = QuickChat(title: "Chat")
+    var state = AppFeature.State()
+    state.quickChats.append(chat)
+    let node = LoopNode(id: chat.id, title: chat.title, loopType: .composite)
+    state.openLoop = LoopWorkspaceFeature.State(
+      node: node, layout: .defaultLayout(forNode: node.id), projectPath: "",
+      projectName: chat.title)
+
+    let sentCommands = SentCommandsBox()
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.orchestratorClient.send = { command in await sentCommands.append(command) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openLoop(.lastTabClosed))
+    #expect(store.state.openLoop == nil)
+    #expect(store.state.pendingLoopDeletion == nil)
+    #expect(store.state.quickChats[id: chat.id] != nil)
+    #expect(await sentCommands.all.isEmpty)
+  }
+}
+
+private actor SentCommandsBox {
+  private(set) var all: [DaemonCommand] = []
+  func append(_ command: DaemonCommand) { all.append(command) }
+}

--- a/graphcode/Tests/LoopWorkspaceFeatureTests.swift
+++ b/graphcode/Tests/LoopWorkspaceFeatureTests.swift
@@ -131,17 +131,42 @@ struct LoopWorkspaceFeatureTests {
   }
 
   /// Closing the last tab is the end of the loop itself — the reducer forwards to
-  /// `AppFeature`, which deletes the node the way the sidebar's delete does (#254).
-  /// The layout is untouched here: the workspace is going away either way.
+  /// `AppFeature`, which asks the human before deleting anything (#254). Nothing is torn
+  /// down on the way out: the layout still stands, its surfaces are still attached and
+  /// its shells still running, because the answer may be no.
   @Test
   @MainActor
   func closingTheLastTabAsksItsParentToEndTheLoop() async {
-    let store = makeStore(makeState())
+    let endings = EndingRecorder()
+    let store = makeStore(makeState(), endings: endings)
     let onlyTabID = store.state.layout.selectedTabID
 
     await store.send(.tabClosed(onlyTabID))
     await store.receive(\.lastTabClosed)
     #expect(store.state.layout.tabs.count == 1)
+    #expect(endings.retired.isEmpty)
+    #expect(endings.killed.isEmpty)
+  }
+
+  /// The same, for the shape that made this reachable without any click at all: a plain
+  /// shell whose process exits sends `.paneClosed`, which collapses to `.tabClosed` when
+  /// the shell is the tab's only pane. Typing `exit` must not be what deletes a loop —
+  /// it asks, exactly like the x does, and kills nothing while the question is open.
+  @Test
+  @MainActor
+  func aLoneShellExitingAsksRatherThanEndingTheLoopOutright() async {
+    var state = makeState()
+    let shell = SurfaceRef(id: UUID(), launchesClaudeCode: false)
+    let shellTab = TabLayout(primary: shell)
+    state.layout = TerminalLayout(tabs: [shellTab], selectedTabID: shellTab.id)
+
+    let endings = EndingRecorder()
+    let store = makeStore(state, endings: endings)
+    await store.send(.paneClosed(tabID: shellTab.id, surfaceID: shell.id))
+
+    await store.receive(\.tabClosed)
+    await store.receive(\.lastTabClosed)
+    #expect(endings.killed.isEmpty)
   }
 
   @Test

--- a/graphcode/Tests/LoopWorkspaceFeatureTests.swift
+++ b/graphcode/Tests/LoopWorkspaceFeatureTests.swift
@@ -12,13 +12,51 @@ import Testing
 /// never touch the app's real Application Support folder.
 @Suite
 struct LoopWorkspaceFeatureTests {
-  private func makeStore(_ state: LoopWorkspaceFeature.State) -> TestStoreOf<LoopWorkspaceFeature> {
+  /// Records what the reducer asks `TerminalSurfaceClient` to end: the attach going
+  /// away (`retired`) and the zmx sessions being terminated behind it (`killed`).
+  private final class EndingRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var retiredIDs: [UUID] = []
+    private var killedIDs: [UUID] = []
+
+    func retire(_ ids: [UUID]) {
+      lock.lock()
+      retiredIDs += ids
+      lock.unlock()
+    }
+
+    func kill(_ ids: [UUID]) {
+      lock.lock()
+      killedIDs += ids
+      lock.unlock()
+    }
+
+    var retired: [UUID] {
+      lock.lock()
+      defer { lock.unlock() }
+      return retiredIDs
+    }
+
+    var killed: [UUID] {
+      lock.lock()
+      defer { lock.unlock() }
+      return killedIDs
+    }
+  }
+
+  private func makeStore(
+    _ state: LoopWorkspaceFeature.State,
+    endings: EndingRecorder? = nil
+  ) -> TestStoreOf<LoopWorkspaceFeature> {
     let directory = FileManager.default.temporaryDirectory
       .appendingPathComponent("graphcode-tests-\(UUID().uuidString)", isDirectory: true)
     let store = TestStore(initialState: state) {
       LoopWorkspaceFeature()
     } withDependencies: {
       $0.terminalLayoutStore = TerminalLayoutStore(baseDirectory: directory)
+      $0.terminalSurfaceClient = TerminalSurfaceClient(
+        retire: { endings?.retire($0) },
+        killSessions: { ids, _ in endings?.kill(ids) })
     }
     store.exhaustivity = .off
     return store
@@ -92,13 +130,17 @@ struct LoopWorkspaceFeatureTests {
     #expect(children[1].isSplit)
   }
 
+  /// Closing the last tab is the end of the loop itself — the reducer forwards to
+  /// `AppFeature`, which deletes the node the way the sidebar's delete does (#254).
+  /// The layout is untouched here: the workspace is going away either way.
   @Test
   @MainActor
-  func closingTheLastTabIsANoOp() async {
+  func closingTheLastTabAsksItsParentToEndTheLoop() async {
     let store = makeStore(makeState())
     let onlyTabID = store.state.layout.selectedTabID
 
     await store.send(.tabClosed(onlyTabID))
+    await store.receive(\.lastTabClosed)
     #expect(store.state.layout.tabs.count == 1)
   }
 
@@ -116,6 +158,71 @@ struct LoopWorkspaceFeatureTests {
 
     #expect(store.state.layout.tabs.count == 1)
     #expect(store.state.layout.selectedTabID == firstTabID)
+  }
+
+  /// A shell tab the human closed dies with it — its zmx session is killed, not just
+  /// detached — while the loop's agent session in the surviving tab is untouched (#254).
+  @Test
+  @MainActor
+  func closingAShellTabKillsItsSessionAndSparesTheAgent() async {
+    var state = makeState()
+    let shellTab = TabLayout(primary: SurfaceRef(id: UUID(), launchesClaudeCode: false))
+    state.layout.tabs.append(shellTab)
+
+    let endings = EndingRecorder()
+    let store = makeStore(state, endings: endings)
+    await store.send(.tabClosed(shellTab.id))
+
+    #expect(endings.killed == [shellTab.primary.id])
+    #expect(!endings.retired.isEmpty)
+    #expect(!endings.killed.contains(state.node.id))
+  }
+
+  /// The other side of the same rule: closing the tab that carries the loop's own
+  /// session retires its surface but never kills the session — the loop outlives any
+  /// pane, and its session ends when the node does.
+  @Test
+  @MainActor
+  func closingTheAgentTabNeverKillsTheAgentSession() async {
+    var state = makeState()
+    let shellTab = TabLayout(primary: SurfaceRef(id: UUID(), launchesClaudeCode: false))
+    state.layout.tabs.append(shellTab)
+
+    let endings = EndingRecorder()
+    let store = makeStore(state, endings: endings)
+    await store.send(.tabClosed(state.layout.tabs[0].id))
+
+    #expect(endings.killed.isEmpty)
+  }
+
+  /// A shell pane closed out of a split ends its session (#254).
+  @Test
+  @MainActor
+  func closingAShellPaneKillsItsSession() async throws {
+    let endings = EndingRecorder()
+    let store = makeStore(makeState(), endings: endings)
+    let tabID = store.state.layout.selectedTabID
+    await store.send(.splitButtonTapped(direction: .horizontal))
+    let addition = try #require(store.state.layout.tabs[id: tabID]?.surfaces.last)
+
+    await store.send(.paneClosed(tabID: tabID, surfaceID: addition.id))
+
+    #expect(endings.killed == [addition.id])
+  }
+
+  /// And the agent pane of a split is spared, exactly like the agent tab is.
+  @Test
+  @MainActor
+  func closingAnAgentPaneNeverKillsTheAgentSession() async throws {
+    let endings = EndingRecorder()
+    let store = makeStore(makeState(), endings: endings)
+    let tabID = store.state.layout.selectedTabID
+    await store.send(.splitButtonTapped(direction: .horizontal))
+    let originalPrimary = try #require(store.state.layout.tabs[id: tabID]?.primary)
+
+    await store.send(.paneClosed(tabID: tabID, surfaceID: originalPrimary.id))
+
+    #expect(endings.killed.isEmpty)
   }
 
   @Test

--- a/graphcode/Tests/SplitNodeTests.swift
+++ b/graphcode/Tests/SplitNodeTests.swift
@@ -159,22 +159,48 @@ struct SplitNodeTests {
 
   /// Closing a tab (or pane) can take the node's own surface out of a saved layout, and
   /// a layout persisted that way would reopen a running loop as shells-only, its live
-  /// session attached to nothing on screen. The default — the agent tab — is what opens
-  /// instead (#254). Compared by shape rather than `==`: a fresh default's tab and
-  /// surface ids are generated per call.
+  /// session attached to nothing on screen. The agent tab is put back at the front —
+  /// and the shell tabs that were saved alongside it stay, because their zmx sessions
+  /// are still running and a layout that forgot them would only hide them (#254).
   @Test
-  func openingRestoresTheDefaultWhenTheAgentSurfaceWasClosedAway() throws {
+  func openingRestoresTheAgentTabWithoutDiscardingTheSavedOnes() throws {
     let nodeID = UUID()
-    let saved = TerminalLayout(
-      tabs: [
-        TabLayout(primary: SurfaceRef(id: UUID(), launchesClaudeCode: false))
-      ], selectedTabID: UUID())
+    let shell = SurfaceRef(id: UUID(), launchesClaudeCode: false)
+    let shellTab = TabLayout(primary: shell)
+    let saved = TerminalLayout(tabs: [shellTab], selectedTabID: shellTab.id)
 
-    let opened = [
-      TerminalLayout.opening(forNode: nodeID, saved: saved),
-      TerminalLayout.opening(forNode: nodeID, saved: nil),
-    ]
-    for layout in opened {
+    let opened = TerminalLayout.opening(forNode: nodeID, saved: saved)
+
+    #expect(opened.tabs.count == 2)
+    #expect(opened.tabs[0].surfaces == [SurfaceRef(id: nodeID, launchesClaudeCode: true)])
+    #expect(opened.tabs[1] == shellTab)
+    // The saved selection still names a tab that is here, so it is left alone.
+    #expect(opened.selectedTabID == shellTab.id)
+  }
+
+  /// A selection left naming a tab that no longer exists lands on the restored agent
+  /// tab — a workspace whose `selectedTabID` matches nothing shows no terminal at all.
+  @Test
+  func openingRepointsADanglingSelectionAtTheRestoredAgentTab() {
+    let nodeID = UUID()
+    let shellTab = TabLayout(primary: SurfaceRef(id: UUID(), launchesClaudeCode: false))
+    let saved = TerminalLayout(tabs: [shellTab], selectedTabID: UUID())
+
+    let opened = TerminalLayout.opening(forNode: nodeID, saved: saved)
+
+    #expect(opened.selectedTabID == opened.tabs[0].id)
+    #expect(opened.tabs[0].surfaces == [SurfaceRef(id: nodeID, launchesClaudeCode: true)])
+  }
+
+  /// Nothing saved — and nothing salvageable — opens the default. Compared by shape
+  /// rather than `==`: a fresh default's tab and surface ids are generated per call.
+  @Test
+  func openingWithoutASavedLayoutUsesTheDefault() throws {
+    let nodeID = UUID()
+    let empty = TerminalLayout(tabs: [], selectedTabID: UUID())
+
+    for saved in [nil, empty] {
+      let layout = TerminalLayout.opening(forNode: nodeID, saved: saved)
       #expect(layout.tabs.count == 1)
       let tab = try #require(layout.tabs.first)
       #expect(layout.selectedTabID == tab.id)

--- a/graphcode/Tests/SplitNodeTests.swift
+++ b/graphcode/Tests/SplitNodeTests.swift
@@ -145,4 +145,40 @@ struct SplitNodeTests {
             .leaf(SurfaceRef(id: secondaryID, launchesClaudeCode: false)),
           ]))
   }
+
+  /// A saved layout that still carries the node's own surface opens exactly as saved —
+  /// tabs, splits, focus and all.
+  @Test
+  func openingUsesTheSavedLayoutWhileTheAgentSurfaceSurvives() {
+    let nodeID = UUID()
+    var saved = TerminalLayout.defaultLayout(forNode: nodeID)
+    saved.tabs.append(TabLayout(primary: SurfaceRef(id: UUID(), launchesClaudeCode: false)))
+
+    #expect(TerminalLayout.opening(forNode: nodeID, saved: saved) == saved)
+  }
+
+  /// Closing a tab (or pane) can take the node's own surface out of a saved layout, and
+  /// a layout persisted that way would reopen a running loop as shells-only, its live
+  /// session attached to nothing on screen. The default — the agent tab — is what opens
+  /// instead (#254). Compared by shape rather than `==`: a fresh default's tab and
+  /// surface ids are generated per call.
+  @Test
+  func openingRestoresTheDefaultWhenTheAgentSurfaceWasClosedAway() throws {
+    let nodeID = UUID()
+    let saved = TerminalLayout(
+      tabs: [
+        TabLayout(primary: SurfaceRef(id: UUID(), launchesClaudeCode: false))
+      ], selectedTabID: UUID())
+
+    let opened = [
+      TerminalLayout.opening(forNode: nodeID, saved: saved),
+      TerminalLayout.opening(forNode: nodeID, saved: nil),
+    ]
+    for layout in opened {
+      #expect(layout.tabs.count == 1)
+      let tab = try #require(layout.tabs.first)
+      #expect(layout.selectedTabID == tab.id)
+      #expect(tab.surfaces == [SurfaceRef(id: nodeID, launchesClaudeCode: true)])
+    }
+  }
 }


### PR DESCRIPTION
Closes #254

## Problem

- The tab pill's hover close was gated on `tabs.count > 1`, so a loop's own (only) tab never offered an x — hovering the tab strip showed nothing.
- A ⌘D split pane had no close affordance at all: `.paneClosed` existed in the reducer but nothing in the UI or menus sent it.
- ⌘W was bound to Close Tab and disabled with one tab — exactly the state ⌘D leaves you in — so there was no way to close.
- Even where closing worked, it only retired the surface (ended the attach); the zmx session behind a closed shell kept running detached until reboot.

## Changes

- **Tab pill x always shows on hover** — including a lone tab. Closing the workspace's last tab now ends the loop itself: `AppFeature` deletes the node the way the sidebar's delete does (daemon `deleteNode`, which also kills the session). A quick chat just puts the terminal away; the chat outlives its session.
- **Pane headers get a hover x while their tab is split**, sending the reducer's existing `.paneClosed` (collapse + focus handoff already handled there).
- **⌘W is Close Pane** — the focused pane, the tab when it isn't split, the loop when it's the last — and **Close Tab moves to ⇧⌘W**. The menu title follows what the keystroke will actually close.
- **Closed shells die with their panes**: `TerminalSurfaceClient.killSessions` (remote-aware via the workspace's project path) ends the zmx sessions behind plain shells on pane/tab close; agent surfaces are exempt — the loop's session belongs to the node, not to any pane, and ends when the node does.
- **Self-healing reopen**: `TerminalLayout.opening(forNode:saved:)` restores the default agent tab when a saved layout lost the node's own surface, so closing the agent tab can't make a running loop reopen as shells-only.

## Verification

- `xcodebuild build`: succeeded
- `xcodebuild test`: 1294 tests, 0 failures (6 new: last-tab forwards to parent, shell-vs-agent kill rules for tab and pane close, layout heal)
- `swiftlint`: 0 errors · `swift-format --strict`: clean