### PR TITLE
Make export/import unconditional and drop its setting

### DIFF
--- a/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
+++ b/GraphcodeKit/Sources/Domain/GraphcodeSettings.swift
@@ -309,19 +309,6 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
   /// switch that quietly does two things.
   public var summarisesLoops: Bool
 
-  /// Whether the export/import surfaces are offered at all — the context-menu items on
-  /// loop cards, sidebar loop and folder rows, the canvas background's counterparts,
-  /// and the CLI's `node export` / `graph export` / `node import` verbs.
-  ///
-  /// **On by default** since 0.1.40, after one release opt-in. It earns the default the
-  /// summary rail couldn't (`summarisesLoops`): every surface is a menu item that does
-  /// nothing until deliberately clicked — no claims made on a loop's behalf, no tokens
-  /// spent, nothing running unattended. Off, none of those surfaces appear and the CLI
-  /// verbs refuse with a pointer here; bundles already exported remain ordinary zips,
-  /// importable again the moment this is back on. A settings file that explicitly says
-  /// `false` — anyone who tried the experiment and turned it off — is preserved.
-  public var sharesLoops: Bool
-
   /// Whether a small model may rewrite the current beat, on top of the free reading.
   ///
   /// **Off by default, and meaningless with `summarisesLoops` off.** The rail works
@@ -387,7 +374,7 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
   /// (which cannot see ramps or `UserDefaults`) actually enforces: every `artifactory`
   /// command, the briefing's board section, and the wake digest's pointer all read
   /// this. A flip the human made in Settings is a recorded choice, preserved the way
-  /// `sharesLoops`' is.
+  /// `summarisesLoops`' is.
   public var artifactoryEnabled: Bool
 
   /// Whether `graphcoded` keeps the Mac awake while any loop is running
@@ -413,7 +400,6 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     briefsSessionsAboutTheGraph: Bool = true,
     autoSelectsModel: Bool = false,
     showsActivityStrip: Bool = false,
-    sharesLoops: Bool = true,
     summarisesLoops: Bool = false,
     summaryUsesModel: Bool = false,
     visualisesSummaries: Bool = false,
@@ -430,7 +416,6 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
     self.briefsSessionsAboutTheGraph = briefsSessionsAboutTheGraph
     self.autoSelectsModel = autoSelectsModel
     self.showsActivityStrip = showsActivityStrip
-    self.sharesLoops = sharesLoops
     self.summarisesLoops = summarisesLoops
     self.summaryUsesModel = summaryUsesModel
     self.visualisesSummaries = visualisesSummaries
