### PR TITLE
Fold the placeholder and instance loop names into one word

### DIFF
--- a/GraphcodeKit/Sources/Domain/NodeDraft.swift
+++ b/GraphcodeKit/Sources/Domain/NodeDraft.swift
@@ -22,7 +22,7 @@ public struct NodeDraft: Codable, Equatable, Sendable {
   /// time the answer arrives the only handle it has is this id. Without it, the client
   /// would have to diff two `graphChanged` broadcasts to guess which node it just made.
   public var id: UUID
-  /// Optional — a blank title creates the node as "New Loop" (see `makeNode`), on the
+  /// Optional — a blank title creates the node as "NewLoop" (see `makeNode`), on the
   /// theory that naming every loop up front was the most tedious field on the form and
   /// the one a backend can fill in afterward.
   public var title: String
@@ -117,7 +117,7 @@ public struct NodeDraft: Codable, Equatable, Sendable {
   /// only in the form — the wire protocol is reachable from the CLI too, and a rule that
   /// only one client applies isn't a rule.
   public var isValid: Bool {
-    // No title requirement: `makeNode` falls back to "New Loop", and the app follows up
+    // No title requirement: `makeNode` falls back to "NewLoop", and the app follows up
     // with a backend-suggested name (see `TitleSuggestionClient`). Requiring one taught
     // people to type a throwaway word to get past the form — the prompt is the field
     // that means something, so it's the one each type below actually demands.
@@ -165,14 +165,14 @@ public struct NodeDraft: Codable, Equatable, Sendable {
       //
       // A name is required, though, and only here: every other type gets one from its
       // own backend after it starts working (`TitleSuggestionClient`), and a composite
-      // never starts. "New Loop" would be its name for good.
+      // never starts. "NewLoop" would be its name for good.
       return !title.trimmingCharacters(in: .whitespaces).isEmpty
     }
   }
 
   /// What an untitled draft's node is called until something better arrives — the app
   /// asks the loop's own backend for a real name and renames the node when it answers.
-  public static let untitledFallback = "New Loop"
+  public static let untitledFallback = "NewLoop"
 
   /// The backend this draft builds with when nobody resolved one. `GraphStore` resolves
   /// inheritance *before* this is consulted — a child created by a running loop takes

--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -2222,13 +2222,14 @@ public actor GraphStore {
         subGraph: template.subGraph))
   }
 
-  /// "Triage #2", "Triage #3" — a spawned instance needs to be tellable apart from its
+  /// "Triage2", "Triage3" — a spawned instance needs to be tellable apart from its
   /// template at a glance in the sidebar, which is the only place many of them will
-  /// ever be seen.
+  /// ever be seen. The index joins the name without a space, the same one-word shape
+  /// every other loop name has.
   static func instanceTitle(for template: LoopNode, existing: [String]) -> String {
     var index = 2
-    while existing.contains("\(template.title) #\(index)") { index += 1 }
-    return "\(template.title) #\(index)"
+    while existing.contains("\(template.title)\(index)") { index += 1 }
+    return "\(template.title)\(index)"
   }
 
   private func commitFiring(_ edgeID: UUID) {

--- a/graphcode/Sources/Clients/TitleSuggestionClient.swift
+++ b/graphcode/Sources/Clients/TitleSuggestionClient.swift
@@ -6,7 +6,7 @@ import GraphcodeKit
 /// title blank — `claude -p` / `copilot -p` / `codex exec`, the headless print-mode
 /// shape of each CLI, so nothing here opens a session or touches the loop's actual work.
 ///
-/// Fire-and-forget by design: the node is already created as "New Loop" by the time this
+/// Fire-and-forget by design: the node is already created as "NewLoop" by the time this
 /// runs, and a `renameNode` follows only if an answer arrives. A backend that is slow,
 /// missing, or confused costs nothing but the fallback name staying.
 struct TitleSuggestionClient: Sendable {
@@ -86,7 +86,7 @@ extension TitleSuggestionClient: DependencyKey {
     case .copilotCLI: command = "exec copilot -p \"$\(promptVariable)\""
     // This is a separate headless process, so it does not inherit the permission flags
     // from the loop session. Without Codex's unattended flag it can stop at an approval
-    // prompt and the new loop remains named "New Loop" forever.
+    // prompt and the new loop remains named "NewLoop" forever.
     case .codex:
       command =
         "exec codex exec --dangerously-bypass-approvals-and-sandbox \"$\(promptVariable)\""

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -810,7 +810,7 @@ extension ProjectFeature {
                 .createEdge(from: parentNodeID, to: draft.id, spec: EdgeSpec()))))
         }
 
-        // A blank title creates the node as "New Loop" and asks the loop's own
+        // A blank title creates the node as "NewLoop" and asks the loop's own
         // backend for a real one — after creation, so a slow (or absent) CLI never
         // holds the node itself hostage. The rename can target the node because the
         // draft's id *is* the node's id (see `NodeDraft.id`); no answer just means

--- a/graphcode/Tests/CompositeSpawnTests.swift
+++ b/graphcode/Tests/CompositeSpawnTests.swift
@@ -37,7 +37,7 @@ struct CompositeSpawnTests {
     await store.handle(.nodeCheckApproved(trigger.id))
 
     let instance = try? #require(await store.graph.nodes.last)
-    #expect(instance?.title == "Triage #2")
+    #expect(instance?.title == "Triage2")
     #expect(instance?.subGraph?.nodes.count == 2)
   }
 

