### PR TITLE
Identify the Mailroom project and translate its title

### DIFF
--- a/graphcode/Resources/Localizable.xcstrings
+++ b/graphcode/Resources/Localizable.xcstrings
@@ -7681,6 +7681,70 @@
         }
       }
     },
+    "Mailroom for %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poststelle für %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sala de correo de %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salle du courrier de %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ufficio posta di %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ のメールルーム"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 메일룸"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sala de correio de %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Почтовая комната для %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的收发室"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的收發室"
+          }
+        }
+      }
+    },
     "Mark as entry": {
       "localizations": {
         "de": {

--- a/graphcode/Sources/Features/LoopWorkspace/MailroomSection.swift
+++ b/graphcode/Sources/Features/LoopWorkspace/MailroomSection.swift
@@ -147,7 +147,7 @@ struct MailroomSection: View {
 
   private var header: some View {
     HStack(spacing: 7) {
-      Text("MAILROOM")
+      Text("Mailroom for \(graph.project.name)")
         .font(.system(size: 10.5, weight: .bold))
         .tracking(0.63)
         .foregroundStyle(.white.opacity(0.5))


### PR DESCRIPTION
The Mailroom header now identifies its project: “Mailroom for graphcode” instead of “MAILROOM”. The folder name comes from the displayed graph.

Adds the interpolated title to all ten existing app locales, preserving the folder-name placeholder and allowing each translation to position it naturally.

Validation: Swift syntax parsing and formatting passed; the string catalog compiled with xcstringstool; verified complete locale coverage, one placeholder per translation, unchanged existing entries, and clean git diff checks. Full app build and visual validation were not run.
