### PR TITLE
Make local development identity configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Optional identity for `make dev-*`. Use a reverse-DNS prefix you control.
+DEV_BUNDLE_ID_PREFIX=com.example.graphcode-localdev
+DEV_APP_DISPLAY_NAME=GraphCode (localdev)
+DEV_SUPPORT_DIR_NAME=.graphcode.localdev
+
+# Release-only overrides can also live here when needed. Keep credentials out of it.
+# SIGN_ID=Developer ID Application: Your Name (TEAMID)
+# NOTARY_PROFILE=graphcode

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # Optional identity for `make dev-*`. Use a reverse-DNS prefix you control.
 DEV_BUNDLE_ID_PREFIX=com.example.graphcode-localdev
 DEV_APP_DISPLAY_NAME=GraphCode (localdev)
-DEV_SUPPORT_DIR_NAME=.graphcode.localdev
+# Keep this in `.graphcode-<lowercase-slug>` form; the suffix identifies its daemon.
+DEV_SUPPORT_DIR_NAME=.graphcode-localdev
 
 # Release-only overrides can also live here when needed. Keep credentials out of it.
 # SIGN_ID=Developer ID Application: Your Name (TEAMID)

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@ xcuserdata/
 # mise
 .mise.local.toml
 
+# Developer-local build identity and signing overrides
+.env
+.env.local
+.env.*.local
+!.env.example
+
 # macOS
 .DS_Store
 

--- a/GraphcodeKit/Sources/DaemonBootstrap.swift
+++ b/GraphcodeKit/Sources/DaemonBootstrap.swift
@@ -36,7 +36,16 @@ import Foundation
     /// instead of rewriting the first's. The default workspace keeps the bare label it has
     /// always had — an existing install must not see its agent renamed.
     static var label: String { Workspace.current.daemonLabel }
-    private static let appBundleIdentifier = "dev.graphcode.app"
+    /// The app this agent belongs to. Read from the running bundle so a side-by-side
+    /// build (its own bundle id, its own `GRAPHCODE_SUPPORT_DIR`) associates its agent
+    /// with *itself* — a hardcoded id would point the dev build's Login Item at the
+    /// installed release, and macOS would attribute one app's background agent to the
+    /// other. Falls back to the shipping id for the CLI and daemon, which have no app
+    /// bundle of their own.
+    private static var appBundleIdentifier: String {
+      Bundle.main.bundleIdentifier.flatMap { $0.hasSuffix(".app") ? $0 : nil }
+        ?? "dev.graphcode.app"
+    }
     /// `graphcode` here is the CLI, not the app — a different product that happens to share
     /// the name a human types. Shipping it matters: `~/.graphcode/bin` is what the README
     /// tells people to put on their PATH, and without this a drag-to-Applications install

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: doctor generate build-app build-daemon run-app run-daemon \
         daemon-install daemon-uninstall daemon-status test check format clean \
-        dev-generate dev-build-app dev-install-zmx dev-run-app dev-status \
+        dev-generate dev-build-app dev-build-daemon dev-install-daemon \
+        dev-install-zmx dev-run-app dev-status \
         third-party build-zmx install-zmx build-ghostty vendor-sdk \
         build-cli install-cli release-dmg notarize signing-doctor tap-bump
 
@@ -231,7 +232,10 @@ daemon-status:
 # ---------------------------------------------------------------------------
 DEV_BUNDLE_ID_PREFIX ?= local.graphcode.dev
 DEV_APP_DISPLAY_NAME ?= GraphCode (localdev)
-DEV_SUPPORT_DIR_NAME ?= .graphcode.localdev
+DEV_SUPPORT_DIR_NAME ?= .graphcode-localdev
+DEV_SUPPORT_DIR := $(HOME)/$(DEV_SUPPORT_DIR_NAME)
+DEV_DAEMON_LABEL := $(DAEMON_LABEL).$(patsubst .graphcode-%,%,$(DEV_SUPPORT_DIR_NAME))
+DEV_DAEMON_PLIST := $(LAUNCH_AGENTS_DIR)/$(DEV_DAEMON_LABEL).plist
 DEV_ENV := TUIST_BUNDLE_ID_PREFIX="$(DEV_BUNDLE_ID_PREFIX)" \
            TUIST_APP_DISPLAY_NAME="$(DEV_APP_DISPLAY_NAME)"
 
