### PR TITLE
Rename the New loop affordance to New Node

### DIFF
--- a/GraphcodeKit/Sources/Domain/NodeDraft.swift
+++ b/GraphcodeKit/Sources/Domain/NodeDraft.swift
@@ -22,7 +22,7 @@ public struct NodeDraft: Codable, Equatable, Sendable {
   /// time the answer arrives the only handle it has is this id. Without it, the client
   /// would have to diff two `graphChanged` broadcasts to guess which node it just made.
   public var id: UUID
-  /// Optional — a blank title creates the node as "NewLoop" (see `makeNode`), on the
+  /// Optional — a blank title creates the node as "NewNode" (see `makeNode`), on the
   /// theory that naming every loop up front was the most tedious field on the form and
   /// the one a backend can fill in afterward.
   public var title: String
@@ -117,7 +117,7 @@ public struct NodeDraft: Codable, Equatable, Sendable {
   /// only in the form — the wire protocol is reachable from the CLI too, and a rule that
   /// only one client applies isn't a rule.
   public var isValid: Bool {
-    // No title requirement: `makeNode` falls back to "NewLoop", and the app follows up
+    // No title requirement: `makeNode` falls back to "NewNode", and the app follows up
     // with a backend-suggested name (see `TitleSuggestionClient`). Requiring one taught
     // people to type a throwaway word to get past the form — the prompt is the field
     // that means something, so it's the one each type below actually demands.
@@ -165,14 +165,14 @@ public struct NodeDraft: Codable, Equatable, Sendable {
       //
       // A name is required, though, and only here: every other type gets one from its
       // own backend after it starts working (`TitleSuggestionClient`), and a composite
-      // never starts. "NewLoop" would be its name for good.
+      // never starts. "NewNode" would be its name for good.
       return !title.trimmingCharacters(in: .whitespaces).isEmpty
     }
   }
 
   /// What an untitled draft's node is called until something better arrives — the app
   /// asks the loop's own backend for a real name and renames the node when it answers.
-  public static let untitledFallback = "NewLoop"
+  public static let untitledFallback = "NewNode"
 
   /// The backend this draft builds with when nobody resolved one. `GraphStore` resolves
   /// inheritance *before* this is consulted — a child created by a running loop takes

--- a/graphcode/Sources/Clients/TitleSuggestionClient.swift
+++ b/graphcode/Sources/Clients/TitleSuggestionClient.swift
@@ -6,7 +6,7 @@ import GraphcodeKit
 /// title blank — `claude -p` / `copilot -p` / `codex exec`, the headless print-mode
 /// shape of each CLI, so nothing here opens a session or touches the loop's actual work.
 ///
-/// Fire-and-forget by design: the node is already created as "NewLoop" by the time this
+/// Fire-and-forget by design: the node is already created as "NewNode" by the time this
 /// runs, and a `renameNode` follows only if an answer arrives. A backend that is slow,
 /// missing, or confused costs nothing but the fallback name staying.
 struct TitleSuggestionClient: Sendable {
@@ -86,7 +86,7 @@ extension TitleSuggestionClient: DependencyKey {
     case .copilotCLI: command = "exec copilot -p \"$\(promptVariable)\""
     // This is a separate headless process, so it does not inherit the permission flags
     // from the loop session. Without Codex's unattended flag it can stop at an approval
-    // prompt and the new loop remains named "NewLoop" forever.
+    // prompt and the new loop remains named "NewNode" forever.
     case .codex:
       command =
         "exec codex exec --dangerously-bypass-approvals-and-sandbox \"$\(promptVariable)\""

--- a/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView+Rows.swift
@@ -76,7 +76,7 @@ extension AppSidebarView {
             .foregroundStyle(.secondary)
         }
         .buttonStyle(.plain)
-        .help("New Loop in \(project.graph.project.name)")
+        .help("New Node in \(project.graph.project.name)")
         if canExpand(project) {
           Button {
             toggleExpanded(project.id)
@@ -153,7 +153,7 @@ extension AppSidebarView {
     // Selects the project first: the creation sheet presents from that project's
     // canvas, and a form opened on a canvas that isn't showing opens nowhere.
     if !node.isResolved {
-      Button("New Child Loop…") {
+      Button("New Child Node…") {
         store.send(.projectHeaderTapped(projectPath))
         send(.newChildLoopTapped(node.id), to: projectPath)
       }
@@ -191,7 +191,7 @@ extension AppSidebarView {
 
   /// Whether this row has child rows at all — nothing does until it has a loop in it.
   /// The Graph row counts now too: its own loops (watchers and other cross-cutting
-  /// triggers, creatable from its canvas since the overview gained "New Loop") list
+  /// triggers, creatable from its canvas since the overview gained "New Node") list
   /// under it like any folder's.
   func canExpand(_ project: ProjectFeature.State) -> Bool {
     !project.graph.nodes.isEmpty

--- a/graphcode/Sources/Features/App/QuickChatsCanvasView.swift
+++ b/graphcode/Sources/Features/App/QuickChatsCanvasView.swift
@@ -73,7 +73,7 @@ struct QuickChatsCanvasView: View {
         CanvasZoomControls(
           transform: $transform, viewport: viewport, content: contentSize(placements))
       }
-      // Top-right and quiet, the same placement and styling a folder canvas's New Loop
+      // Top-right and quiet, the same placement and styling a folder canvas's New Node
       // has — see `ProjectCanvasView` for why it isn't in the window toolbar.
       .overlay(alignment: .topTrailing) {
         CanvasAddButton(help: "New Chat") { store.send(.newQuickChatTapped) }

--- a/graphcode/Sources/Features/Canvas/CanvasAddButton.swift
+++ b/graphcode/Sources/Features/Canvas/CanvasAddButton.swift
@@ -39,7 +39,7 @@ struct CanvasAddButton: View {
 }
 
 #Preview {
-  CanvasAddButton(help: "New Loop", action: {})
+  CanvasAddButton(help: "New Node", action: {})
     .padding(24)
     .background(Theme.canvasBackground)
 }

--- a/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverviewCards.swift
@@ -31,14 +31,14 @@ extension GraphOverviewView {
   /// beginning. The same handle the folder's own canvas puts on its origin dot.
   ///
   /// The one create the Graph view was missing. A card's `+` continues a chain and the
-  /// top-right New Loop lands in the global graph, so starting a *new* chain in a
+  /// top-right New Node lands in the global graph, so starting a *new* chain in a
   /// particular folder meant crossing to that folder's canvas first.
   /// Only on lanes that *have* an origin dot: `CanvasBandView` draws one exactly when a
   /// lane has entry ports, and a `+` floating where no dot is reads as a stray control.
-  /// A lane whose loops are all in a cycle keeps the top-right New Loop.
+  /// A lane whose loops are all in a cycle keeps the top-right New Node.
   func entryHandleLayer(_ overview: GraphOverview) -> some View {
     ForEach(overview.tetheredFolders) { folder in
-      CanvasEntryHandle(help: "New loop in \(folder.name)") {
+      CanvasEntryHandle(help: "New Node in \(folder.name)") {
         store.send(.projects(.element(id: folder.path, action: .addEntryLoopTapped)))
       }
       .position(folder.originPosition)
@@ -159,7 +159,7 @@ extension GraphOverviewView {
         store.send(
           .projects(.element(id: loop.projectPath, action: .addChildNodeTapped(loop.node.id))))
       }
-      .help("New loop handed off from \(loop.node.title)")
+      .help("New Node handed off from \(loop.node.title)")
   }
 
   /// The same `LoopCardView` a project's own canvas draws, so a loop reads identically
@@ -217,7 +217,7 @@ extension GraphOverviewView {
     let node = loop.node
     Button("Open Terminal") { open(loop) }
     if !node.isResolved {
-      Button("New Child Loop…") { send(.newChildLoopTapped(node.id), to: loop.projectPath) }
+      Button("New Child Node…") { send(.newChildLoopTapped(node.id), to: loop.projectPath) }
     }
     if node.loopType == .composite {
       Button("Pilot Once…") { send(.pilotCompositeTapped(node.id), to: loop.projectPath) }

--- a/graphcode/Sources/Features/Overview/GraphOverviewView.swift
+++ b/graphcode/Sources/Features/Overview/GraphOverviewView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// second way in with its own behaviour.
 ///
 /// **Creates, but never rewires.** The two `+`s a folder's canvas has are both here —
-/// New Loop at the top right, and a hover-revealed one on every card that starts a loop
+/// New Node at the top right, and a hover-revealed one on every card that starts a loop
 /// handed off from it — because "I can see the loop I want to continue from" is the
 /// moment you want to continue from it, and crossing to that folder's canvas first only
 /// to click the same handle is a detour. What stays out is rewiring: no dragging cards
@@ -69,7 +69,7 @@ struct GraphOverviewView: View {
   /// This view once had no toolbar on purpose — global triggers were CLI-only. That
   /// rule made the global graph's one legitimate use from the app unreachable: loops
   /// that belong to no folder, like an email or Teams-message watcher, had nowhere a
-  /// human could create them. "New Loop" here files the loop into the global graph
+  /// human could create them. "New Node" here files the loop into the global graph
   /// through the same `ProjectFeature` form a folder's canvas uses; its session opens
   /// at home (see `ZmxSessionLauncher.workingDirectory`), since there is no project
   /// directory for it to belong to.
@@ -93,9 +93,9 @@ struct GraphOverviewView: View {
         }
       }
       // On the canvas top-right rather than in the toolbar, same placement and quiet
-      // styling as a project canvas's New Loop — see there for why.
+      // styling as a project canvas's New Node — see there for why.
       .overlay(alignment: .topTrailing) {
-        CanvasAddButton(help: "New Loop") {
+        CanvasAddButton(help: "New Node") {
           store.send(
             .projects(
               .element(
@@ -110,7 +110,7 @@ struct GraphOverviewView: View {
 
   /// One host per open folder, all of them mounted for the life of this view.
   ///
-  /// Two forms can be opened from here now — the global graph's, from the New Loop
+  /// Two forms can be opened from here now — the global graph's, from the New Node
   /// button, and any folder's, from a card's `+` handle — and which folder the second
   /// one belongs to isn't known until the click. Mounting a host per folder rather than
   /// inserting one when a form opens is what makes the sheet actually present: a

--- a/graphcode/Sources/Features/Project/NodeDraftForm.swift
+++ b/graphcode/Sources/Features/Project/NodeDraftForm.swift
@@ -75,7 +75,7 @@ struct NodeDraftForm: View {
   private var header: some View {
     HStack(alignment: .firstTextBaseline, spacing: 8) {
       VStack(alignment: .leading, spacing: 2) {
-        Text("New loop").font(.system(size: 16, weight: .semibold))
+        Text("New Node").font(.system(size: 16, weight: .semibold))
         Text("in \(store.graph.project.name)")
           .font(.system(size: 12))
           .foregroundStyle(.white.opacity(0.45))
@@ -87,7 +87,7 @@ struct NodeDraftForm: View {
 
   /// Action blue, never a loop-type hue — templates are chrome, not taxonomy, and
   /// there is no sixth colour in this feature (PROMPT_TEMPLATES.md § What changes
-  /// in the New loop dialog).
+  /// in the New Node dialog).
   private var templatesButton: some View {
     Button {
       store.send(.templatesButtonTapped)

--- a/graphcode/Sources/Features/Project/NodeDraftTemplateBar.swift
+++ b/graphcode/Sources/Features/Project/NodeDraftTemplateBar.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import GraphcodeKit
 import SwiftUI
 
-/// The template chrome the New loop dialog grew: the applied-template strip at the
+/// The template chrome the New Node dialog grew: the applied-template strip at the
 /// top and the two-row footer at the bottom. In its own file because `NodeDraftForm`
 /// sits at swiftlint's type-body limit, the same reason `ProjectFeature`'s template
 /// verbs live beside it rather than inside it.

--- a/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasCards.swift
@@ -83,7 +83,7 @@ extension ProjectCanvasView {
     // resolved loop: its hand-off edges have already fired, so a child created now
     // would wait on a parent that can never release it.
     if !node.isResolved {
-      Button("New Child Loop…") { store.send(.newChildLoopTapped(node.id)) }
+      Button("New Child Node…") { store.send(.newChildLoopTapped(node.id)) }
     }
     if node.loopType == .composite {
       // First, because it is the step everything else depends on: a composite with

--- a/graphcode/Sources/Features/Project/ProjectCanvasView.swift
+++ b/graphcode/Sources/Features/Project/ProjectCanvasView.swift
@@ -100,7 +100,7 @@ struct ProjectCanvasView: View {
         // A quiet + in system materials, not a filled accent pill — HIG-style: the
         // affordance should be findable, not the loudest thing on the canvas.
         .overlay(alignment: .topTrailing) {
-          CanvasAddButton(help: "New Loop") {
+          CanvasAddButton(help: "New Node") {
             store.send(.addNodeButtonTapped(parentBackend: nil))
           }
           .padding(.trailing, 20)
@@ -352,11 +352,11 @@ struct ProjectCanvasView: View {
   ///
   /// It sits where the dot does, and only when there is one: `CanvasBandView` draws the
   /// origin exactly when the canvas has entry ports. An empty canvas has no band at all,
-  /// and there the top-right New Loop is the way in.
+  /// and there the top-right New Node is the way in.
   @ViewBuilder
   private func entryHandleLayer(_ derived: Derived) -> some View {
     if let rect = bandRect(derived), !entryPorts(derived).isEmpty {
-      CanvasEntryHandle(help: "New loop in \(store.graph.project.name)") {
+      CanvasEntryHandle(help: "New Node in \(store.graph.project.name)") {
         store.send(.addEntryLoopTapped)
       }
       .position(x: rect.minX + CanvasBand.originLane / 2, y: rect.midY)

--- a/graphcode/Sources/Features/Project/ProjectFeature+Templates.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature+Templates.swift
@@ -148,7 +148,7 @@ extension ProjectFeature {
 
     case .templateLibraryRequested:
       // The empty canvas offers starters, and it is the one surface that needs the
-      // library before anybody has opened the New loop dialog.
+      // library before anybody has opened the New Node dialog.
       let projectPath = state.graph.project.path
       let library = templateLibrary
       return .run { send in

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -810,7 +810,7 @@ extension ProjectFeature {
                 .createEdge(from: parentNodeID, to: draft.id, spec: EdgeSpec()))))
         }
 
-        // A blank title creates the node as "NewLoop" and asks the loop's own
+        // A blank title creates the node as "NewNode" and asks the loop's own
         // backend for a real one — after creation, so a slow (or absent) CLI never
         // holds the node itself hostage. The rename can target the node because the
         // draft's id *is* the node's id (see `NodeDraft.id`); no answer just means

--- a/graphcode/Sources/Features/Project/ProjectFeature.swift
+++ b/graphcode/Sources/Features/Project/ProjectFeature.swift
@@ -193,7 +193,7 @@ struct ProjectFeature {
     /// The + handle on a node card: opens the same form, and the created loop gets a
     /// hand-off edge from this node.
     case addChildNodeTapped(UUID)
-    /// The context menus' "New Child Loop…": a *custody* child — `createdBy` set, the
+    /// The context menus' "New Child Node…": a *custody* child — `createdBy` set, the
     /// daemon draws the already-fired link, the loop starts now. Distinct from
     /// `.addChildNodeTapped` (the + handle), which wires an unfired hand-off that
     /// sequences the new loop *after* the parent — under a long-running parent that

--- a/graphcode/Sources/Features/Project/TemplateSaveSheet.swift
+++ b/graphcode/Sources/Features/Project/TemplateSaveSheet.swift
@@ -130,7 +130,7 @@ struct TemplateSaveSheet: View {
   }
 }
 
-/// Presents the save sheet for a save started **outside** the New loop dialog — a
+/// Presents the save sheet for a save started **outside** the New Node dialog — a
 /// loop's context menu, which PROMPT_TEMPLATES.md § Save as template names first.
 /// The dialog hosts its own copy while it is open, so this one stands down then:
 /// two `.sheet`s bound to the same item present nothing at all.

--- a/graphcode/Sources/Features/Settings/TemplatesSettings.swift
+++ b/graphcode/Sources/Features/Settings/TemplatesSettings.swift
@@ -23,7 +23,7 @@ struct TemplatesSettingsSection: View {
     Section {
       if templates.isEmpty {
         Text(
-          "No templates yet. Save one from the New loop dialog (⌘T), or right-click a "
+          "No templates yet. Save one from the New Node dialog (⌘T), or right-click a "
             + "loop that worked and choose Save as Template…."
         )
         .font(.caption2)

--- a/graphcode/Tests/EntryLoopCreationTests.swift
+++ b/graphcode/Tests/EntryLoopCreationTests.swift
@@ -7,7 +7,7 @@ import Testing
 
 /// The `+` on a lane's origin dot in the Graph view: a top-level loop in that folder.
 ///
-/// The gap it fills — a card's `+` continues a chain, and the top-right New Loop lands in
+/// The gap it fills — a card's `+` continues a chain, and the top-right New Node lands in
 /// the global graph, so starting a *new* chain in a particular folder meant crossing to
 /// that folder's own canvas first.
 @Suite
@@ -60,7 +60,7 @@ struct EntryLoopCreationTests {
     await store.send(.createNodeConfirmed)
 
     #expect(store.state.declaredEntryIDs.contains(draftID))
-    // Cleared, so the *next* form — the top-right New Loop, a card's `+` — doesn't
+    // Cleared, so the *next* form — the top-right New Node, a card's `+` — doesn't
     // inherit the declaration.
     #expect(!store.state.draftDeclaresEntry)
   }
@@ -83,7 +83,7 @@ struct EntryLoopCreationTests {
   func aLaneWithNoBeginningGetsNoHandle() {
     // The handle lives where the origin dot does, and `CanvasBandView` draws that dot
     // exactly when a lane has entry ports. A `+` floating where no dot is reads as a
-    // stray control — a cycle-only lane keeps the top-right New Loop instead.
+    // stray control — a cycle-only lane keeps the top-right New Node instead.
     let first = LoopNode(title: "first")
     let second = LoopNode(title: "second")
     var graph = LoopGraph(project: ProjectRef(path: "/tmp/project", name: "project"))

--- a/graphcode/Tests/GraphStoreTests.swift
+++ b/graphcode/Tests/GraphStoreTests.swift
@@ -335,7 +335,7 @@ struct GraphStoreTests {
 
     // A turn-based draft with no criterion is deliberately *not* in this list — that one
     // is valid now, since the human doing the verifying is there either way. Neither is
-    // an untitled draft: a blank title creates the node as "NewLoop" and the app names
+    // an untitled draft: a blank title creates the node as "NewNode" and the app names
     // it properly afterward (see `TitleSuggestionClient`).
     await store.handle(.createNode(NodeDraft(title: "No goal", loopType: .goalBased)))
     await store.handle(.createNode(NodeDraft(title: "Bare", loopType: .timeBased)))

--- a/graphcode/Tests/NodeDraftTests.swift
+++ b/graphcode/Tests/NodeDraftTests.swift
@@ -92,7 +92,7 @@ struct NodeDraftTests {
 
   /// The title used to be the one field every draft demanded, and it was the most
   /// tedious one on the form — the prompt is what the human has in their head. A blank
-  /// title now creates the node as "NewLoop", and the app follows up with a
+  /// title now creates the node as "NewNode", and the app follows up with a
   /// backend-suggested name (see `TitleSuggestionClient`).
   @Test
   func anUntitledDraftIsValidAndFallsBackToAPlaceholderName() {
@@ -100,7 +100,7 @@ struct NodeDraftTests {
       title: "  ", loopType: .turnBased, checkDescription: "Sound?",
       firstInstruction: "Read the RFC")
     #expect(draft.isValid)
-    #expect(draft.makeNode().title == "NewLoop")
+    #expect(draft.makeNode().title == "NewNode")
     // A typed title is used as typed.
     #expect(
       NodeDraft(title: "Research", loopType: .turnBased).makeNode().title == "Research")
@@ -135,7 +135,7 @@ struct NodeDraftTests {
     let draft = NodeDraft(title: "Triage inbox", loopType: .composite)
     #expect(draft.isValid)
     // The name, though, is required for this type alone: every other kind gets one from
-    // its own backend once it starts working, and a composite never starts. "NewLoop"
+    // its own backend once it starts working, and a composite never starts. "NewNode"
     // would be its name for good.
     #expect(!NodeDraft(title: "  ", loopType: .composite).isValid)
 

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -299,7 +299,7 @@ struct ProjectFeatureTests {
     #expect(state.draft.heartbeatIntervalSeconds == 3600)
   }
 
-  /// "New Child Loop…" makes a *custody* child: `createdBy` rides the draft (the
+  /// "New Child Node…" makes a *custody* child: `createdBy` rides the draft (the
   /// daemon draws the fired-at-birth link) and no separate edge command follows — a
   /// hand-off from a long-running parent left the child blocked indefinitely while
   /// its session already ran.

--- a/graphcode/Tests/ProjectFeatureTests.swift
+++ b/graphcode/Tests/ProjectFeatureTests.swift
@@ -33,7 +33,7 @@ struct ProjectFeatureTests {
     #expect(store.state.nodePositions[node.id] != nil)
   }
 
-  /// An untitled draft is created as "NewLoop" immediately, then renamed to whatever
+  /// An untitled draft is created as "NewNode" immediately, then renamed to whatever
   /// the backend suggests — creation never waits on the suggestion, and the rename can
   /// find its node because the draft's id *is* the node's id.
   @Test
@@ -71,7 +71,7 @@ struct ProjectFeatureTests {
       return #expect(Bool(false), "expected a createNode command, got \(commands)")
     }
     #expect(draft.id == draftID)
-    #expect(draft.makeNode().title == "NewLoop")
+    #expect(draft.makeNode().title == "NewNode")
     #expect(
       commands.last
         == .graphCommand(


### PR DESCRIPTION
Renames the human-facing creation affordance from **New loop** to **New Node**. Agent-facing wording is deliberately untouched.

## What changed

| Surface | Before | After |
|---|---|---|
| Project canvas toolbar / overview add button | `New Loop` | `New Node` |
| Canvas entry handle (project + folder lanes) | `New loop in <name>` | `New Node in <name>` |
| Card `+` handle tooltip | `New loop handed off from <title>` | `New Node handed off from <title>` |
| Sidebar project row | `New Loop in <name>` | `New Node in <name>` |
| Sidebar + card context menus | `New Child Loop…` | `New Child Node…` |
| Creation dialog heading | `New loop` | `New Node` |
| Templates settings empty state | `…from the New loop dialog (⌘T)` | `…from the New Node dialog (⌘T)` |
| Untitled draft placeholder title | `NewLoop` | `NewNode` |

Doc comments that quote those labels were updated alongside them so the controls stay greppable by name.

## What deliberately did not change

- `SessionBriefing` — loops still read "a **node is a loop**", still learn `graphcode node create`, and still see "child loop" as a request for it.
- The CLI: no verb, flag, or default behaviour moved.
- Settings' `New loops use` picker — a different control (default backend), left as is.
- General prose that says "loop" for a running session (onboarding, menus like Stop Loop / Export Loop…), since loop and node stay interchangeable in the vocabulary.

## Verification

| Check | Result |
|---|---|
| `xcodebuild … -scheme graphcode test` | ✅ 1584 tests in 163 suites passed |
| `graphcode-cli` / `graphcoded` builds | ✅ 0 errors |
| `make check` (swiftlint + swift-format) | ✅ exit 0, 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sfcMSS7bfwPixeE5X6HAS