### PR TITLE
Open every goal loop with the backend's /goal directive

### DIFF
--- a/GraphcodeKit/Sources/Domain/BackendCapabilities.swift
+++ b/GraphcodeKit/Sources/Domain/BackendCapabilities.swift
@@ -29,6 +29,18 @@ public struct BackendCapabilities: Codable, Equatable, Sendable {
   /// `supportsDaemonRecurrence`. A backend with neither capability cannot host one.
   public var supportsInSessionRecurrence: Bool
   public var supportsDaemonRecurrence: Bool
+  /// The in-session directive that arms the backend's *own* stop-condition check —
+  /// `/goal <condition>`, which sets a session-scoped hook that keeps the agent working
+  /// until a separate evaluator says the condition holds. The goal-based counterpart of
+  /// `/loop`, and it earns its place for the same reason: a goal stated as prose is an
+  /// instruction the agent may consider discharged after one pass, while a goal stated
+  /// as the directive is checked by the CLI every time the agent tries to stop.
+  ///
+  /// `nil` where the CLI has no such command. Those backends still host goal loops on
+  /// the prose prompt, exactly as every backend did before this existed —
+  /// `supportsGoalMode` is the question of whether the type can run at all, this is only
+  /// whether the session can be handed its own stop condition.
+  public var goalDirective: String?
 
   public init(
     supportsGoalMode: Bool = false,
@@ -38,7 +50,8 @@ public struct BackendCapabilities: Codable, Equatable, Sendable {
     supportsMCP: Bool = false,
     supportsMidSessionInput: Bool = false,
     supportsInSessionRecurrence: Bool = false,
-    supportsDaemonRecurrence: Bool = false
+    supportsDaemonRecurrence: Bool = false,
+    goalDirective: String? = nil
   ) {
     self.supportsGoalMode = supportsGoalMode
     self.supportsHooks = supportsHooks
@@ -48,6 +61,7 @@ public struct BackendCapabilities: Codable, Equatable, Sendable {
     self.supportsMidSessionInput = supportsMidSessionInput
     self.supportsInSessionRecurrence = supportsInSessionRecurrence
     self.supportsDaemonRecurrence = supportsDaemonRecurrence
+    self.goalDirective = goalDirective
   }
 }
 
@@ -80,7 +94,11 @@ extension CLISessionBackendKind {
         supportsSubAgents: true,
         supportsMCP: true,
         supportsMidSessionInput: true,
-        supportsInSessionRecurrence: true)
+        supportsInSessionRecurrence: true,
+        // `/goal <condition>` — read off 2.1.261, where it is a first-class slash command
+        // ("Set a goal Claude checks before stopping") that starts a turn immediately and
+        // installs a Stop hook the session cannot finish past until the condition holds.
+        goalDirective: "/goal")
 
     case .copilotCLI:
       // Spiked against GitHub Copilot CLI 0.0.410 — every entry below was read off the
@@ -109,6 +127,11 @@ extension CLISessionBackendKind {
       // shell commands)") and `/subagents`, plus `--agent <agent>` on the launch line.
       // That is the fan-out a composite leans on. The same age caveat applies: a
       // composite whose Copilot workers never fan out is a Copilot older than that.
+      //
+      // `goalDirective` stays nil: `copilot help commands` at 1.0.80 lists no `/goal`.
+      // `/autopilot` takes an objective and is the nearest thing, but it also flips a
+      // session-wide permission mode, which is a bigger change than being handed a stop
+      // condition — so a Copilot goal loop is carried by the prose prompt.
       return BackendCapabilities(
         supportsGoalMode: true,
         supportsHooks: false,
@@ -142,7 +165,11 @@ extension CLISessionBackendKind {
         supportsMCP: true,
         supportsMidSessionInput: true,
         supportsInSessionRecurrence: false,
-        supportsDaemonRecurrence: true)
+        supportsDaemonRecurrence: true,
+        // `/goal [<objective>|clear|edit|pause|resume]` — read off 0.153.2, which pursues
+        // the objective across turns and reports against it. Same directive name as Claude
+        // Code's, so `GoalSpec` composes one prompt shape for both.
+        goalDirective: "/goal")
 
     case .openCode:
       // Spiked against OpenCode 1.18.21 — every entry read off `opencode --help` and its
@@ -162,7 +189,9 @@ extension CLISessionBackendKind {
       // source, not assumed (`PresenceHooks.openCodePlugin`).
       //
       // Sub-agents exist inside the TUI (`@agent` mentions) but not as anything a
-      // composite could lean on from outside. Recurrence is provided by graphcode's daemon.
+      // composite could lean on from outside. Recurrence is provided by graphcode's daemon,
+      // and `goalDirective` is nil for the same reason `/loop` is absent: 1.18.29 ships no
+      // `/goal`, so a goal loop here is carried by the prose prompt.
       return BackendCapabilities(
         supportsGoalMode: true,
         supportsHooks: true,

--- a/GraphcodeKit/Sources/Domain/BackendCapabilities.swift
+++ b/GraphcodeKit/Sources/Domain/BackendCapabilities.swift
@@ -36,10 +36,11 @@ public struct BackendCapabilities: Codable, Equatable, Sendable {
   /// instruction the agent may consider discharged after one pass, while a goal stated
   /// as the directive is checked by the CLI every time the agent tries to stop.
   ///
-  /// `nil` where the CLI has no such command. Those backends still host goal loops on
-  /// the prose prompt, exactly as every backend did before this existed —
-  /// `supportsGoalMode` is the question of whether the type can run at all, this is only
-  /// whether the session can be handed its own stop condition.
+  /// Every backend graphcode drives has grown the command, so every row now carries it.
+  /// The field stays a per-backend `String?` rather than collapsing into a constant for
+  /// the same reason `isSpiked` did: `nil` is what a backend arriving without the command
+  /// needs, and a session handed a directive its CLI does not have types the arming step
+  /// as literal prose — a goal loop that looks armed and is not.
   public var goalDirective: String?
 
   public init(
@@ -128,10 +129,10 @@ extension CLISessionBackendKind {
       // That is the fan-out a composite leans on. The same age caveat applies: a
       // composite whose Copilot workers never fan out is a Copilot older than that.
       //
-      // `goalDirective` stays nil: `copilot help commands` at 1.0.80 lists no `/goal`.
-      // `/autopilot` takes an objective and is the nearest thing, but it also flips a
-      // session-wide permission mode, which is a bigger change than being handed a stop
-      // condition — so a Copilot goal loop is carried by the prose prompt.
+      // `goalDirective` follows `supportsInSessionRecurrence`'s history exactly: set from
+      // a `copilot help commands` listing that did not mention the command, then flipped
+      // because Copilot has it. That listing is not the authority it looks like — it omits
+      // `/loop` and `/every` too, which this row has claimed and relied on for releases.
       return BackendCapabilities(
         supportsGoalMode: true,
         supportsHooks: false,
@@ -139,7 +140,8 @@ extension CLISessionBackendKind {
         supportsSubAgents: true,
         supportsMCP: true,
         supportsMidSessionInput: true,
-        supportsInSessionRecurrence: true)
+        supportsInSessionRecurrence: true,
+        goalDirective: "/goal")
 
     case .codex:
       // Spiked against Codex CLI 0.145.0 — every entry read off the real `codex --help`,
@@ -189,9 +191,13 @@ extension CLISessionBackendKind {
       // source, not assumed (`PresenceHooks.openCodePlugin`).
       //
       // Sub-agents exist inside the TUI (`@agent` mentions) but not as anything a
-      // composite could lean on from outside. Recurrence is provided by graphcode's daemon,
-      // and `goalDirective` is nil for the same reason `/loop` is absent: 1.18.29 ships no
-      // `/goal`, so a goal loop here is carried by the prose prompt.
+      // composite could lean on from outside. Recurrence is provided by graphcode's daemon.
+      //
+      // `goalDirective` is the one row here not read off the CLI: `/goal` is absent from
+      // 1.18.29's command strings, and it is set anyway on the maintainer's word that the
+      // command exists. The symptom if that is ever wrong is specific — a goal session
+      // that opens with `/goal …` echoed as plain text and starts no work — and this
+      // comment, not a bisect, is where to look.
       return BackendCapabilities(
         supportsGoalMode: true,
         supportsHooks: true,
@@ -200,7 +206,8 @@ extension CLISessionBackendKind {
         supportsMCP: true,
         supportsMidSessionInput: true,
         supportsInSessionRecurrence: false,
-        supportsDaemonRecurrence: true)
+        supportsDaemonRecurrence: true,
+        goalDirective: "/goal")
     }
   }
 

--- a/GraphcodeKit/Sources/Domain/GoalSpec.swift
+++ b/GraphcodeKit/Sources/Domain/GoalSpec.swift
@@ -105,6 +105,18 @@ public struct GoalSpec: Codable, Equatable, Sendable {
     return trimmed.isEmpty ? nil : trimmed
   }
 
+  /// Subcommands a `/goal` directive reads instead of a condition — Codex's full set,
+  /// which contains Claude Code's `clear`. A goal whose summary opens with one of them
+  /// ("clear the lint backlog") would arm nothing and quietly clear the session's goal
+  /// instead, so `condition` keeps the first word ordinary.
+  static let directiveSubcommands: Set<String> = ["clear", "edit", "pause", "resume"]
+
+  static func condition(_ summary: String) -> String {
+    let firstWord = summary.trimmingCharacters(in: .whitespaces).prefix { !$0.isWhitespace }
+    guard directiveSubcommands.contains(firstWord.lowercased()) else { return summary }
+    return "Done when: \(summary)"
+  }
+
   /// The opening prompt for the node's session. States the goal, and — when there's a
   /// predicate or a metric — tells the session the same things the daemon is watching,
   /// so the two aren't working to different definitions of done, or of better.
@@ -114,8 +126,18 @@ public struct GoalSpec: Codable, Equatable, Sendable {
   /// the way an autonomous improvement loop is handed its own fitness function. The
   /// orchestrator still samples the same command once per pass, so the recorded numbers
   /// come from the measurement, never from the loop's self-report.
-  public var sessionPrompt: String {
-    var parts = ["Work toward this goal until it is met: \(summary)"]
+  ///
+  /// `directive` is the backend's own stop-condition command when it has one
+  /// (`BackendCapabilities.goalDirective`), and it replaces the "work toward this" prose
+  /// rather than joining it: the directive already says to keep working, and its argument
+  /// is the condition an evaluator judges. Everything the prompt adds after the summary
+  /// is part of that argument — `/goal` takes the rest of the line — which is why each
+  /// sentence has to read as something a session should hold itself to, not as an aside.
+  public func sessionPrompt(directive: String? = nil) -> String {
+    var parts = [
+      directive.map { "\($0) \(Self.condition(summary))" }
+        ?? "Work toward this goal until it is met: \(summary)"
+    ]
     if let predicate = effectivePredicate {
       parts.append("The goal counts as met when this command exits 0: \(predicate)")
     }

--- a/GraphcodeKit/Sources/Domain/LoopNode.swift
+++ b/GraphcodeKit/Sources/Domain/LoopNode.swift
@@ -314,7 +314,8 @@ public struct LoopNode: Identifiable, Codable, Equatable, Sendable {
         + "Each one is your cue to run one pass of this task, then wait for the next: "
         + "\(task) Do not schedule your own /loop, wakeup, or cron for it — the "
         + "orchestrator holds the timer. Stay in the session between heartbeats."
-    case .goalBased: return goal?.sessionPrompt
+    case .goalBased:
+      return goal?.sessionPrompt(directive: backend.capabilities.goalDirective)
     case .turnBased:
       return Self.turnBasedPrompt(
         instruction: firstInstruction, check: checkDescription,

--- a/GraphcodeKit/Sources/Domain/SessionPrompt.swift
+++ b/GraphcodeKit/Sources/Domain/SessionPrompt.swift
@@ -8,16 +8,21 @@ import Foundation
 /// digest is (`NodeMemory`), both by preamble on the same message. Concatenating those
 /// in front is what a preamble usually means, and for prose it is right.
 ///
-/// It is wrong for exactly one prompt shape, and that shape is a whole loop type. A
-/// time-based node whose session owns recurrence has a slash-command prompt — `/loop 1h
-/// …`. Buried mid-message it is literal text: no schedule is created, the loop runs
-/// exactly one pass and sits `idle` forever. Copilot hosts this form of time-based loop
-/// and receives its briefing as a preamble, so it got both halves of that and never armed
-/// recurrence at all (issue #179).
+/// It is wrong for the two prompt shapes that open with a slash command, and each of
+/// those is a whole loop type. A time-based node whose session owns recurrence has a
+/// slash-command prompt — `/loop 1h …`. Buried mid-message it is literal text: no
+/// schedule is created, the loop runs exactly one pass and sits `idle` forever. Copilot
+/// hosts this form of time-based loop and receives its briefing as a preamble, so it got
+/// both halves of that and never armed recurrence at all (issue #179). A goal-based node
+/// on a backend with `/goal` is the same shape and fails the same way — the directive
+/// that arms the stop check would be typed as prose and nothing would be armed.
 ///
 /// So the preamble trails a prompt that opens with a directive and leads one that doesn't.
 /// Trailing costs nothing: `/loop <interval> <task>` takes the rest of the line as the
 /// task, so the pointer travels into every scheduled pass rather than only the first.
+/// `/goal <condition>` takes the rest of the line too, so a trailing pointer becomes part
+/// of the condition — worth knowing, and still the right side: a condition carrying one
+/// extra instruction the session discharges immediately beats a directive that never ran.
 public enum SessionPrompt {
   /// Whether `prompt` opens with something its backend will read as a command rather than
   /// prose. A leading `/` is the whole test — a prompt that opens with an absolute path

--- a/graphcode/Tests/CopilotBackendTests.swift
+++ b/graphcode/Tests/CopilotBackendTests.swift
@@ -153,6 +153,8 @@ struct CopilotBackendTests {
     // No `--model`: valid ids aren't discoverable from its help, and a guess fails at
     // launch, so its own default applies.
     #expect(!arguments.contains("--model"))
-    #expect(arguments.last == "Work toward this goal until it is met: Tests pass")
+    // The prompt is the positional last argument, and for a goal it opens with Codex's
+    // own `/goal` — the stop condition the loop type exists to hand over.
+    #expect(arguments.last == "/goal Tests pass")
   }
 }

--- a/graphcode/Tests/GoalBasedLoopTests.swift
+++ b/graphcode/Tests/GoalBasedLoopTests.swift
@@ -279,9 +279,10 @@ struct GoalBasedLoopTests {
   @Test
   func aGoalOpensWithTheBackendsOwnStopCondition() throws {
     // Prose asks; the directive binds. `/goal <condition>` installs a check the session
-    // cannot finish past, which is the whole contract of the type — so where a backend
-    // has one it leads the prompt, exactly as `/loop` leads a time-based one.
-    for backend in [CLISessionBackendKind.claudeCode, .codex] {
+    // cannot finish past, which is the whole contract of the type — so it leads the
+    // prompt, exactly as `/loop` leads a time-based one. Every backend graphcode drives
+    // has the command, so every backend gets it.
+    for backend in CLISessionBackendKind.allCases {
       let node = LoopNode(
         title: "Green build", loopType: .goalBased,
         goal: GoalSpec(summary: "CI passes", predicate: "make test"), backend: backend)
@@ -290,15 +291,17 @@ struct GoalBasedLoopTests {
       #expect(prompt.contains("make test"))
       #expect(!prompt.contains("Work toward this goal"))
     }
+  }
 
-    // And a backend without the command is not handed a directive it would type as
-    // literal text: it keeps the prose prompt it always had.
-    for backend in [CLISessionBackendKind.copilotCLI, .openCode] {
-      let node = LoopNode(
-        title: "Green build", loopType: .goalBased, goal: GoalSpec(summary: "CI passes"),
-        backend: backend)
-      #expect(node.sessionPrompt == "Work toward this goal until it is met: CI passes")
-    }
+  @Test
+  func aBackendWithoutTheCommandStillGetsAWorkableGoal() {
+    // The prose prompt is not dead code, it is what the next backend opens with until
+    // someone reads `/goal` off its real CLI. A directive typed at an agent that has no
+    // such command is echoed as text and arms nothing, so `nil` has to keep working.
+    let spec = GoalSpec(summary: "CI passes", predicate: "make test")
+    #expect(
+      spec.sessionPrompt().hasPrefix("Work toward this goal until it is met: CI passes"))
+    #expect(spec.sessionPrompt().contains("make test"))
   }
 
   @Test

--- a/graphcode/Tests/GoalBasedLoopTests.swift
+++ b/graphcode/Tests/GoalBasedLoopTests.swift
@@ -269,11 +269,53 @@ struct GoalBasedLoopTests {
     #expect(prompt.contains("lower is better"))
     #expect(prompt.contains("run it as you work"))
 
-    // No metric, no measurement sentence — the base prompt stays word-for-word what it
-    // always was.
+    // No metric, no measurement sentence — the base prompt is the directive and the
+    // condition, and nothing else.
     let bare = LoopNode(
       title: "Docs", loopType: .goalBased, goal: GoalSpec(summary: "docs read clearly"))
-    #expect(bare.sessionPrompt == "Work toward this goal until it is met: docs read clearly")
+    #expect(bare.sessionPrompt == "/goal docs read clearly")
+  }
+
+  @Test
+  func aGoalOpensWithTheBackendsOwnStopCondition() throws {
+    // Prose asks; the directive binds. `/goal <condition>` installs a check the session
+    // cannot finish past, which is the whole contract of the type — so where a backend
+    // has one it leads the prompt, exactly as `/loop` leads a time-based one.
+    for backend in [CLISessionBackendKind.claudeCode, .codex] {
+      let node = LoopNode(
+        title: "Green build", loopType: .goalBased,
+        goal: GoalSpec(summary: "CI passes", predicate: "make test"), backend: backend)
+      let prompt = try #require(node.sessionPrompt)
+      #expect(prompt.hasPrefix("/goal CI passes"))
+      #expect(prompt.contains("make test"))
+      #expect(!prompt.contains("Work toward this goal"))
+    }
+
+    // And a backend without the command is not handed a directive it would type as
+    // literal text: it keeps the prose prompt it always had.
+    for backend in [CLISessionBackendKind.copilotCLI, .openCode] {
+      let node = LoopNode(
+        title: "Green build", loopType: .goalBased, goal: GoalSpec(summary: "CI passes"),
+        backend: backend)
+      #expect(node.sessionPrompt == "Work toward this goal until it is met: CI passes")
+    }
+  }
+
+  @Test
+  func aGoalThatOpensWithASubcommandIsNotReadAsOne() throws {
+    // `/goal clear` clears the session's goal on both backends that have the command, so
+    // a goal phrased "clear the lint backlog" would arm nothing and look like it had.
+    let node = LoopNode(
+      title: "Lint", loopType: .goalBased,
+      goal: GoalSpec(summary: "clear the lint backlog"))
+    let prompt = try #require(node.sessionPrompt)
+    #expect(prompt == "/goal Done when: clear the lint backlog")
+
+    // Only the leading word is the hazard — one in the middle is ordinary English.
+    let inner = LoopNode(
+      title: "Lint", loopType: .goalBased,
+      goal: GoalSpec(summary: "the lint backlog is clear"))
+    #expect(inner.sessionPrompt == "/goal the lint backlog is clear")
   }
 
   @Test

--- a/graphcode/Tests/SessionPromptTests.swift
+++ b/graphcode/Tests/SessionPromptTests.swift
@@ -53,6 +53,21 @@ struct SessionPromptTests {
     #expect(composed.contains("/tmp/m/WAKE.md"))
   }
 
+  /// A goal loop on a backend with `/goal` is the same shape as a `/loop` one, so it
+  /// inherits the same rule for free — the check the type exists to arm is the thing a
+  /// leading preamble would turn into prose.
+  @Test
+  func theGoalDirectiveKeepsTheFrontOfAPromptToo() throws {
+    let node = LoopNode(
+      title: "Green build", loopType: .goalBased, goal: GoalSpec(summary: "CI passes"))
+    let prompt = try #require(node.sessionPrompt)
+    let composed = SessionPrompt.composed(
+      preamble: NodeMemory.wakePointer(toDigestAt: "/tmp/m/WAKE.md"), prompt: prompt)
+
+    #expect(composed.hasPrefix("/goal CI passes"))
+    #expect(composed.contains("/tmp/m/WAKE.md"))
+  }
+
   @Test
   func aTrailingPreambleGetsItsOwnSentence() {
     // Without the boundary the task and the preamble run together into one instruction:


### PR DESCRIPTION
A goal-based loop stated its goal as prose — `Work toward this goal until it is met: …`. The CLIs have grown a `/goal <condition>` command since, which installs a session-scoped check the agent cannot finish past until the condition holds. That is exactly the contract the loop type names: prose *asks* for it, the directive *binds* it.

So a goal prompt now leads with `/goal`, the way a time-based prompt leads with `/loop`. The directive replaces the prose framing rather than joining it — `/goal` already says to keep working, and its argument is the condition an evaluator judges.

All four backends carry it. `goalDirective` stays a per-backend `String?` rather than a constant for the reason `isSpiked` was kept: `nil` is what the next backend needs on the day it arrives without the command, since a session handed a directive its CLI lacks types the arming step as prose and starts no work — a goal loop that looks armed and is not. The prose prompt keeps its own test.

Two details worth the review:

- **Subcommand collision.** `/goal clear` clears the session's goal, so a goal phrased *"clear the lint backlog"* would arm nothing and look like it had. A summary opening with `clear`/`edit`/`pause`/`resume` is prefixed `Done when: ` so the first word stays ordinary.
- **`SessionPrompt` needed no change.** A `/goal` prompt is a leading directive like any other, so the briefing and wake-digest preambles already trail it. `/goal` takes the rest of the line, so a trailing pointer lands inside the condition — still the right side: a condition carrying one instruction the session discharges immediately beats a directive that never ran.

## Verification

| Check | Result |
| --- | --- |
| `xcodebuild test` | ✅ 1577 tests, 162 suites, 0 failures |
| `swiftlint lint` | ✅ 0 errors |
| `swift format lint --strict` | ✅ clean |

Local CLI checks recorded in the capability comments: `/goal` was read off Claude Code 2.1.261 and Codex 0.153.2 directly. It did not appear in Copilot 1.0.82's `help commands` or OpenCode 1.18.29's strings — but Copilot's listing omits `/loop` and `/every` as well, which this file has shipped on for releases, so that listing is not evidence of absence. Both are enabled on the maintainer's word, and the OpenCode comment names the symptom to look for if it ever turns out otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Na4EdpaATRmgmuK9o7nVH