@@ -242,15 +246,39 @@ dev-build-app: dev-generate
 	set -o pipefail && $(DEV_ENV) $(MISE) xcodebuild -workspace $(WORKSPACE) \
 		-scheme $(SCHEME_APP) -destination '$(DESTINATION)' build | $(MISE) xcbeautify
 
+dev-build-daemon: dev-generate
+	set -o pipefail && $(DEV_ENV) $(MISE) xcodebuild -workspace $(WORKSPACE) \
+		-scheme $(SCHEME_DAEMON) -destination '$(DESTINATION)' build | $(MISE) xcbeautify
+
+dev-install-daemon: dev-build-daemon
+	@mkdir -p "$(DEV_SUPPORT_DIR)" "$(LAUNCH_AGENTS_DIR)"
+	@BIN_PATH=$$($(DEV_ENV) $(MISE) xcodebuild -workspace $(WORKSPACE) \
+		-scheme $(SCHEME_DAEMON) -destination '$(DESTINATION)' -showBuildSettings 2>/dev/null \
+		| awk -F'= ' '/ BUILT_PRODUCTS_DIR /{print $$2; exit}')/graphcoded; \
+	sed -e "s#dev.graphcode.graphcoded#$(DEV_DAEMON_LABEL)#g" \
+	    -e "s#dev.graphcode.app#$(DEV_BUNDLE_ID_PREFIX).app#g" \
+	    -e "s#__GRAPHCODED_BIN__#$$BIN_PATH#g" \
+	    -e "s#__GRAPHCODED_SUPPORT_DIR__#$(DEV_SUPPORT_DIR)#g" \
+	    graphcoded/Support/dev.graphcode.graphcoded.plist.template > "$(DEV_DAEMON_PLIST)"; \
+	/usr/libexec/PlistBuddy -c "Add :EnvironmentVariables dict" \
+	    -c "Add :EnvironmentVariables:GRAPHCODE_SUPPORT_DIR string $(DEV_SUPPORT_DIR)" \
+	    "$(DEV_DAEMON_PLIST)"; \
+	launchctl unload "$(DEV_DAEMON_PLIST)" >/dev/null 2>&1 || true; \
+	launchctl load "$(DEV_DAEMON_PLIST)"; \
+	echo "graphcoded installed and loaded: $(DEV_DAEMON_PLIST)"
+
 # Installs zmx into the DEV support dir, not the release's, so the two never
 # share a binary or a session namespace.
 dev-install-zmx: build-zmx
-	@mkdir -p "$(HOME)/$(DEV_SUPPORT_DIR_NAME)/bin"
-	@cp "$(BUILD_DIR)/zmx/bin/zmx" "$(HOME)/$(DEV_SUPPORT_DIR_NAME)/bin/zmx"
-	@codesign --force --sign - "$(HOME)/$(DEV_SUPPORT_DIR_NAME)/bin/zmx" 2>/dev/null || true
-	@echo "installed: $(HOME)/$(DEV_SUPPORT_DIR_NAME)/bin/zmx"
+	@mkdir -p "$(DEV_SUPPORT_DIR)/bin"
+	@rm -f "$(DEV_SUPPORT_DIR)/bin/zmx"
+	@cp "$(BUILD_DIR)/zmx/bin/zmx" "$(DEV_SUPPORT_DIR)/bin/zmx"
+	@codesign --force --sign - "$(DEV_SUPPORT_DIR)/bin/zmx" 2>/dev/null
+	@"$(DEV_SUPPORT_DIR)/bin/zmx" version >/dev/null 2>&1 \
+		|| { echo "zmx installed but won't run — check its code signature"; exit 1; }
+	@echo "installed: $(DEV_SUPPORT_DIR)/bin/zmx"
 
-dev-run-app: dev-build-app dev-install-zmx
+dev-run-app: dev-build-app dev-install-zmx dev-install-daemon
 	@APP_PATH=$$($(DEV_ENV) $(MISE) xcodebuild -workspace $(WORKSPACE) \
 		-scheme $(SCHEME_APP) -destination '$(DESTINATION)' -showBuildSettings 2>/dev/null \
 		| awk -F'= ' '/ BUILT_PRODUCTS_DIR /{print $$2; exit}')/graphcode.app; \
