### PR TITLE
Mark a loop watching the Mailroom with an envelope glyph

### DIFF
--- a/graphcode/Sources/Features/App/AppSidebarView.swift
+++ b/graphcode/Sources/Features/App/AppSidebarView.swift
@@ -282,6 +282,12 @@ struct AppSidebarView: View {
         .frame(width: 3, height: 14)
       Text(node.title).font(.system(size: 12.5)).lineLimit(1)
       Spacer(minLength: 4)
+      if let watching = MailroomWatchPresentation.tooltip(for: node) {
+        Image(systemName: MailroomWatchPresentation.symbolName)
+          .font(.system(size: 10))
+          .foregroundStyle(.white.opacity(0.45))
+          .help(watching)
+      }
       Text(LoopCardPresentation.duration(sidebarNow.timeIntervalSince(node.createdAt)))
         .font(.system(size: 10.5, design: .monospaced))
         .foregroundStyle(.white.opacity(0.5))

--- a/graphcode/Sources/Features/Canvas/LoopCardView.swift
+++ b/graphcode/Sources/Features/Canvas/LoopCardView.swift
@@ -241,6 +241,12 @@ struct LoopCardView: View {
       if isRemote {
         Image(systemName: "network").font(.system(size: 9)).foregroundStyle(.white.opacity(0.4))
       }
+      if let watching = MailroomWatchPresentation.tooltip(for: node) {
+        Image(systemName: MailroomWatchPresentation.symbolName)
+          .font(.system(size: 9))
+          .foregroundStyle(.white.opacity(0.4))
+          .help(watching)
+      }
       switch entryRole {
       case .entry: EntryChip()
       case .cycleOnly: CycleChip()

--- a/graphcode/Sources/Features/Canvas/MailroomWatchPresentation.swift
+++ b/graphcode/Sources/Features/Canvas/MailroomWatchPresentation.swift
@@ -1,21 +1,15 @@
 import GraphcodeKit
 import MailroomKit
 
-/// The quiet mark for a loop that is watching its project's Mailroom: an outline
-/// envelope on the sidebar row and the canvas card, and a tooltip that says what it
-/// is listening for. Nothing more — no count, no unread dot, no colour. The watch is
-/// a standing subscription, and the mark only says one exists.
+/// The envelope that marks a loop watching its project's Mailroom, and its tooltip.
 ///
-/// Hidden on a resolved loop. `mailroomWatch` outlives the session that set it, but a
-/// loop that has finished for good cannot be rung, and a glyph promising otherwise
-/// would be the card claiming a mailbox that nobody will open.
+/// Hidden on a resolved loop: `mailroomWatch` outlives the session that set it, but a
+/// loop that has finished for good cannot be rung.
 enum MailroomWatchPresentation {
   static let symbolName = "envelope"
 
   static func showsGlyph(for node: LoopNode) -> Bool { tooltip(for: node) != nil }
 
-  /// `"Watching the Mailroom"`, or with `· topic <t>` when the watch is narrowed to one;
-  /// `nil` when there is nothing to draw.
   static func tooltip(for node: LoopNode) -> String? {
     guard let watch = node.mailroomWatch, !node.isResolved else { return nil }
     guard let topic = watch.topic else { return "Watching the Mailroom" }

--- a/graphcode/Sources/Features/Canvas/MailroomWatchPresentation.swift
+++ b/graphcode/Sources/Features/Canvas/MailroomWatchPresentation.swift
@@ -1,0 +1,24 @@
+import GraphcodeKit
+import MailroomKit
+
+/// The quiet mark for a loop that is watching its project's Mailroom: an outline
+/// envelope on the sidebar row and the canvas card, and a tooltip that says what it
+/// is listening for. Nothing more — no count, no unread dot, no colour. The watch is
+/// a standing subscription, and the mark only says one exists.
+///
+/// Hidden on a resolved loop. `mailroomWatch` outlives the session that set it, but a
+/// loop that has finished for good cannot be rung, and a glyph promising otherwise
+/// would be the card claiming a mailbox that nobody will open.
+enum MailroomWatchPresentation {
+  static let symbolName = "envelope"
+
+  static func showsGlyph(for node: LoopNode) -> Bool { tooltip(for: node) != nil }
+
+  /// `"Watching the Mailroom"`, or with `· topic <t>` when the watch is narrowed to one;
+  /// `nil` when there is nothing to draw.
+  static func tooltip(for node: LoopNode) -> String? {
+    guard let watch = node.mailroomWatch, !node.isResolved else { return nil }
+    guard let topic = watch.topic else { return "Watching the Mailroom" }
+    return "Watching the Mailroom · topic \(topic)"
+  }
+}

--- a/graphcode/Tests/MailroomWatchPresentationTests.swift
+++ b/graphcode/Tests/MailroomWatchPresentationTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import GraphcodeKit
+import MailroomKit
+import Testing
+
+@testable import graphcode
+
+/// Whether a loop wears the Mailroom-watch envelope, and what its tooltip says
+/// (`MailroomWatchPresentation`).
+@Suite
+struct MailroomWatchPresentationTests {
+  private func node(watch: MailroomWatch?, state: LoopState = .running) -> LoopNode {
+    LoopNode(title: "Triage", loopType: .goalBased, mailroomWatch: watch, state: state)
+  }
+
+  @Test
+  func aLoopWithoutAWatchShowsNothing() {
+    let plain = node(watch: nil)
+
+    #expect(!MailroomWatchPresentation.showsGlyph(for: plain))
+    #expect(MailroomWatchPresentation.tooltip(for: plain) == nil)
+  }
+
+  @Test
+  func aWatchOnEveryPostSaysSoWithoutATopic() {
+    let hearingAll = node(watch: MailroomWatch())
+
+    #expect(MailroomWatchPresentation.showsGlyph(for: hearingAll))
+    #expect(MailroomWatchPresentation.tooltip(for: hearingAll) == "Watching the Mailroom")
+  }
+
+  @Test
+  func aWatchOnOneTopicNamesIt() {
+    let narrowed = node(watch: MailroomWatch(topic: "design"))
+
+    #expect(MailroomWatchPresentation.showsGlyph(for: narrowed))
+    #expect(
+      MailroomWatchPresentation.tooltip(for: narrowed) == "Watching the Mailroom · topic design")
+  }
+
+  @Test(arguments: [LoopState.succeeded, .failed, .stalled, .stopped])
+  func aResolvedLoopHidesItsWatch(state: LoopState) {
+    // The watch survives on the node, but nothing can ring a loop that has finished.
+    let finished = node(watch: MailroomWatch(topic: "design"), state: state)
+
+    #expect(!MailroomWatchPresentation.showsGlyph(for: finished))
+    #expect(MailroomWatchPresentation.tooltip(for: finished) == nil)
+  }
+}

--- a/graphcode/Tests/MailroomWatchPresentationTests.swift
+++ b/graphcode/Tests/MailroomWatchPresentationTests.swift
@@ -5,8 +5,6 @@ import Testing
 
 @testable import graphcode
 
-/// Whether a loop wears the Mailroom-watch envelope, and what its tooltip says
-/// (`MailroomWatchPresentation`).
 @Suite
 struct MailroomWatchPresentationTests {
   private func node(watch: MailroomWatch?, state: LoopState = .running) -> LoopNode {
@@ -40,7 +38,6 @@ struct MailroomWatchPresentationTests {
 
   @Test(arguments: [LoopState.succeeded, .failed, .stalled, .stopped])
   func aResolvedLoopHidesItsWatch(state: LoopState) {
-    // The watch survives on the node, but nothing can ring a loop that has finished.
     let finished = node(watch: MailroomWatch(topic: "design"), state: state)
 
     #expect(!MailroomWatchPresentation.showsGlyph(for: finished))


### PR DESCRIPTION
Implements Option A from the Mailroom-watch design canvas (https://claude.ai/code/artifact/b66281a3-4d39-435d-8a92-ecc0eb4a0b6f): a quiet outline envelope glyph marking a loop that is watching the Mailroom, in two places only.

## What

- **Sidebar row** (`AppSidebarView.nodeRow`): `envelope` SF Symbol between the title's spacer and the age text, 10pt, white at 45%.
- **Canvas card** (`LoopCardView.metaRow`): same glyph after the existing 9pt `network` remote glyph, 9pt, white at 40%.
- Both shown only when `node.mailroomWatch != nil` and the node is not resolved, and both carry a `.help` tooltip: `Watching the Mailroom`, or `Watching the Mailroom · topic <t>` when the watch has a topic.
- New `MailroomWatchPresentation` enum answers "show glyph?" and "tooltip text" from a `LoopNode`, so the rule lives in one place and is testable without pixels.

No colour, no count, no unread dot — Option B is explicitly out of scope.

## Tests

`MailroomWatchPresentationTests`: no watch, watch on every post, watch with a topic, and a watch on a resolved node (hidden) parameterised over all four resolved states.

## Gate

In flight from the worktree with private DerivedData; literal exit codes to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8s9Ranjzra1VAKrP27gN7