@@ -469,11 +454,6 @@ public struct GraphcodeSettings: Codable, Equatable, Sendable {
       try container.decodeIfPresent(Bool.self, forKey: .autoSelectsModel) ?? false
     showsActivityStrip =
       try container.decodeIfPresent(Bool.self, forKey: .showsActivityStrip) ?? false
-    // Absent takes the new default — on. An explicit `false`, written by anyone who
-    // tried the experiment and switched it off, is preserved; flipping a recorded
-    // choice under someone is what the migration comments above never do.
-    sharesLoops =
-      try container.decodeIfPresent(Bool.self, forKey: .sharesLoops) ?? true
     // Absent means nobody has opted in, which is the default again. A person who switched
     // it on has `true` in their file — including anyone whose 0.1.37 install wrote the
     // then-default out — and that is preserved.

--- a/GraphcodeKit/Sources/Domain/SessionBriefing.swift
+++ b/GraphcodeKit/Sources/Domain/SessionBriefing.swift
@@ -246,8 +246,6 @@ public enum SessionBriefing {
       - `graphcode node export \(projectPath) <node-id> --output <file.zip>` packages a
         loop and its descendants for sharing, and `graphcode node import \(projectPath)
         <file.zip> [--as-child-of <node-id>]` splices a bundle in with fresh identities.
-        Both stay off until "Export and import loops" is enabled in the app's Settings —
-        the command says so when it is not.
       - `graphcode projects` lists every project, `graphcode usage \(projectPath)` totals
         a graph's token spend, and the reserved path `graphcode://global` addresses the
         app-wide global graph wherever a project path is accepted.

--- a/graphcode-cli/Sources/main.swift
+++ b/graphcode-cli/Sources/main.swift
@@ -30,19 +30,6 @@ func fail(_ message: String, code: Int32 = ExitCode.usage) -> Never {
   exit(code)
 }
 
-/// Export/import can be switched off; the CLI honours the same switch the app's menus
-/// do (`GraphcodeSettings.sharesLoops`), read from the same file, so a script can't
-/// reach a surface the Settings screen says doesn't exist.
-func requireLoopSharing() {
-  guard !GraphcodeSettingsStore.load().sharesLoops else { return }
-  fail(
-    """
-    export/import is switched off on this machine. Turn on "Export and import loops" \
-    in GraphCode's Settings, or set "sharesLoops": true in \
-    \(GraphcodeSettingsStore.url.path).
-    """)
-}
-
 let command: GraphcodeCommand
 do {
   command = try GraphcodeCommand.parse(Array(CommandLine.arguments.dropFirst()))
@@ -55,13 +42,6 @@ do {
 if case .help = command {
   print(GraphcodeCommand.helpText)
   exit(0)
-}
-
-// Before dialling the daemon: a refusal on policy has nothing to ask a daemon about,
-// and should read the same whether or not one is running.
-switch command {
-case .exportNode, .exportGraph, .importNodes: requireLoopSharing()
-default: break
 }
 
 // Also before the daemon: reap reads graphs from disk and talks to zmx directly, and

--- a/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
@@ -126,15 +126,12 @@ extension AppSidebarView {
     Divider()
     // The folder-level counterparts to a loop row's Export/Import: everything in this
     // folder as one bundle, and an import that lands at the folder's top level —
-    // regardless of where its canvas happens to be parked. Behind the same
-    // experiments switch as every other export/import surface.
-    if sharesLoops {
-      if !project.graph.nodes.isEmpty {
-        Button("Export All Loops…") { send(.projectExportRequested, to: project.id) }
-      }
-      Button("Import Loops…") { send(.projectImportRequested, to: project.id) }
-      Divider()
+    // regardless of where its canvas happens to be parked.
+    if !project.graph.nodes.isEmpty {
+      Button("Export All Loops…") { send(.projectExportRequested, to: project.id) }
     }
+    Button("Import Loops…") { send(.projectImportRequested, to: project.id) }
+    Divider()
     Button("Delete Loops…", role: .destructive) { projectPendingLoopDeletion = project }
     Button("Delete \"\(project.graph.project.name)\"…", role: .destructive) {
       projectPendingDelete = project
@@ -176,14 +173,12 @@ extension AppSidebarView {
 
     Divider()
 
-    if sharesLoops {
-      Button("Export Loop…") { send(.exportNodeRequested(node.id), to: projectPath) }
-      Button("Import Loops Here…") {
-        send(.importLoopsRequested(asChildOf: node.id), to: projectPath)
-      }
-
-      Divider()
+    Button("Export Loop…") { send(.exportNodeRequested(node.id), to: projectPath) }
+    Button("Import Loops Here…") {
+      send(.importLoopsRequested(asChildOf: node.id), to: projectPath)
     }
+
+    Divider()
 
     Button("Delete Loop…", role: .destructive) {
       send(.deleteNodeRequested(node.id), to: projectPath)

--- a/graphcode/Sources/Features/App/AppSidebarView.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView.swift
@@ -15,20 +15,13 @@ import UniformTypeIdentifiers
 struct AppSidebarView: View {
   @Bindable var store: StoreOf<AppFeature>
 
-  /// Whether the loop rows' menus offer Export/Import (`GraphcodeSettings.sharesLoops`).
-  ///
-  /// Captured as a plain value at construction — the default expression runs in
-  /// `AppView.body`, the same safe spot its activity-strip read lives — because
-  /// reading the `@Observable` settings model *inside* `nodeMenu`'s builder
-  /// segfaulted the List's outline diffing at launch (`ForEachState.item(at:offset:)`
-  /// null deref while the coordinator walked row view IDs). The canvas menus get away
-  /// with the in-builder read; the sidebar's outline does not, so the flag arrives
-  /// here as data and the toggle still propagates through `AppView`'s re-render.
-  var sharesLoops: Bool = SettingsModel.shared.settings.sharesLoops
-
   /// Whether the add menu offers Add Codespace… — the `codespaces` ramp
-  /// (`FeatureRamps`), read once at construction for the same reason as
-  /// `sharesLoops`. A ramp change applies from the next re-render.
+  /// (`FeatureRamps`), captured as a plain value at construction: the default
+  /// expression runs in `AppView.body`, the same safe spot its activity-strip read
+  /// lives, because reading an `@Observable` model *inside* a row menu's builder
+  /// segfaulted the List's outline diffing at launch (`ForEachState.item(at:offset:)`
+  /// null deref while the coordinator walked row view IDs). A ramp change applies from
+  /// the next re-render.
   var offersCodespaces: Bool = FeatureRamps.isEnabled(.codespaces)
 
   // Several of the stored properties and the selection type below are not `private`

--- a/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/LoopWorkspaceRail.swift
@@ -26,8 +26,8 @@ struct LoopWorkspaceRail: View {
   /// beside the summary's own fold.
   let isBoardFolded: Bool
   /// Whether this project's Artifactory is switched on, passed in as a plain value the
-  /// way `AppSidebarView` takes `sharesLoops`: the settings model is `@Observable` and
-  /// the render path should not be reading a file.
+  /// way `AppSidebarView` takes `offersCodespaces`: the settings model is `@Observable`
+  /// and the render path should not be reading a file.
   let artifactoryEnabled: Bool
   /// Whether the board section is collapsed to its one line, beside the summary's and
   /// the diagram's own folds.

--- a/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
@@ -245,17 +245,11 @@ extension GraphOverviewView {
 
     Divider()
 
-    // Behind the experiments switch, exactly as on a folder's canvas and in the sidebar:
-    // a right-click verb that writes files and splices loops into graphs is one a person
-    // should choose, not find. Read inline like the folder canvas's menu does — the
-    // sidebar's outline is the one place that cannot (see `AppSidebarView.sharesLoops`).
-    if SettingsModel.shared.settings.sharesLoops {
-      Button("Export Loop…") { send(.exportNodeRequested(node.id), to: loop.projectPath) }
-      Button("Import Loops Here…") {
-        send(.importLoopsRequested(asChildOf: node.id), to: loop.projectPath)
-      }
-      Divider()
+    Button("Export Loop…") { send(.exportNodeRequested(node.id), to: loop.projectPath) }
+    Button("Import Loops Here…") {
+      send(.importLoopsRequested(asChildOf: node.id), to: loop.projectPath)
     }
+    Divider()
 
     Button("Delete Loop…", role: .destructive) {
       send(.deleteNodeRequested(node.id), to: loop.projectPath)

--- a/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
@@ -130,14 +130,10 @@ extension ProjectCanvasView {
     Divider()
     // Export packages this loop and everything descended from it — child loops,
     // sub-loops, session memory — into a zip another graph can import; Import splices
-    // a bundle's loops in underneath this one. See `GraphExportBundle`. Behind the
-    // experiments switch: a right-click verb that writes files and splices loops into
-    // graphs is one a person should choose, not find.
-    if SettingsModel.shared.settings.sharesLoops {
-      Button("Export Loop…") { store.send(.exportNodeRequested(node.id)) }
-      Button("Import Loops Here…") { store.send(.importLoopsRequested(asChildOf: node.id)) }
-      Divider()
-    }
+    // a bundle's loops in underneath this one. See `GraphExportBundle`.
+    Button("Export Loop…") { store.send(.exportNodeRequested(node.id)) }
+    Button("Import Loops Here…") { store.send(.importLoopsRequested(asChildOf: node.id)) }
+    Divider()
     Button("Delete Loop…", role: .destructive) {
       store.send(.deleteNodeRequested(node.id))
     }

--- a/graphcode/Sources/Features/Project/ProjectCanvasView.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasView.swift
@@ -286,15 +286,12 @@ struct ProjectCanvasView: View {
     }
     // The whole-canvas counterparts to a card's Export Loop…/Import Loops Here…:
     // everything on this canvas as one bundle, and an import that lands beside the
-    // existing loops rather than under one of them. Behind the same experiments
-    // switch as the card's items.
-    if SettingsModel.shared.settings.sharesLoops {
-      Divider()
-      if !store.canvasGraph.nodes.isEmpty {
-        Button("Export All Loops…") { store.send(.exportGraphRequested) }
-      }
-      Button("Import Loops…") { store.send(.importLoopsRequested(asChildOf: nil)) }
+    // existing loops rather than under one of them.
+    Divider()
+    if !store.canvasGraph.nodes.isEmpty {
+      Button("Export All Loops…") { store.send(.exportGraphRequested) }
     }
+    Button("Import Loops…") { store.send(.importLoopsRequested(asChildOf: nil)) }
   }
 
   private var worktreesMenuTitle: String {

--- a/graphcode/Sources/Features/Settings/SettingsView.swift
+++ b/graphcode/Sources/Features/Settings/SettingsView.swift
@@ -177,18 +177,6 @@ struct SettingsView: View {
         .foregroundStyle(.secondary)
         .fixedSize(horizontal: false, vertical: true)
 
-        Toggle(
-          "Export and import loops",
-          isOn: $model.settings.sharesLoops)
-        Text(
-          "Right-click a loop — on the canvas or in the sidebar — to package it, its "
-            + "child loops and their session memory into a zip, and to import such a "
-            + "bundle back in. Also enables the CLI's export/import verbs."
-        )
-        .font(.caption2)
-        .foregroundStyle(.secondary)
-        .fixedSize(horizontal: false, vertical: true)
-
         // Always offered. The daemon-side bit lives in `artifactoryEnabled`
         // (`GraphcodeSettings`), on by default; a flip here is what turns the board
         // off for a person who finds it too much, and is remembered over any rollout.

--- a/graphcode/Tests/BoardsOffRegressionTests.swift
+++ b/graphcode/Tests/BoardsOffRegressionTests.swift
@@ -181,7 +181,6 @@ struct BoardsOffRegressionTests {
     #expect(loaded.summarisesLoops)
     #expect(loaded.summaryUsesModel)
     #expect(loaded.daemonHeartbeatEnabled == before.daemonHeartbeatEnabled)
-    #expect(loaded.sharesLoops == before.sharesLoops)
   }
 
   @Test

--- a/graphcode/Tests/SessionBriefingTests.swift
+++ b/graphcode/Tests/SessionBriefingTests.swift
@@ -117,7 +117,7 @@ struct SessionBriefingTests {
     #expect(briefing.contains("irreversible"))
     #expect(briefing.contains("edge create \(Self.project)"))
     #expect(briefing.contains("node export \(Self.project)"))
-    #expect(briefing.contains("Export and import loops"))
+    #expect(briefing.contains("node import \(Self.project)"))
     #expect(briefing.contains("graphcode://global"))
   }
 

--- a/graphcode/Tests/SettingsBackendWriteTests.swift
+++ b/graphcode/Tests/SettingsBackendWriteTests.swift
@@ -52,7 +52,7 @@ struct SettingsBackendWriteTests {
     defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
     var settings = GraphcodeSettings()
-    settings.sharesLoops = true
+    settings.summarisesLoops = true
     settings.showsActivityStrip = false
     GraphcodeSettingsStore.save(settings, to: url)
 
@@ -60,7 +60,7 @@ struct SettingsBackendWriteTests {
 
     let reloaded = GraphcodeSettingsStore.load(from: url)
     #expect(reloaded.defaultBackend == .copilotCLI)
-    #expect(reloaded.sharesLoops)
+    #expect(reloaded.summarisesLoops)
     #expect(!reloaded.showsActivityStrip)
   }
 


### PR DESCRIPTION
## What

Export/import of loops is now always available. `GraphcodeSettings.sharesLoops` is gone, along with the "Export and import loops" toggle in Settings.

## Why

The switch has defaulted to on since 0.1.40. Every surface behind it is a right-click menu item that does nothing until deliberately clicked — nothing runs, nothing is spent — so the toggle only offered a way to hide working verbs from yourself.

## Changes

| Area | Change |
| --- | --- |
| `GraphcodeSettings` | property, init parameter and decode migration removed |
| `SettingsView` | toggle + its caption removed |
| Canvas / overview / sidebar menus | five `if sharesLoops` gates unwrapped |
| `AppSidebarView` | stored flag dropped; the segfault note it carried moved to `offersCodespaces`, which needs it for the same reason |
| `graphcode-cli` | `requireLoopSharing()` and its dispatch removed |
| `SessionBriefing` | the "stay off until enabled in Settings" caveat dropped from the export/import bullet |
| Tests | three assertions repointed to other settings; briefing test now checks the `node import` verb |

A settings file that still records `"sharesLoops": false` is ignored — that is what enabling by default means here.

## Verification

| Check | Result |
| --- | --- |
| `xcodebuild -scheme graphcode build` | ✅ 0 errors |
| `-scheme graphcode-cli` / `-scheme graphcoded` | ✅ 0 errors |
| Tests | ✅ 1537 tests in 160 suites passed |
| `swiftlint lint` | ✅ 0 errors |
| `swift format lint --strict` | ✅ clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EUE64JZc1QUodfL8LnPkK