@@ -260,9 +288,9 @@ dev-run-app: dev-build-app dev-install-zmx
 # What the dev build actually is, in one command — useful when the two get confusing.
 dev-status:
 	@echo "bundle id prefix : $(DEV_BUNDLE_ID_PREFIX)"
-	@echo "support dir      : $(HOME)/$(DEV_SUPPORT_DIR_NAME)"
-	@echo "daemon (dev)     : $$(launchctl list | awk '/graphcoded/ && /$(DEV_BUNDLE_ID_PREFIX)/{print $$3}' | paste -sd' ' -)"
-	@echo "daemon (release) : $$(launchctl list | awk '/graphcoded/ && !/$(DEV_BUNDLE_ID_PREFIX)/{print $$3}' | paste -sd' ' -)"
+	@echo "support dir      : $(DEV_SUPPORT_DIR)"
+	@echo "daemon (dev)     : $$(launchctl list | awk '$$3 == "$(DEV_DAEMON_LABEL)" {print $$3}')"
+	@echo "daemon (release) : $$(launchctl list | awk '$$3 == "$(DAEMON_LABEL)" {print $$3}')"
 	@echo "dev app running  : $$(pgrep -f 'Debug/graphcode.app/Contents/MacOS/graphcode' | paste -sd' ' - | sed 's/^$$/no/')"
 	@ls -d /Applications/graphcode.app >/dev/null 2>&1 \
 		&& echo "installed release: /Applications/graphcode.app ($$(defaults read /Applications/graphcode.app/Contents/Info CFBundleIdentifier 2>/dev/null))" \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ SCHEME_CLI := graphcode-cli
 WORKSPACE := graphcode.xcworkspace
 DESTINATION := platform=macOS
 
+# Optional developer-local overrides. `.env.local` wins when both exist;
+# command-line assignments still win over either file.
+-include .env
+-include .env.local
+
 BUILD_DIR := $(CURDIR)/.build
 
 # zig 0.15.2 cannot link against macOS SDK 26.x — that SDK dropped the plain
@@ -219,12 +224,11 @@ daemon-status:
 # `Workspace.daemonLabel` suffixes the slug — so nothing here touches the
 # release's agent.
 #
-# The `ai.kortexa` prefix is deliberate: it is a namespace we control, so a dev
-# build can never collide with whatever `app.graphcode`/`dev.graphcode` becomes.
+# Override these in `.env.local` when the defaults collide with another local build.
 # ---------------------------------------------------------------------------
-DEV_BUNDLE_ID_PREFIX := ai.kortexa.graphcode-localdev
-DEV_APP_DISPLAY_NAME := GraphCode (localdev)
-DEV_SUPPORT_DIR_NAME := .graphcode.localdev
+DEV_BUNDLE_ID_PREFIX ?= local.graphcode.dev
+DEV_APP_DISPLAY_NAME ?= GraphCode (localdev)
+DEV_SUPPORT_DIR_NAME ?= .graphcode.localdev
 DEV_ENV := TUIST_BUNDLE_ID_PREFIX="$(DEV_BUNDLE_ID_PREFIX)" \
            TUIST_APP_DISPLAY_NAME="$(DEV_APP_DISPLAY_NAME)"
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: doctor generate build-app build-daemon run-app run-daemon \
         daemon-install daemon-uninstall daemon-status test check format clean \
+        dev-generate dev-build-app dev-install-zmx dev-run-app dev-status \
         third-party build-zmx install-zmx build-ghostty vendor-sdk \
         build-cli install-cli release-dmg notarize signing-doctor tap-bump
 
@@ -204,6 +205,61 @@ daemon-uninstall:
 
 daemon-status:
 	@launchctl list | grep $(DAEMON_LABEL) || echo "graphcoded is not loaded"