--- a/graphcode/Tests/GraphStoreTests.swift
+++ b/graphcode/Tests/GraphStoreTests.swift
@@ -276,7 +276,7 @@ struct GraphStoreTests {
     #expect(graph.nodes[id: nodes[1].id]?.state == .idle)
     #expect(graph.nodes[id: nodes[1].id]?.title == "Template")
     // The instance is distinguishable at a glance and carries no edges of its own.
-    #expect(graph.nodes[2].title == "Template #2")
+    #expect(graph.nodes[2].title == "Template2")
     #expect(!graph.edges.contains { $0.from == graph.nodes[2].id || $0.to == graph.nodes[2].id })
   }
 
@@ -335,7 +335,7 @@ struct GraphStoreTests {
 
     // A turn-based draft with no criterion is deliberately *not* in this list — that one
     // is valid now, since the human doing the verifying is there either way. Neither is
-    // an untitled draft: a blank title creates the node as "New Loop" and the app names
+    // an untitled draft: a blank title creates the node as "NewLoop" and the app names
     // it properly afterward (see `TitleSuggestionClient`).
     await store.handle(.createNode(NodeDraft(title: "No goal", loopType: .goalBased)))
     await store.handle(.createNode(NodeDraft(title: "Bare", loopType: .timeBased)))

--- a/graphcode/Tests/MessageAndSpawnTests.swift
+++ b/graphcode/Tests/MessageAndSpawnTests.swift
@@ -181,7 +181,7 @@ struct MessageAndSpawnTests {
     await store.handle(.nodeCheckApproved(nodes[0].id))
 
     let titles = await store.graph.nodes.map(\.title)
-    #expect(titles == ["Triage", "Worker", "Worker #2", "Worker #3"])
+    #expect(titles == ["Triage", "Worker", "Worker2", "Worker3"])
   }
 
   @Test
@@ -205,13 +205,13 @@ struct MessageAndSpawnTests {
     await store.handle(.nodeCheckApproved(trigger.id))
 
     let instance = try? #require(await store.graph.nodes.last)
-    #expect(instance?.title == "Worker #2")
+    #expect(instance?.title == "Worker2")
     #expect(instance?.modelTier == .capable)
     #expect(instance?.worktreeBinding == worktree)
     #expect(instance?.triggerPrompt == "/loop 1h Check")
     // An unattended instance starts working immediately — spawning it and not running it
     // would just litter the graph.
-    #expect(started.value.map(\.title) == ["Worker #2"])
+    #expect(started.value.map(\.title) == ["Worker2"])
   }
 
   @Test

--- a/graphcode/Tests/NodeDraftTests.swift
+++ b/graphcode/Tests/NodeDraftTests.swift
@@ -92,7 +92,7 @@ struct NodeDraftTests {
 
   /// The title used to be the one field every draft demanded, and it was the most
   /// tedious one on the form — the prompt is what the human has in their head. A blank
-  /// title now creates the node as "New Loop", and the app follows up with a
+  /// title now creates the node as "NewLoop", and the app follows up with a
   /// backend-suggested name (see `TitleSuggestionClient`).
   @Test
   func anUntitledDraftIsValidAndFallsBackToAPlaceholderName() {
@@ -100,7 +100,7 @@ struct NodeDraftTests {
       title: "  ", loopType: .turnBased, checkDescription: "Sound?",
       firstInstruction: "Read the RFC")
     #expect(draft.isValid)
-    #expect(draft.makeNode().title == "New Loop")
+    #expect(draft.makeNode().title == "NewLoop")
     // A typed title is used as typed.
     #expect(
       NodeDraft(title: "Research", loopType: .turnBased).makeNode().title == "Research")
@@ -135,7 +135,7 @@ struct NodeDraftTests {
     let draft = NodeDraft(title: "Triage inbox", loopType: .composite)
     #expect(draft.isValid)
     // The name, though, is required for this type alone: every other kind gets one from
-    // its own backend once it starts working, and a composite never starts. "New Loop"
+    // its own backend once it starts working, and a composite never starts. "NewLoop"
     // would be its name for good.
     #expect(!NodeDraft(title: "  ", loopType: .composite).isValid)
 

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -33,7 +33,7 @@ struct ProjectFeatureTests {
     #expect(store.state.nodePositions[node.id] != nil)
   }
 
-  /// An untitled draft is created as "New Loop" immediately, then renamed to whatever
+  /// An untitled draft is created as "NewLoop" immediately, then renamed to whatever
   /// the backend suggests — creation never waits on the suggestion, and the rename can
   /// find its node because the draft's id *is* the node's id.
   @Test
@@ -71,7 +71,7 @@ struct ProjectFeatureTests {
       return #expect(Bool(false), "expected a createNode command, got \(commands)")
     }
     #expect(draft.id == draftID)
-    #expect(draft.makeNode().title == "New Loop")
+    #expect(draft.makeNode().title == "NewLoop")
     #expect(
       commands.last
         == .graphCommand(


### PR DESCRIPTION
Follow-on to #266, which makes the backend namer produce single-word names. Two loop names the app writes for itself still carried a space:

| Was | Now | What it is |
| --- | --- | --- |
| `New Loop` | `NewLoop` | the name a loop wears until its backend answers with a real one |
| `Triage #2` | `Triage2` | the suffix that tells a spawned instance apart from its template |

No overlap with #266 — different files, either order merges.

## Verification

| Check | Result |
| --- | --- |
| `xcodebuild … test` | ✅ 1537 tests in 160 suites passed |
| `swiftlint lint` | ✅ 0 errors |
| `swift format lint --strict` | ✅ clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dY6vr12Vcxa3rweeCow43