### PR TITLE
Record a presence read that ran out of time (#322)

### DIFF
--- a/GraphcodeKit/Sources/GraphStore.swift
+++ b/GraphcodeKit/Sources/GraphStore.swift
@@ -368,8 +368,26 @@ public actor GraphStore {
   private func presenceReading(of node: LoopNode) async -> PresenceReading? {
     guard let onReadPresence else { return nil }
     let path = graph.project.path
-    return await withDeadline(presenceReadDeadline) { await onReadPresence(node, path) }
-      ?? .unknown
+    // The closure is passed rather than trailing: a trailing closure in a `guard let`
+    // condition is read as the guard's own body.
+    let read = await withDeadline(presenceReadDeadline, { await onReadPresence(node, path) })
+    guard let reading = read else {
+      // The timeout is the event; the lease is only the backstop. `drain-stall` fires
+      // past `drainLeaseDuration`, and a read bounded well below that never reaches it —
+      // so the stall that actually happens was the one nothing recorded, which is how
+      // issue #311 stayed invisible for a day. A read that ran out of time says a
+      // backend is not answering, and that is worth a line whether or not a drain was
+      // waiting on it: the presence poll hits this with no client command in flight,
+      // and used to leave no trace at all.
+      DaemonLog.shared.record(
+        "presence-stall",
+        DaemonRequestContext.fields + [
+          ("node", node.id.uuidString),
+          ("deadline_ms", DaemonLog.milliseconds(presenceReadDeadline.timeInterval)),
+        ])
+      return .unknown
+    }
+    return reading
   }
 
   private func recordMemory(_ nodeID: UUID, _ entry: String) {

--- a/graphcode/Tests/DrainWedgeTests.swift
+++ b/graphcode/Tests/DrainWedgeTests.swift
@@ -147,6 +147,42 @@ struct DrainWedgeTests {
     _ = await wedging.value
   }
 
+  /// Issue #322: the stall that actually happens is the one nothing recorded.
+  ///
+  /// `drain-stall` fires only past `drainLeaseDuration`, and a presence read bounded far
+  /// below that never reaches it — so a read that timed out left no line at all, and the
+  /// presence poll hits this with no client command in flight to carry a `handle_ms`.
+  /// That is how #311 stayed invisible for a day: frozen and working looked identical.
+  @Test
+  func aTimedOutPresenceReadIsRecorded() async {
+    let fixture = fixture()
+    let lines = LockIsolated<[String]>([])
+    let tap = DaemonLog.shared.tap { line in lines.withValue { $0.append(line) } }
+    defer { DaemonLog.shared.untap(tap) }
+    let store = GraphStore(
+      graph: fixture.graph,
+      onDeliverMessage: { _, _, _ in true },
+      onReadPresence: { _, _ in
+        // Longer than the deadline, so the read is abandoned rather than answered.
+        try? await Task.sleep(for: .seconds(5))
+        return PresenceReading(presence: .idle, confidence: .reported)
+      },
+      // Last, because that is where `GraphStore.init` declares it and Swift matches an
+      // argument list in declaration order.
+      presenceReadDeadline: .milliseconds(50))
+
+    await store.handle(
+      .messageNode(fixture.bystander, text: "needs a presence read", from: nil, followUp: true))
+
+    #expect(
+      lines.value.contains { $0.contains("event=presence-stall") },
+      "a presence read that ran out of time left no line: \(lines.value)")
+    // The node it could not read, so a reader can tell which backend stopped answering,
+    // and the bound it broke — never a title or any other user text.
+    #expect(lines.value.contains { $0.contains(fixture.bystander.uuidString) })
+    #expect(lines.value.contains { $0.contains("deadline_ms=") })
+  }
+
   /// What the deadline cannot reach, and the reason the guard is a lease.
   ///
   /// `deliverToSession` is the same `PTYProcessSession` chain as the presence read and


### PR DESCRIPTION
One log line, and a test that fails without it.

## The gap

`drain-stall` fires only past `drainLeaseDuration` (300 s). A presence read is bounded at `presenceReadDeadline` (45 s). So a drain stalled by a hung read **releases long before the threshold and leaves no line at all** — the stall that actually happens in practice is the one nothing records.

Measured end-to-end against the shipped **0.1.64** during the #311 wedge rerun:

| Build | Control | Wedged |
|---|---|---|
| 0.1.64 (258) | 3.2 s | 46.1 s |
| beta5, pre-fix | 15 s | never — 364 s |

Delivery recovers correctly at the deadline, exactly once, nothing lost. But those runs produced **zero `drain-stall` and zero `delivery-stall` lines**. The only trace was `handle_ms=48787.6` on a `messageNode` that happened to be riding the wedged drain — and a wedge the **presence poller** hits, with no client command in flight, left nothing at all.

That is how #311 stayed invisible for a day: frozen and working looked identical from outside. #289 shipped so that could not happen again, and for the wedge that actually occurs it was silent.

## The change

Log where the read gives up. The timeout is the event; the lease is only the backstop.

The line carries the **node whose backend stopped answering** and the **bound it broke** — a UUID and a duration, never a title or any other user text. That matches what `delivery-stall` already records, and keeps #289's constraint that no user content reaches the log.

## Test

`aTimedOutPresenceReadIsRecorded` — a presence read that sleeps past a 50 ms deadline must leave a `presence-stall` line naming the node and the deadline.

Verified the way that actually proves something: **with the fix removed from `GraphStore.swift`, the test fails; restored, it passes.**

Worth recording how nearly I got that wrong — my first attempt used `-only-testing:` with a *method* name, which matched nothing and exited 0. A vacuous pass I almost recorded as evidence. The suite-level filter is what the project's own skill prescribes, for exactly this reason.

## Gate

1693 tests / 180 suites / 0 failures, no restarts; `scripts/cli-smoke.sh` exit 0; swiftlint 0 errors; swift-format clean.

## Worth a follow-up, not in this PR

Any deadline shorter than the stall threshold it feeds is invisible by construction. This was the one that mattered because the presence poll runs without a client command to carry its timing, but the pattern is worth an audit of the other bounded waits.

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BP43ags4cn8fq2ZZdv85J9