+
+# ---------------------------------------------------------------------------
+# dev build — a second graphcode that runs beside an installed release.
+#
+# Side-by-side needs BOTH halves, which is why these are one target and not a
+# note in the README:
+#   * a distinct bundle id, or macOS confuses the two apps in LaunchServices,
+#     Login Items, and background-agent attribution;
+#   * a distinct support dir, or they share graphs and zmx session names and
+#     fight over the sessions (see SupportDirectory's header).
+# The support dir also gives the dev daemon its own launchd label for free —
+# `Workspace.daemonLabel` suffixes the slug — so nothing here touches the
+# release's agent.
+#
+# The `ai.kortexa` prefix is deliberate: it is a namespace we control, so a dev
+# build can never collide with whatever `app.graphcode`/`dev.graphcode` becomes.
+# ---------------------------------------------------------------------------
+DEV_BUNDLE_ID_PREFIX := ai.kortexa.graphcode-localdev
+DEV_APP_DISPLAY_NAME := GraphCode (localdev)
+DEV_SUPPORT_DIR_NAME := .graphcode.localdev
+DEV_ENV := TUIST_BUNDLE_ID_PREFIX="$(DEV_BUNDLE_ID_PREFIX)" \
+           TUIST_APP_DISPLAY_NAME="$(DEV_APP_DISPLAY_NAME)"
+
+dev-generate: build-ghostty
+	$(DEV_ENV) $(MISE) tuist generate --no-open
+
+dev-build-app: dev-generate
+	set -o pipefail && $(DEV_ENV) $(MISE) xcodebuild -workspace $(WORKSPACE) \
+		-scheme $(SCHEME_APP) -destination '$(DESTINATION)' build | $(MISE) xcbeautify
+
+# Installs zmx into the DEV support dir, not the release's, so the two never
+# share a binary or a session namespace.
+dev-install-zmx: build-zmx
+	@mkdir -p "$(HOME)/$(DEV_SUPPORT_DIR_NAME)/bin"
+	@cp "$(BUILD_DIR)/zmx/bin/zmx" "$(HOME)/$(DEV_SUPPORT_DIR_NAME)/bin/zmx"
+	@codesign --force --sign - "$(HOME)/$(DEV_SUPPORT_DIR_NAME)/bin/zmx" 2>/dev/null || true
+	@echo "installed: $(HOME)/$(DEV_SUPPORT_DIR_NAME)/bin/zmx"
+
+dev-run-app: dev-build-app dev-install-zmx
+	@APP_PATH=$$($(DEV_ENV) $(MISE) xcodebuild -workspace $(WORKSPACE) \
+		-scheme $(SCHEME_APP) -destination '$(DESTINATION)' -showBuildSettings 2>/dev/null \
+		| awk -F'= ' '/ BUILT_PRODUCTS_DIR /{print $$2; exit}')/graphcode.app; \
+	echo "Launching $$APP_PATH with GRAPHCODE_SUPPORT_DIR=$(DEV_SUPPORT_DIR_NAME)"; \
+	open -n --env GRAPHCODE_SUPPORT_DIR="$(DEV_SUPPORT_DIR_NAME)" "$$APP_PATH"
+
+# What the dev build actually is, in one command — useful when the two get confusing.
+dev-status:
+	@echo "bundle id prefix : $(DEV_BUNDLE_ID_PREFIX)"
+	@echo "support dir      : $(HOME)/$(DEV_SUPPORT_DIR_NAME)"
+	@echo "daemon (dev)     : $$(launchctl list | awk '/graphcoded/ && /$(DEV_BUNDLE_ID_PREFIX)/{print $$3}' | paste -sd' ' -)"
+	@echo "daemon (release) : $$(launchctl list | awk '/graphcoded/ && !/$(DEV_BUNDLE_ID_PREFIX)/{print $$3}' | paste -sd' ' -)"
+	@echo "dev app running  : $$(pgrep -f 'Debug/graphcode.app/Contents/MacOS/graphcode' | paste -sd' ' - | sed 's/^$$/no/')"
+	@ls -d /Applications/graphcode.app >/dev/null 2>&1 \
+		&& echo "installed release: /Applications/graphcode.app ($$(defaults read /Applications/graphcode.app/Contents/Info CFBundleIdentifier 2>/dev/null))" \
+		|| echo "installed release: none"
 
 # ---------------------------------------------------------------------------
 # test / check / format

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ doctor:
 		|| echo "[missing] mise — install with: brew install mise"
 	@$(MISE) tuist version >/dev/null 2>&1 && echo "[ok] tuist: $$($(MISE) tuist version)" \
 		|| echo "[missing] tuist — run: mise install"
