### PR TITLE
Log every step of a self-update, and stop the install hanging on a pipe

### DIFF
--- a/graphcode/Sources/Clients/UpdateInstallClient.swift
+++ b/graphcode/Sources/Clients/UpdateInstallClient.swift
@@ -45,18 +45,28 @@ extension UpdateInstallClient: DependencyKey {
 
   static let liveValue = UpdateInstallClient(
     install: { dmg, progress in
-      let image = try await download(dmg, progress: progress)
+      UpdateLog.record("install: \(dmg.lastPathComponent) -> \(installedApp.path)")
+      let image = try await UpdateLog.step("download") {
+        try await download(dmg, progress: progress)
+      }
       defer { try? FileManager.default.removeItem(at: image) }
-      let mountPoint = try await attach(image)
+      let mountPoint = try await UpdateLog.step("attach") { try await attach(image) }
       do {
-        let app = try appInside(mountPoint)
-        try await verifySignature(of: app)
-        try await swapIntoApplications(app)
+        let app = try await UpdateLog.step("locate app") { try appInside(mountPoint) }
+        try await UpdateLog.step("verify signature") { try await verifySignature(of: app) }
+        try await UpdateLog.step("swap into /Applications") {
+          try await swapIntoApplications(app)
+        }
       } catch {
-        try? await run("/usr/bin/hdiutil", ["detach", mountPoint.path, "-force"])
+        try? await UpdateLog.step("detach after failure") {
+          try await run("/usr/bin/hdiutil", ["detach", mountPoint.path, "-force"])
+        }
         throw error
       }
-      try? await run("/usr/bin/hdiutil", ["detach", mountPoint.path, "-force"])
+      try? await UpdateLog.step("detach") {
+        try await run("/usr/bin/hdiutil", ["detach", mountPoint.path, "-force"])
+      }
+      UpdateLog.record("install: done")
     },
     relaunch: {
       // Started through LaunchServices rather than as a child of this process, and that
@@ -85,6 +95,7 @@ extension UpdateInstallClient: DependencyKey {
       // never record itself and the workspace would read as free with a window open on
       // it. The `willTerminate` release still runs and is a no-op by then — it only
       // deletes a claim that still names this process.
+      UpdateLog.record("relaunch: asking LaunchServices to open \(installedApp.path)")
       WorkspaceLock.release()
       let launched = await withCheckedContinuation { continuation in
         NSWorkspace.shared.openApplication(at: installedApp, configuration: configuration) {
@@ -94,6 +105,10 @@ extension UpdateInstallClient: DependencyKey {
       }
       // Only once the successor is actually running: terminating first would race the
       // launch request against this process's own death.
+      UpdateLog.record(
+        launched
+          ? "relaunch: LaunchServices started the successor"
+          : "relaunch: LaunchServices REFUSED — falling back to the detached shell")
       if !launched {
         // Nothing to lose by trying the old way if LaunchServices refused outright.
         let reopen = Process()
@@ -251,35 +266,76 @@ extension UpdateInstallClient: DependencyKey {
     }
   }
 
+  /// Runs a tool and returns what it wrote.
+  ///
+  /// **The output goes to temporary files, not pipes, and that is the entire point.** The
+  /// obvious shape — two `Pipe`s read to EOF from inside `terminationHandler` — hangs
+  /// forever in two separate ways, and both are reachable from here:
+  ///
+  /// - A tool that writes more than the pipe buffer holds (64KB) blocks in `write` until
+  ///   somebody reads. Nobody does, because the only reader runs on termination and the
+  ///   tool cannot terminate while it is blocked writing.
+  /// - `readDataToEndOfFile()` waits for every *write end* to close, which is not the
+  ///   same as the tool exiting. `hdiutil attach` hands its descriptors to
+  ///   `diskimages-helper`, which stays alive for as long as the image is attached — so
+  ///   EOF never arrives even though `hdiutil` itself is long gone.
+  ///
+  /// Both present identically to the human: an install parked on "Installing…" with no
+  /// error, no relaunch prompt and no way forward but a manual reinstall. A file has
+  /// neither a capacity to fill nor an EOF to wait for, so neither failure exists.
+  ///
+  /// The timeout is the backstop for a tool that genuinely wedges. An error someone can
+  /// read and report beats a dialog that sits there for the rest of the day.
   @discardableResult
-  private static func run(_ tool: String, _ arguments: [String]) async throws -> String {
-    let process = Process()
+  private static func run(
+    _ tool: String, _ arguments: [String], timeout: TimeInterval = 600
+  ) async throws -> String {
+    let name = String(tool.split(separator: "/").last ?? "tool")
+    let fileManager = FileManager.default
+    let base = fileManager.temporaryDirectory
+      .appendingPathComponent("graphcode-\(name)-\(UUID().uuidString)")
+    let outURL = base.appendingPathExtension("out")
+    let errURL = base.appendingPathExtension("err")
+    fileManager.createFile(atPath: outURL.path, contents: nil)
+    fileManager.createFile(atPath: errURL.path, contents: nil)
+    defer {
+      try? fileManager.removeItem(at: outURL)
+      try? fileManager.removeItem(at: errURL)
+    }
+
+    nonisolated(unsafe) let process = Process()
     process.executableURL = URL(fileURLWithPath: tool)
     process.arguments = arguments
-    let stdout = Pipe()
-    let stderr = Pipe()
-    process.standardOutput = stdout
-    process.standardError = stderr
-    return try await withCheckedThrowingContinuation { continuation in
-      process.terminationHandler = { finished in
-        let output = stdout.fileHandleForReading.readDataToEndOfFile()
-        let errors = stderr.fileHandleForReading.readDataToEndOfFile()
-        if finished.terminationStatus == 0 {
-          continuation.resume(
-            returning: String(bytes: output + errors, encoding: .utf8) ?? "")
-        } else {
-          let reason = String(bytes: errors, encoding: .utf8) ?? ""
-          continuation.resume(
-            throwing: UpdateInstallFailure.swapFailed(
-              "\(tool.split(separator: "/").last ?? "tool") failed: \(reason)"))
-        }
-      }
-      do {
-        try process.run()
-      } catch {
-        continuation.resume(throwing: error)
-      }
+    process.standardOutput = try FileHandle(forWritingTo: outURL)
+    process.standardError = try FileHandle(forWritingTo: errURL)
+
+    let (exited, exitContinuation) = AsyncStream<Int32>.makeStream()
+    // Installed before `run()` so the exit cannot be missed — the same rule `GitClient`
+    // documents, for the same reason.
+    process.terminationHandler = { finished in
+      exitContinuation.yield(finished.terminationStatus)
+      exitContinuation.finish()
     }
+    UpdateLog.record("  run: \(name) \(arguments.joined(separator: " "))")
+    try process.run()
+
+    let watchdog = Task {
+      try await Task.sleep(for: .seconds(timeout))
+      UpdateLog.record("  run: \(name) exceeded \(Int(timeout))s — terminating")
+      process.terminate()
+    }
+    defer { watchdog.cancel() }
+
+    var status: Int32 = -1
+    for await exitStatus in exited { status = exitStatus }
+
+    let output = (try? Data(contentsOf: outURL)).map { String(decoding: $0, as: UTF8.self) } ?? ""
+    let errors = (try? Data(contentsOf: errURL)).map { String(decoding: $0, as: UTF8.self) } ?? ""
+    UpdateLog.record("  run: \(name) exited \(status)")
+    guard status == 0 else {
+      throw UpdateInstallFailure.swapFailed("\(name) failed: \(errors)")
+    }
+    return output + errors
   }
 }
 

--- a/graphcode/Sources/Clients/UpdateLog.swift
+++ b/graphcode/Sources/Clients/UpdateLog.swift
@@ -1,0 +1,64 @@
+import Foundation
+import GraphcodeKit
+import OSLog
+
+/// One line per step of a self-update, written to `~/.graphcode/update.log` on the machine
+/// that ran it.
+///
+/// An install that wedges leaves no other trace: the flow reports progress through the
+/// store, so a step that never returns shows as a dialog stuck on "Installing…" and
+/// nothing else — no error, no console output, nothing to send. The steps are a download,
+/// three subprocesses and two renames, and which of them stopped is the whole diagnosis.
+///
+/// Also mirrored to `os.Logger` so `log stream --predicate 'subsystem == "dev.graphcode.app"'`
+/// shows it live while reproducing.
+enum UpdateLog {
+  static let maxBytes = 262_144
+  static let keptLines = 2000
+
+  private static let logger = Logger(subsystem: "dev.graphcode.app", category: "update")
+
+  /// Best-effort by the same rule as `DialLog`: failing to log must never fail an install.
+  static func record(_ message: String) {
+    logger.info("\(message, privacy: .public)")
+    let fileManager = FileManager.default
+    let directory = SupportDirectory.url
+    let log = directory.appendingPathComponent("update.log")
+    try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    let stamp = ISO8601DateFormatter().string(from: Date())
+    let line = "\(stamp) \(message)\n"
+    let size = (try? fileManager.attributesOfItem(atPath: log.path))?[.size] as? Int ?? 0
+    if size > maxBytes, let contents = try? String(contentsOf: log, encoding: .utf8) {
+      let kept = contents.split(separator: "\n").suffix(keptLines).joined(separator: "\n")
+      try? (kept + "\n" + line).write(to: log, atomically: true, encoding: .utf8)
+      return
+    }
+    if let handle = try? FileHandle(forWritingTo: log) {
+      _ = try? handle.seekToEnd()
+      try? handle.write(contentsOf: Data(line.utf8))
+      try? handle.close()
+    } else {
+      try? Data(line.utf8).write(to: log)
+    }
+  }
+
+  /// Runs `body`, logging the step's start and how it ended — including the elapsed time,
+  /// which is what separates "slow" from "wedged" when reading the log afterwards.
+  @discardableResult
+  static func step<T>(_ name: String, _ body: () async throws -> T) async rethrows -> T {
+    record("\(name): started")
+    let began = Date()
+    do {
+      let value = try await body()
+      record("\(name): ok in \(elapsed(since: began))")
+      return value
+    } catch {
+      record("\(name): FAILED in \(elapsed(since: began)) — \(error)")
+      throw error
+    }
+  }
+
+  static func elapsed(since date: Date) -> String {
+    String(format: "%.1fs", Date().timeIntervalSince(date))
+  }
+}


### PR DESCRIPTION
A machine reported Check for Updates parking on "Installing…" forever: no error, no
"Relaunch Now", and no way forward but installing the DMG by hand.

## Where it stops

The progress dialog reads `Text(fraction < 1 ? "Downloading update…" : "Installing…")`,
so "Installing…" is only ever shown once the download has finished. Everything after it
— `hdiutil attach`, `codesign`, `ditto` — went through one `run()` helper, and that
helper could not return.

## Why it could not return

`run()` read both pipes to EOF from inside `terminationHandler`. Two separate hangs live
in that shape, and I confirmed both against the real code:

| Case | Result |
|---|---|
| Child writes more than the 64KB pipe buffer, then exits | HUNG |
| Grandchild inherits the pipe write end and lingers | HUNG |

The first deadlocks because the tool blocks in `write` before it can exit, so the handler
that would drain the pipe never runs. The second because `readDataToEndOfFile()` waits
for every *write end* to close, which is not the same as the tool exiting — and
`hdiutil attach` hands its descriptors to `diskimages-helper`, which stays alive for as
long as the image is attached. `hdiutil` is the first `run()` after the download, which
is exactly where the report says it stops.

I could **not** reproduce the wedge on my machine — `diskimages-helper` did not hold the
pipe here — so the second case is a strong hypothesis rather than a confirmed root cause.
That is the reason the logging ships alongside the fix rather than after it.

## The fix

Output goes to temporary files instead of pipes: no capacity to fill, no EOF to wait for,
so neither hang exists. Exit is still awaited through `terminationHandler` (never
`waitUntilExit`), matching `GitClient.run`. A 600s watchdog terminates a tool that
genuinely wedges, so the worst case becomes an error someone can report rather than a
dialog that sits there all day.

## The logging

`~/.graphcode/update.log` gets one line per step — download, attach, locate, verify, swap,
detach, relaunch — each with its outcome and elapsed time, plus every subprocess and its
exit status. Mirrored to `os.Logger` (`subsystem == "dev.graphcode.app"`, category
`update`) for watching live. Bounded at 256KB the way `DialLog` is, and best-effort
throughout: failing to log must never fail an install.

If the wedge recurs, the last line in that file names the step that stopped.

## Verification

- `xcodebuild build`: all three schemes (`graphcode`, `graphcode-cli`, `graphcoded`) clean
- `xcodebuild test`: 0 failures
- `swiftlint`: 0 errors, `swift-format --strict`: clean

**Not covered:** no test was added. `run()` is private and testing it would mean adding a
seam purely for the test; the evidence for the two hangs is empirical, from a standalone
reproduction, not from the suite.
