### PR TITLE
Name loops in a single word

### DIFF
--- a/graphcode/Sources/Clients/TitleSuggestionClient.swift
+++ b/graphcode/Sources/Clients/TitleSuggestionClient.swift
@@ -2,7 +2,7 @@ import Dependencies
 import Foundation
 import GraphcodeKit
 
-/// Asks a loop's own backend for a one-or-two-word title when the human left the form's
+/// Asks a loop's own backend for a one-word title when the human left the form's
 /// title blank — `claude -p` / `copilot -p` / `codex exec`, the headless print-mode
 /// shape of each CLI, so nothing here opens a session or touches the loop's actual work.
 ///
@@ -44,15 +44,15 @@ extension TitleSuggestionClient: DependencyKey {
   /// every single one.
   private static let takenNamesListed = 100
 
-  /// As precise as possible, preferring two words — a single word is allowed when it
-  /// alone names the task, never more than two — and none of the names any canvas
-  /// already shows. The model is told, and `accept` enforces what telling cannot
+  /// As precise as possible, and always one word: a name that needs two concepts joins
+  /// them in CamelCase rather than spending a space on them. And none of the names any
+  /// canvas already shows — the model is told, and `accept` enforces what telling cannot
   /// guarantee.
   static func instruction(for prompt: String, taken: Set<String>) -> String {
     var instruction = """
-      Reply with the most precise name you can for this task. Prefer two words; use \
-      a single word only when it alone names the task precisely. Never more than two \
-      words, no punctuation, no quotes — and nothing else.
+      Reply with the most precise name you can for this task, as a single word — never \
+      two. When naming it precisely takes two concepts, join them in CamelCase, like \
+      GraphcodeTemplates. No spaces, no punctuation, no quotes — and nothing else.
       """
     let listed = taken.sorted().prefix(takenNamesListed)
     if !listed.isEmpty {
@@ -142,10 +142,11 @@ extension TitleSuggestionClient: DependencyKey {
     return String(data: data, encoding: .utf8)
   }
 
-  /// One clean name — at most two words — out of whatever the model printed. `codex
-  /// exec` wraps its answer in log lines, and any model can get chatty — the *last*
-  /// non-empty line is the answer far more reliably than the first, and two tokens of
-  /// it are all that was asked for.
+  /// One clean single word out of whatever the model printed. `codex exec` wraps its
+  /// answer in log lines, and any model can get chatty — the *last* non-empty line is
+  /// the answer far more reliably than the first, and two tokens of it are all that was
+  /// asked for. A model that answers in separate words anyway is folded into the
+  /// CamelCase it was asked for rather than refused.
   static func sanitize(_ output: String) -> String? {
     let lastLine =
       output
@@ -156,7 +157,7 @@ extension TitleSuggestionClient: DependencyKey {
       .map { $0.trimmingCharacters(in: CharacterSet.alphanumerics.inverted) }
       .filter { !$0.isEmpty }
     guard !words.isEmpty else { return nil }
-    let name = words.joined(separator: " ")
+    let name = words.map { $0.prefix(1).uppercased() + $0.dropFirst() }.joined()
     guard name.count <= 30 else { return nil }
     return name
   }

--- a/graphcode/Tests/TitleSuggestionTests.swift
+++ b/graphcode/Tests/TitleSuggestionTests.swift
@@ -4,16 +4,18 @@ import Testing
 @testable import GraphcodeKit
 @testable import graphcode
 
-/// The naming rules for backend-suggested loop titles: at most two precise words, and
-/// never a name any open project — local folder, remote repository, or the Graph —
-/// already shows.
+/// The naming rules for backend-suggested loop titles: one precise word — two concepts
+/// folded into CamelCase rather than split — and never a name any open project — local
+/// folder, remote repository, or the Graph — already shows.
 @Suite
 struct TitleSuggestionTests {
   @Test
-  func aNameIsAtMostTwoCleanWords() {
+  func aNameIsOneCleanWord() {
     #expect(TitleSuggestionClient.sanitize("Research") == "Research")
-    #expect(TitleSuggestionClient.sanitize("Database Migration") == "Database Migration")
-    #expect(TitleSuggestionClient.sanitize("Fix flaky login tests") == "Fix flaky")
+    #expect(TitleSuggestionClient.sanitize("Database Migration") == "DatabaseMigration")
+    #expect(TitleSuggestionClient.sanitize("GraphCode Templates") == "GraphCodeTemplates")
+    #expect(TitleSuggestionClient.sanitize("Fix flaky login tests") == "FixFlaky")
+    #expect(TitleSuggestionClient.sanitize("deploy") == "Deploy")
     #expect(TitleSuggestionClient.sanitize("\"Deploy!\"") == "Deploy")
     #expect(TitleSuggestionClient.sanitize("") == nil)
     #expect(TitleSuggestionClient.sanitize("   \n  ") == nil)
@@ -39,16 +41,16 @@ struct TitleSuggestionTests {
     #expect(TitleSuggestionClient.accept("Deploy", taken: ["deploy"]) == nil)
     #expect(TitleSuggestionClient.accept("Deploy", taken: ["Research"]) == "Deploy")
     #expect(
-      TitleSuggestionClient.accept("Database Migration", taken: ["database migration"]) == nil)
+      TitleSuggestionClient.accept("DatabaseMigration", taken: ["databasemigration"]) == nil)
   }
 
   @Test
-  func theInstructionPrefersTwoPreciseWordsAndListsTakenNames() {
+  func theInstructionAsksForOneWordAndListsTakenNames() {
     let instruction = TitleSuggestionClient.instruction(
       for: "fix the build", taken: ["Deploy", "Research"])
-    #expect(instruction.contains("Prefer two words"))
-    #expect(instruction.contains("single word only when it alone names the task"))
-    #expect(instruction.contains("Never more than two words"))
+    #expect(instruction.contains("as a single word"))
+    #expect(instruction.contains("join them in CamelCase"))
+    #expect(!instruction.contains("two words"))
     #expect(instruction.contains("Deploy, Research"))
     #expect(instruction.contains("fix the build"))
     let bare = TitleSuggestionClient.instruction(for: "fix the build", taken: [])


### PR DESCRIPTION
Loop names came out of the backend namer as two words — "Artifactory Audit", "Graphcode Templates", "Compact Names" — because the instruction told it to prefer two. A loop's name is read in a sidebar row and a card header, where one word carries further.

- The instruction now asks for a single word, and says to fold two concepts into CamelCase (`GraphCodeTemplates`) rather than spend a space on them.
- `sanitize` still takes two tokens off the model's answer, but joins them capitalised instead of with a space — a chatty backend gets folded into the name it was asked for rather than refused.

Existing loops keep the names they already have; this changes what new ones are called.

## Verification

| Check | Result |
| --- | --- |
| `xcodebuild … test` | ✅ 1537 tests in 160 suites passed |
| `swiftlint lint` | ✅ 0 errors |
| `swift format lint --strict` | ✅ clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dY6vr12Vcxa3rweeCow43