### PR TITLE
Fix #286: a live session that reads as absent shows FAILED

### DIFF
--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -40,6 +40,18 @@ public enum CopilotSessionLog {
   /// reports a session sitting at a prompt nobody is watching as a loop hard at work,
   /// which is the original lie with a new source. Unlisted, it falls through to idle at
   /// `.heuristic`: "a live session with nothing happening", which is what it is.
+  /// The events that begin a session's life. Everything above one of these in the log
+  /// belongs to a *previous* run of the same session and says nothing about this one.
+  ///
+  /// `--resume <id>` reopens the session's own state directory and appends to the same
+  /// `events.jsonl`, so a resumed session's log reads `session.shutdown` then
+  /// `session.resume` — and a scan that only knows how to skip unmapped events walks
+  /// straight past the resume and reports the shutdown behind it. A live session then
+  /// reads `.absent`, which `LoopNode.displayState` shows as FAILED for a running
+  /// unattended loop. Measured on a real log: shutdown at 17:30:23, resume at 17:30:26,
+  /// nothing mapped since, reported absent.
+  static let lifecycleBoundaries: Set<String> = ["session.start", "session.resume"]
+
   static func presence(forEvent event: String) -> Presence? {
     switch event {
     case "user.message", "assistant.turn_start",
@@ -339,14 +351,18 @@ public enum CopilotSessionLog {
     return reading.isEmpty ? nil : reading
   }
 
-  /// The last event in a log that says anything about what the session is doing.
+  /// The last event in a log that says anything about what the session is doing, or
+  /// `nil` when nothing since the session last started or resumed does.
+  ///
+  /// The scan stops at a `lifecycleBoundaries` event rather than reading past it: a
+  /// record written before this run began describes a process that no longer exists.
   static func lastStateChange(inLogAt url: URL) -> Presence? {
     for line in tailLines(ofLogAt: url).reversed() {
       guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
-        let event = (object as? [String: Any])?["type"] as? String,
-        let presence = presence(forEvent: event)
+        let event = (object as? [String: Any])?["type"] as? String
       else { continue }
-      return presence
+      if lifecycleBoundaries.contains(event) { return nil }
+      if let presence = presence(forEvent: event) { return presence }
     }
     return nil
   }
@@ -429,11 +445,17 @@ public enum CopilotSessionLog {
       + "if grep -qx 'name: \(name)' \"$HOME/.copilot/session-state/$d/workspace.yaml\" 2>/dev/null; then "
       + "D=\"$HOME/.copilot/session-state/$d\"; break; fi; done"
 
+    // The keep-list carries `lifecycleBoundaries` as well as the mapped events, so
+    // `tail -1` can *see* a resume standing between the shutdown and now; the `case`
+    // then blanks it, which is how the local scan's "stop, report nothing" reaches a
+    // shell. An empty `copilot=` is heuristic idle in `parseRemotePresence`, exactly
+    // what `lastStateChange` returning nil gives locally.
     let readEvent =
       "E=$(tail -c 65536 \"$D/events.jsonl\" 2>/dev/null"
       + " | grep -o '\"type\":\"[^\"]*\"'"
-      + " | grep -E 'user\\.message|assistant\\.turn_start|tool\\.execution_start|tool\\.execution_complete|permission\\.completed|permission\\.requested|assistant\\.turn_end|session\\.shutdown'"
-      + " | tail -1 | sed 's/.*\"type\":\"//;s/\"//')"
+      + " | grep -E 'user\\.message|assistant\\.turn_start|tool\\.execution_start|tool\\.execution_complete|permission\\.completed|permission\\.requested|assistant\\.turn_end|session\\.shutdown|session\\.start|session\\.resume'"
+      + " | tail -1 | sed 's/.*\"type\":\"//;s/\"//'); "
+      + "case \"$E\" in session.start|session.resume) E='';; esac"
 
     let script =
       "if \(check) >/dev/null 2>&1; then "

--- a/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
+++ b/GraphcodeKit/Sources/Sessions/CopilotSessionLog.swift
@@ -386,8 +386,13 @@ public enum CopilotSessionLog {
       return await remotePresence(of: node, at: remote)
     }
     let name = SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName
-    guard ZmxLocator.isInstalled, await ZmxSessionLauncher.sessionExists(node) else {
-      return .absent
+    guard ZmxLocator.isInstalled else { return .absent }
+    switch await ZmxSessionLauncher.sessionTaskState(node) {
+    // `zmx` could not be asked, so nothing was observed — the same answer the remote
+    // probe gives when ssh fails, and not the `.absent` that reads as FAILED.
+    case .unknown: return .unknown
+    case .absent, .exited: return .absent
+    case .alive: break
     }
     guard let directory = directory(forSessionNamed: name),
       let presence = lastStateChange(

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -488,6 +488,7 @@ public enum ZmxSessionLauncher {
     // behind has nothing to say.
     switch await sessionTaskState(node) {
     case .absent: return .absent
+    case .unknown: return .unknown
     case .exited(let code):
       return PresenceReading(presence: .idle, confidence: .scanned, exitCode: code)
     case .alive: break
@@ -539,6 +540,7 @@ public enum ZmxSessionLauncher {
     guard ZmxLocator.isInstalled else { return .absent }
     switch await sessionTaskState(node) {
     case .absent: return .absent
+    case .unknown: return .unknown
     case .exited(let code):
       return PresenceReading(presence: .idle, confidence: .scanned, exitCode: code)
     case .alive: break
@@ -604,9 +606,12 @@ public enum ZmxSessionLauncher {
   /// an ensure keyed on `zmx get` could never revive a husk, because the husk *is* the
   /// session that check asks about.
   static func sessionTaskState(_ node: LoopNode) async -> SessionTaskState {
-    guard ZmxLocator.isInstalled, let result = runZmx(["ls"]), result.status == 0 else {
-      return .absent
-    }
+    guard ZmxLocator.isInstalled else { return .absent }
+    // A listing that could not be taken is not a listing without the session in it.
+    // `zmx ls` exits 0 whenever it runs at all, so a throw or a non-zero status is the
+    // probe failing, never evidence — and reporting it as `.absent` turned one bad tick
+    // into FAILED on every running unattended loop at once.
+    guard let result = runZmx(["ls"]), result.status == 0 else { return .unknown }
     return parseSessionTaskState(
       lsOutput: result.output,
       sessionName: SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName)
@@ -616,6 +621,10 @@ public enum ZmxSessionLauncher {
     case alive
     case exited(exitCode: Int?)
     case absent
+    /// `zmx` could not be asked. Distinct from `.absent` for the same reason the remote
+    /// probe separates an unreachable host from a missing session: only one of them is
+    /// an observation.
+    case unknown
   }
 
   /// Parses the `zmx ls` line for one session into a `SessionTaskState`. Internal so

--- a/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
+++ b/GraphcodeKit/Sources/Sessions/ZmxSessionLauncher.swift
@@ -607,14 +607,23 @@ public enum ZmxSessionLauncher {
   /// session that check asks about.
   static func sessionTaskState(_ node: LoopNode) async -> SessionTaskState {
     guard ZmxLocator.isInstalled else { return .absent }
-    // A listing that could not be taken is not a listing without the session in it.
-    // `zmx ls` exits 0 whenever it runs at all, so a throw or a non-zero status is the
-    // probe failing, never evidence — and reporting it as `.absent` turned one bad tick
-    // into FAILED on every running unattended loop at once.
-    guard let result = runZmx(["ls"]), result.status == 0 else { return .unknown }
-    return parseSessionTaskState(
-      lsOutput: result.output,
+    let result = runZmx(["ls"])
+    return sessionTaskState(
+      lsStatus: result?.status, lsOutput: result?.output ?? "",
       sessionName: SurfaceRef(id: node.id, launchesClaudeCode: true).zmxSessionName)
+  }
+
+  /// The judgement above, over a `zmx ls` that may never have run. A listing that could
+  /// not be taken is not a listing without the session in it: `zmx ls` exits 0 whenever
+  /// it runs at all, so a `nil` status (the subprocess threw) and a non-zero one are the
+  /// probe failing, never evidence. Reporting either as `.absent` turned one bad tick
+  /// into FAILED on every running unattended loop at once. Internal so tests can hold
+  /// both failures without a zmx to fail.
+  static func sessionTaskState(lsStatus: Int32?, lsOutput: String, sessionName: String)
+    -> SessionTaskState
+  {
+    guard let lsStatus, lsStatus == 0 else { return .unknown }
+    return parseSessionTaskState(lsOutput: lsOutput, sessionName: sessionName)
   }
 
   enum SessionTaskState: Equatable {

--- a/graphcode/Tests/CopilotPresenceTests.swift
+++ b/graphcode/Tests/CopilotPresenceTests.swift
@@ -94,6 +94,100 @@ struct CopilotPresenceTests {
   }
 
   @Test
+  func aResumeIsNotOverriddenByTheShutdownBehindIt() throws {
+    // The real ordering, off a live log: shutdown at 17:30:23, `--resume` at 17:30:26
+    // appending to the *same* events.jsonl, nothing mapped since. A reverse scan that
+    // only skips unmapped events walks past the resume and reports the shutdown behind
+    // it, so a session sitting at its prompt reads `.absent` — FAILED on a running
+    // unattended loop, which is what this test exists to keep from coming back.
+    let root = try temporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let directory = try session(
+      named: "graphcode-RESUMED",
+      events: [
+        "session.start", "user.message", "assistant.turn_start", "assistant.turn_end",
+        "session.shutdown",
+        "session.resume", "session.permissions_changed",
+      ], in: root)
+
+    let reading = CopilotSessionLog.lastStateChange(
+      inLogAt: directory.appendingPathComponent("events.jsonl"))
+
+    // Nothing since the resume says anything: `presence(of:)` turns this into idle at
+    // `.heuristic`, "a live session with nothing happening", never absent.
+    #expect(reading == nil)
+  }
+
+  @Test
+  func workAfterAResumeIsStillRead() throws {
+    // The boundary stops the scan; it does not blind it. A resumed session that has
+    // started working reads busy off the events written after the resume.
+    let root = try temporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let directory = try session(
+      named: "graphcode-RESUMED-BUSY",
+      events: [
+        "assistant.turn_end", "session.shutdown",
+        "session.resume", "user.message", "assistant.turn_start", "tool.execution_start",
+      ], in: root)
+
+    let reading = CopilotSessionLog.lastStateChange(
+      inLogAt: directory.appendingPathComponent("events.jsonl"))
+
+    #expect(reading == .busy)
+  }
+
+  @Test
+  func aShutdownWithNoResumeBehindItStillEndsTheSession() throws {
+    // The other half: a session that really did shut down must keep reporting absent,
+    // or the reading stops being able to say a loop died at all.
+    let root = try temporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let directory = try session(
+      named: "graphcode-DEAD",
+      events: ["session.start", "user.message", "assistant.turn_end", "session.shutdown"],
+      in: root)
+
+    let reading = CopilotSessionLog.lastStateChange(
+      inLogAt: directory.appendingPathComponent("events.jsonl"))
+
+    #expect(reading == .absent)
+  }
+
+  @Test
+  func theRemoteProbeCanSeeAResumeAndBlanksIt() {
+    // The remote reader is the same scan expressed as grep + `tail -1`, and it has to
+    // make the same two decisions: the boundaries must be in the keep-list for `tail -1`
+    // to see them at all, and a boundary in hand must blank the answer rather than be
+    // reported as an event.
+    let node = LoopNode(
+      id: UUID(uuidString: "22222222-3333-4444-5555-666666666666")!,
+      title: "Sync", loopType: .goalBased, goal: GoalSpec(summary: "main is current"),
+      backend: .copilotCLI, state: .running)
+    let location = RemoteProjectLocation(host: "box", remotePath: "/home/me/project")
+    let script = CopilotSessionLog.remotePresenceInvocation(forNode: node, at: location)
+      .joined(separator: " ")
+
+    #expect(script.contains("session\\.resume"))
+    #expect(script.contains("session\\.start"))
+    // Only as far as the pattern: the whole script rides inside a single-quoted
+    // login-shell command, so the empty assignment reaches ssh re-quoted, and
+    // matching on that would be a test of the quoter rather than of this.
+    #expect(script.contains("case \"$E\" in session.start|session.resume)"))
+  }
+
+  @Test
+  func anEmptyRemoteEventIsALiveSessionWithNothingToSay() {
+    // What the blanked `$E` above arrives as, and the reading it has to produce: the
+    // remote twin of `lastStateChange` returning nil.
+    let reading = CopilotSessionLog.parseRemotePresence(
+      succeeded: true, output: "\(ZmxSessionLauncher.remoteProbeMarker) live copilot=")
+
+    #expect(reading.presence == .idle)
+    #expect(reading.confidence == .heuristic)
+  }
+
+  @Test
   func theSessionIsFoundByTheNameGraphcodeGaveIt() throws {
     let root = try temporaryRoot()
     defer { try? FileManager.default.removeItem(at: root) }

--- a/graphcode/Tests/ZmxSessionLauncherTests.swift
+++ b/graphcode/Tests/ZmxSessionLauncherTests.swift
@@ -536,3 +536,35 @@ struct ZmxSessionLauncherTests {
     #expect(script.contains("201~"))
   }
 }
+
+/// The probe's own failures, kept out of the suite body above only because swiftlint's
+/// `type_body_length` is at its limit there.
+extension ZmxSessionLauncherTests {
+  @Test
+  func aListingThatCouldNotBeTakenIsUnknownNotAbsent() {
+    // `zmx ls` exits 0 whenever it runs at all, so a nil status (the subprocess threw)
+    // and a non-zero one are the probe failing, not a session that is gone. Folding
+    // them into `.absent` made one bad tick read as FAILED on every running unattended
+    // loop at once — `LoopNode.displayState` renders `.unknown` as the graph's own
+    // belief instead, which is what a failed remote probe has always done.
+    #expect(
+      ZmxSessionLauncher.sessionTaskState(
+        lsStatus: nil, lsOutput: "", sessionName: "graphcode-a") == .unknown)
+    #expect(
+      ZmxSessionLauncher.sessionTaskState(
+        lsStatus: 1, lsOutput: "", sessionName: "graphcode-a") == .unknown)
+  }
+
+  @Test
+  func aListingThatRanIsStillReadAsItAlwaysWas() {
+    // The seam must not soften a real answer: a listing that came back is judged on its
+    // contents, absent row and all.
+    #expect(
+      ZmxSessionLauncher.sessionTaskState(
+        lsStatus: 0, lsOutput: "", sessionName: "graphcode-a") == .absent)
+    #expect(
+      ZmxSessionLauncher.sessionTaskState(
+        lsStatus: 0, lsOutput: lsLine(name: "graphcode-a") + "\n",
+        sessionName: "graphcode-a") == .alive)
+  }
+}


### PR DESCRIPTION
Fixes #286.

Two independent causes of the same false FAILED label, one commit each, plus their tests.

## 1. A resumed Copilot session reads as absent

`copilot --resume <id>` reopens the session's own state directory and appends to the same `events.jsonl`, so a resumed session's log reads `session.shutdown` then `session.resume`. `lastStateChange` scans the tail in reverse and returns the first *mapped* event; `session.resume` is unmapped, so the scan walked past it and reported the shutdown behind it. The liveness check runs first and is then discarded — a session zmx confirms is alive still read `.absent`, which `LoopNode.displayState` shows as FAILED on a running unattended loop older than a minute.

Measured on a real log (`~/.copilot/session-state/…/events.jsonl`): shutdown 17:30:23, resume 17:30:26, nothing mapped since. Both the local scan and the remote grep reported `session.shutdown`.

The scan now stops at a lifecycle boundary — `session.start`, `session.resume` — and reports nothing rather than a record from a process that no longer exists. The remote probe gets the same decision expressed as a shell: the boundaries join the grep keep-list so `tail -1` can see them, and a `case` blanks the result, which `parseRemotePresence` already turns into heuristic idle.

This one is not only cosmetic on remote — `GraphStore.sessionPermitsResolution` treats `.absent` as permission to resolve irreversibly, so a falsely-absent remote loop defeated the guard that exists to stop a closed pane from resolving a live loop.

## 2. A zmx probe that could not run reads as absent

`sessionTaskState` folded three failures into `.absent`: zmx not installed, the `zmx ls` subprocess throwing, and a non-zero exit. `zmx ls` exits 0 whenever it runs at all, so the latter two are the probe failing, never evidence — and with `refreshPresence` writing each reading back unconditionally and no debounce anywhere, one bad tick flipped every running unattended local loop at once, on all four backends.

The remote path has always separated these (`parseRemotePresence` maps an unreachable host to `.unknown`, which `displayState` renders as the graph's own belief). The local path now does the same. Everything reached through `sessionExists` keeps today's behaviour, since `.unknown` is not `.alive` and those callers all do nothing until the next tick.

**Deliberately not changed:** `sessionDiedImmediately` still treats a failed probe as a death, which can relaunch a live session. Pre-existing, and a resume-path change of its own.

## Tests

Seven, each checked against the code it is about — reverting either fix fails them, re-applying passes them (verified by reverting both and running the two suites: 5 issues).

| Test | Holds |
|---|---|
| `aResumeIsNotOverriddenByTheShutdownBehindIt` | the real ordering off a live log reports nothing, not absent |
| `workAfterAResumeIsStillRead` | the boundary stops the scan without blinding it |
| `aShutdownWithNoResumeBehindItStillEndsTheSession` | a session that really died still reads absent |
| `theRemoteProbeCanSeeAResumeAndBlanksIt` | keep-list and `case` are both in the built script |
| `anEmptyRemoteEventIsALiveSessionWithNothingToSay` | the emptied `copilot=` matches `lastStateChange` returning nil |
| `aListingThatCouldNotBeTakenIsUnknownNotAbsent` | a nil and a non-zero `zmx ls` status are both unknown |
| `aListingThatRanIsStillReadAsItAlwaysWas` | a listing that came back is judged on its contents as before |

`sessionTaskState` grew an overload taking the `zmx ls` status and output rather than running it — the only way to hold a probe that failed without a zmx to fail. The two zmx tests live in an extension because the suite body is at swiftlint's 350-line `type_body_length` limit.

## Gate

1591 tests / 163 suites / 0 failures · swiftlint 0 errors · `swift format lint --strict` clean · `graphcode`, `graphcode-cli` and `graphcoded` all build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfShFmr2FX8Qdcd55efXcL