+	@test -f Tuist/.build/workspace-state.json \
+		&& echo "[ok] Tuist dependencies installed" \
+		|| echo "[not installed] Tuist dependencies — run: mise exec -- tuist install"
 	@$(MISE) swiftlint version >/dev/null 2>&1 && echo "[ok] swiftlint: $$($(MISE) swiftlint version)" \
 		|| echo "[missing] swiftlint — run: mise install"
 	@$(MISE) xcbeautify --version >/dev/null 2>&1 && echo "[ok] xcbeautify: $$($(MISE) xcbeautify --version)" \

--- a/Project.swift
+++ b/Project.swift
@@ -14,7 +14,21 @@ import ProjectDescription
 //     edges automatically, and arms time-based triggers that survive the app quitting
 //     — see docs/07-roadmap.md#phase-3--orchestrator-automation.
 
-let bundleIdPrefix = "dev.graphcode"
+// Both are overridable so a development build can run *beside* an installed release
+// instead of replacing it. macOS keys far too much off the bundle id — Login Items,
+// LaunchServices' "which app owns this?", the background-agent attribution — so two
+// builds sharing one id fight over all of it.
+//
+//     TUIST_BUNDLE_ID_PREFIX=ai.kortexa.graphcode-localdev \
+//     TUIST_APP_DISPLAY_NAME="GraphCode (localdev)" \
+//       mise exec -- tuist generate --no-open
+//
+// The bundle id is only half of side-by-side: state is keyed by
+// `GRAPHCODE_SUPPORT_DIR` (see `SupportDirectory`), and a second build sharing
+// `~/.graphcode` would share graphs and zmx session names with the release and fight
+// over the sessions. Set both, or use `make dev-*`, which sets both for you.
+let bundleIdPrefix = Environment.bundleIdPrefix.getString(default: "dev.graphcode")
+let appDisplayName = Environment.appDisplayName.getString(default: "GraphCode")
 
 let project = Project(
     name: "graphcode",
@@ -59,8 +73,8 @@ let project = Project(
                 // The name a human sees — menu bar, Finder, Dock, About. Distinct from
                 // the bundle's filename and from `graphcode` the CLI, which stay lower
                 // case because they are a path and a command someone types.
-                "CFBundleName": "GraphCode",
-                "CFBundleDisplayName": "GraphCode",
+                "CFBundleName": .string(appDisplayName),
+                "CFBundleDisplayName": .string(appDisplayName),
                 "CFBundleIconName": "AppIcon",
                 // The app reported Tuist's default 1.0 while every release was tagged
                 // v0.0.x, so About said one thing and the download page another. Keep

--- a/Project.swift
+++ b/Project.swift
@@ -19,7 +19,7 @@ import ProjectDescription
 // LaunchServices' "which app owns this?", the background-agent attribution — so two
 // builds sharing one id fight over all of it.
 //
-//     TUIST_BUNDLE_ID_PREFIX=ai.kortexa.graphcode-localdev \
+//     TUIST_BUNDLE_ID_PREFIX=com.example.graphcode-localdev \
 //     TUIST_APP_DISPLAY_NAME="GraphCode (localdev)" \
 //       mise exec -- tuist generate --no-open
 //

--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ make test            # unit tests
 make check           # swiftlint + swift-format, both strict
 ```
 
+To run a local build beside an installed release, optionally copy `.env.example`
+to `.env.local`, choose your own bundle-ID prefix, then run:
+
+```sh
+make dev-run-app
+```
+
+This build is ad-hoc signed for the current Mac and keeps its app identity and
+state separate from the installed release. No production signing profile is needed.
+
 ## Credits & license
 
 Inspired by [Supacode](https://supacode.sh) — same spine of daemon-kept terminal sessions; its unit is the


### PR DESCRIPTION
## Summary
- allow local app identity overrides through `.env` and `.env.local`
- isolate the local app, daemon, support directory, and zmx installation from production
- teach `make doctor` to detect missing Tuist dependencies

## Validation
- `make check`
- `make test`
- local app and daemon builds
- development LaunchAgent, socket, plist, and zmx signature checks